### PR TITLE
Update archives.md

### DIFF
--- a/site/content/rest-api/archives.md
+++ b/site/content/rest-api/archives.md
@@ -259,6 +259,10 @@ Returns all ended chats.
 
 The results are divided into pages, each containing 25 chats. To access next pages of the results, use `?page=<PAGE>` parameter. Please note that first page's number is `1`, not `0`.
 
+Note that **the results are limited** to the latest 100000 records on your LiveChat license, which gives you exactly 4000 pages with 25 chats per page. If you have more than 100000 chats on your license and you want to get them all, you will have to call our API several times.
+
+In the first call, use the data range that covers the first 100000 chats. When making other calls, use the data range that includes the rest of your conversations.
+
 
 ## Get single chat
 


### PR DESCRIPTION
Added information which states that the response from /chats endpoint is limited to 100000 latest chats. If the customer wants to get the list of all chats, he will have to call our API several times, including the specific data range filter. The change will come to live after switching to new ElasticSearch.