### PR TITLE
Reorder docs so it looks better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .vscode/
 dist/
 old/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Be sure that you have the node >= 6.0.0 and npm installed. Next, clone this repo
 
 ```bash
 npm install
-npm start
+npm run start@2.0
 ```
 
 To build your static output to the `/dist` folder, use:

--- a/site/content/agent-app-widgets/js-api.md
+++ b/site/content/agent-app-widgets/js-api.md
@@ -113,10 +113,7 @@ You can use the SDK to add your own content to the Customer Details view. To bet
 ### How to add a section
 To extend the Customer Details view, you need to first declare the initial state of the section in the Developer Console:
 
-  1. Log into the Agent App using your license.
-  2. Go to [Developer Console Apps](https://developers.livechatinc.com/console/apps) and select your app or create a new one with the Agent App Widget template.
-  3. Go to the `Building blocks` section of your app and create a new Agent App widget. You need to provide the `Widget source URL`, which can be either an URL pointing to the Web or to localhost (for eg. `https://localhost:4000`), if you want to use the local version of the widget. The URL will be used as an iframe source and should be publily available.
-  4. Set the `Widget placement` to `Chat details` and provide the initial state JSON, eg.: 
+> Example of initial state JSON for "Chat details":
 
 ```json
 {
@@ -136,13 +133,18 @@ To extend the Customer Details view, you need to first declare the initial state
   ]
 }
 ```
-  6. The sections list can only be initialized once and they can't be modified afterwarts. This means you can't add or remove a section using the SDK later on. You can however modify the list of components inside a section later on.
-  7. Go to `Private installation` and click the `Install app` button.
-  8. Your widget should be now visible in the right sidebar of the Agent App chat view. Beware - if you did not set any icon for your widget, it may seem that it's not there. To make sure, you can hover over the widget icon bar and check if there's any clickable whitespace. You can set the icon in Developers Console.
+
+  1. Log into the Agent App using your license.
+  2. Go to [Developer Console Apps](https://developers.livechatinc.com/console/apps) and select your app or create a new one with the Agent App Widget template.
+  3. Go to the `Building blocks` section of your app and create a new Agent App widget. You need to provide the `Widget source URL`, which can be either an URL pointing to the Web or to localhost (for eg. `https://localhost:4000`), if you want to use the local version of the widget. The URL will be used as an iframe source and should be publily available.
+  4. Set the `Widget placement` to `Chat details` and provide the initial state JSON.
+  5. The sections list can only be initialized once and they can't be modified afterwarts. This means you can't add or remove a section using the SDK later on. You can however modify the list of components inside a section later on.
+  6. Go to `Private installation` and click the `Install app` button.
+  7. Your widget should be now visible in the right sidebar of the Agent App chat view. Beware - if you did not set any icon for your widget, it may seem that it's not there. To make sure, you can hover over the widget icon bar and check if there's any clickable whitespace. You can set the icon in Developers Console.
 
 ### How to update a section
 
-To update a section you can use the `modifyCustomerDetailsSection` method like this:
+> Example of using the `modifyCustomerDetailsSection` method:
 
 ```js
 LiveChat.modifyCustomerDetailsSection(
@@ -160,6 +162,9 @@ LiveChat.modifyCustomerDetailsSection(
   } 
 );
 ```
+
+To update a section you can use the `LiveChat.modifyCustomerDetailsSection()` method.
+
 ---
 **IMPORTANT**
 
@@ -173,12 +178,6 @@ Components are *lego bricks* which can be used for building a section.
 #### Section
 Section is a container for components.
 
-| Property     | Required | Type                |
-|--------------|----------| ------------------- |
-| `title`      | Yes      | string              |
-| `components` | Yes      | array of components | 
-| `imgUrl`     | No       | string              | 
-
 > Example of section component
 
 ```json
@@ -189,17 +188,14 @@ Section is a container for components.
 }
 ```
 
+| Property     | Required | Type                |
+|--------------|----------| ------------------- |
+| `title`      | Yes      | string              |
+| `components` | Yes      | array of components | 
+| `imgUrl`     | No       | string              | 
+
 #### Title
 Title could be used in several cases. Component look depends on given data.
-
-| Property      | Required | Type | Note        |
-|---------------|----------| ---- | ----------- |
-| `title`       | Yes      | string |           |
-| `value`       | No       | string |           |
-| `description` | No       | string |           |
-| `imgUrl`      | No       | string |           |
-| `imgSize`     | No       | string, one of: ["small", "big"]` | Default value: "big" | 
-| `link` | No | string | URL added when title is a link. |
 
 > Example of title component
 
@@ -215,14 +211,17 @@ Title could be used in several cases. Component look depends on given data.
 }
 ```
 
+| Property      | Required | Type | Note        |
+|---------------|----------| ---- | ----------- |
+| `title`       | Yes      | string |           |
+| `value`       | No       | string |           |
+| `description` | No       | string |           |
+| `imgUrl`      | No       | string |           |
+| `imgSize`     | No       | string, one of: ["small", "big"]` | Default value: "big" | 
+| `link` | No | string | URL added when title is a link. |
+
 #### Button
 Simple button from design system.
-
-| Property      | Required | Type    | Description            |
-|---------------|----------| ------- | ---------------------- |
-| `id`          | Yes      | string  |                        |
-| `label`       | Yes      | string  |                        |
-| `openApp`     | No       | boolean | Default value: `false` | 
 
 > Example of button component
 
@@ -237,21 +236,23 @@ Simple button from design system.
 }
 ```
 
-> You can listen for button clicks using the SDK
+| Property      | Required | Type    | Description            |
+|---------------|----------| ------- | ---------------------- |
+| `id`          | Yes      | string  |                        |
+| `label`       | Yes      | string  |                        |
+| `openApp`     | No       | boolean | Default value: `false` | 
+
+##### Click events
+
 ```js
 Livechat.on("customer_details_section_button_click", ({ buttonId }) => {
   console.log(buttonId);
 });
 ```
-> Note that `buttonId` will be the same as the `id` from the schema. If you want to capture a specific click, you need to make sure that the `id` is unique across all definitions.
+
+You can listen for button clicks using the SDK. Note that `buttonId` will be the same as the `id` from the schema. If you want to capture a specific click, you need to make sure that the `id` is unique across all definitions.
 
 #### Label with value
-
-| Property | Required | Type    | Description |
-|----------|----------| ------- | ----------- |
-| `label`  | No       | string  |             |
-| `value`  | No       | string  |             |
-| `inline` | No       | boolean | Default value: `true` |
 
 > Example of label with value component
 
@@ -266,13 +267,13 @@ Livechat.on("customer_details_section_button_click", ({ buttonId }) => {
 }
 ```
 
-#### Link
+| Property | Required | Type    | Description |
+|----------|----------| ------- | ----------- |
+| `label`  | No       | string  |             |
+| `value`  | No       | string  |             |
+| `inline` | No       | boolean | Default value: `true` |
 
-| Property | Required | Type    | Description     |
-|----------|----------| ------- | --------------- |
-| `url`    | Yes      | string  |                 |
-| `value`  | No       | string  |                 |
-| `inline` | No       | boolean | default: `true` |
+#### Link
 
 > Example of link component
 
@@ -286,6 +287,12 @@ Livechat.on("customer_details_section_button_click", ({ buttonId }) => {
   }
 }
 ```
+
+| Property | Required | Type    | Description     |
+|----------|----------| ------- | --------------- |
+| `url`    | Yes      | string  |                 |
+| `value`  | No       | string  |                 |
+| `inline` | No       | boolean | default: `true` |
 
 #### Line
 Line could be used to separate section content. It has no components inside. 


### PR DESCRIPTION
Hey, I've reordered the docs so Hugo displays them better. I've also changed some wording around code blocks, because it was written as if they appear below the text, instead of beside it.

For eg:
> Set the `Widget placement` to `Chat details` and provide the initial state JSON, eg.: 

vs
> Set the `Widget placement` to `Chat details` and provide the initial state JSON.

with an additional explanation in the example:

> Example of initial state JSON for "Chat details":

I've also added `package-lock.json` to `.gitignore` since it's automatically generated. And changed a line in `README` with the correct command to run the docs.