### PR TITLE
license_id must be a string when adding visitor details in json

### DIFF
--- a/site/content/rest-api/visitors.md
+++ b/site/content/rest-api/visitors.md
@@ -168,7 +168,7 @@ curl "https://api.livechatinc.com/visitors/S1352647457.ac951bfe2e/details" \
   -H X-API-Version:2 \
   -H Content-type:application/json \
   -d '{
-        "license_id":12345,
+        "license_id":"12345",
         "token":"26132406c42c96ba61ed42689b70f719",
         "id":"my-app",
         "fields":[

--- a/site/content@beta/rest-api/visitors.md
+++ b/site/content@beta/rest-api/visitors.md
@@ -168,7 +168,7 @@ curl "https://api.livechatinc.com/visitors/S1352647457.ac951bfe2e/details" \
   -H X-API-Version:2 \
   -H Content-type:application/json \
   -d '{
-        "license_id":12345,
+        "license_id":"12345",
         "token":"26132406c42c96ba61ed42689b70f719",
         "id":"my-app",
         "fields":[


### PR DESCRIPTION
When adding visitor details and sending the data in json format, the license_id must a string.
The license_id that you receive via the [webhook](https://developers.livechatinc.com/docs/build-integration/#webhook-format), is also a string.

When you use an integer, the API also returns that the data is valid and the visitor details are updated, but nothing happens.

See: https://developers.livechatinc.com/docs/rest-api/#add-custom-visitor-details

Related issue: #300 