### PR TITLE
Fix for page description in /archives

### DIFF
--- a/site/content/rest-api/archives.md
+++ b/site/content/rest-api/archives.md
@@ -261,9 +261,9 @@ Returns all ended chats.
 
 The results are divided into pages, each containing 25 chats. To access next pages of the results, use `?page=<PAGE>` parameter. Please note that first page's number is `1`, not `0`.
 
-Note that **the results are limited** to the latest 100000 records on your LiveChat license, which gives you exactly 4000 pages with 25 chats per page. If you have more than 100000 chats on your license and you want to get them all, you will have to call our API several times.
+Note that **the results are limited** to the latest 25000 records on your LiveChat license, which gives you exactly 1000 pages with 25 chats per page. If you have more than 25000 chats on your license and you want to get them all, you will have to call our API several times.
 
-In the first call, use the data range that covers the first 100000 chats. When making other calls, use the data range that includes the rest of your conversations.
+In the first call, use the data range that covers the first 25000 chats. When making other calls, use the data range that includes the rest of your conversations.
 
 
 ## Get single chat


### PR DESCRIPTION
Fixing the description explaining the page limitation, available in REST APIs /archives section