### PR TITLE
Continuous param in start_chat, activate_chat

### DIFF
--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -1448,6 +1448,7 @@ When `chat.users` is defined, one of following scopes is required:
 | `chat.thread`            | No       | `object`  |                                                                         |
 | `chat.thread.events`     | No       | `array`   | The list of initial chat events.                                        |
 | `chat.thread.properties` | No       | `object`  |                                                                         |
+| `continuous`             | No       | `bool`    | Starts chat as continuous (online group is not required); default: `false`. |
 
 #### Response
 

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -1547,6 +1547,7 @@ When `chat.users` is defined, one of following scopes is required:
 | `chat.thread`            | No       | `object`  |                                                                         |
 | `chat.thread.events`     | No       | `array`   | The list of initial chat events                                         |
 | `chat.thread.properties` | No       | `object`  |                                                                         |
+| `continuous`             | No       | `bool`    | Starts chat as continuous (online group is not required); default: `false`. |
 
 </Text>
 <Code>
@@ -1670,6 +1671,7 @@ When `chat.users` is defined, one of following scopes is required:
 | `chat.thread`            | No       | `object` |                                                                     |
 | `chat.thread.events`     | No       | `array`  | Initial chat events array                                           |
 | `chat.thread.properties` | No       | `object` | Initial chat thread properties                                      |
+| `continuous`             | No       | `bool`   | Sets a chat to the continuous mode. When unset leaves the mode unchanged. |
 
 </Text>
 <Code>


### PR DESCRIPTION
Added the `continuous` parameter in start_chat and activate_chat in Agent Chat API, as it was missing.