### PR TITLE
Fixes in Customer and Agent Chat APIs

### DIFF
--- a/content/management/configuration-api/index.mdx
+++ b/content/management/configuration-api/index.mdx
@@ -683,7 +683,7 @@ Webhooks notify you when events are triggered.
 | **Properties** | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`chat_thread_properties_updated`](#chat_thread_properties_updated) [`chat_thread_properties_deleted`](#chat_thread_properties_deleted)  |  
 | **Thread tags** | [`chat_thread_tagged`](#chat_thread_tagged) [`chat_thread_untagged`](#chat_thread_untagged) | 
 | **Status** | [`agent_status_changed`](#agent_status_changed) [`agent_deleted`](#agent_deleted)| 
-| **Other** | [`last_seen_timestamp_updated`](#last_seen_timestamp_updated)  | 
+| **Other** | [`events_marked_as_seen`](#events_marked_as_seen)  | 
 
 
 </Text>
@@ -1157,7 +1157,7 @@ Webhooks notify you when events are triggered.
 
 ### Other
 
-#### `last_seen_timestamp_updated`
+#### `events_marked_as_seen`
 
 <CodeResponse title={'Sample webhook payload'}>
 
@@ -1167,9 +1167,9 @@ Webhooks notify you when events are triggered.
   "secret_key": "<secret_key>",
   "action": "<action>",
   "payload": {
-	"user_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
-	"chat_id": "PJ0MRSHTDG",
-    "timestamp": 123456789  
+  "user_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "chat_id": "PJ0MRSHTDG",
+  "seen_up_to": "2017-10-12T15:19:21.010200Z"
     },
   "additional_data": {
     "chat_properties": { //optional

--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -187,7 +187,7 @@ File event informs about a file being uploaded.
 | `custom_id`                                           | optional  |                                                                   - |
 | `properties`                                          | optional  |                                                                   - |
 | `recipients`                                          | required  |                          Possible values: `all` (default), `agents` |
-| `url`                                                 | required  | Has to point to the LiveChat CDN.                                   |
+| `url`                                                 | required  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](#upload-file). |
 | `width`, `height`, `thumbnail_url`, `thumbnail2x_url` | optional  |                                                     Only for images |
 
 </Text>
@@ -842,7 +842,7 @@ Here's the list of all system messages you might come across:
 | `email`                          | optional  |                                           |
 | `fields`                         | optional  | Is not present when the chat is archived. |
 | `name`                           | optional  |                                           |
-| `events_seen_up_to`              |           | RFC 3339 datetime string                  |
+| `events_seen_up_to`              | optional  | RFC 3339 datetime string                  |
 | `last_visit`                     | optional  |                                           |
 | `present`                        | optional  |                                           |
 | `statistics`                     | optional  |                                           |

--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -206,7 +206,7 @@ File event informs about a file being uploaded.
     // "Properties" object
   },
   "name": "image25.png", // generated server-side
-  "url": "https://domain.com/file.png",
+  "url": "https://domain.com/image25.png",
   "thumbnail_url": "https://domain.com/thumbnail.png", // generated server-side
   "thumbnail2x_url": "https://domain.com/thumbnail2x.png", // generated server-side
   "content_type": "image/png", // generated server-side
@@ -482,11 +482,11 @@ Custom event is an event with customizable payload.
 
 System message event is native system event sent in specific situations.
 
-| Field                 | Req./Opt. |                                                                                                        Note |
+| Field                 | Req./Opt. |                                                                                                       Notes |
 | --------------------- | :-------: | ----------------------------------------------------------------------------------------------------------: |
 | `custom_id`           | optional  |                                                                                                           - |
 | `created_at`          | required  |                                         Date & time format with a resolution of microseconds, `UTC string`. |
-| `recipients`          | required  | Possiblejj values: `all` (default for system events), `agents` (for events sent via send_event) |
+| `recipients`          | required  | Possible values: `all` (default for system events), `agents` (for events sent via `send_event`)             |
 | `system_message_type` | required  |                                                                                                           - |
 
 Here's the list of all system messages you might come across:

--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -187,7 +187,7 @@ File event informs about a file being uploaded.
 | `custom_id`                                           | optional  |                                                                   - |
 | `properties`                                          | optional  |                                                                   - |
 | `recipients`                                          | required  |                          Possible values: `all` (default), `agents` |
-| `system_message_type`                                 | required  |                                                                   - |
+| `url`                                                 | required  | Has to point to the LiveChat CDN.                                   |
 | `width`, `height`, `thumbnail_url`, `thumbnail2x_url` | optional  |                                                     Only for images |
 
 </Text>
@@ -206,7 +206,7 @@ File event informs about a file being uploaded.
     // "Properties" object
   },
   "name": "image25.png", // generated server-side
-  "url": "https://domain.com/asdsfdsf.png",
+  "url": "https://domain.com/file.png",
   "thumbnail_url": "https://domain.com/thumbnail.png", // generated server-side
   "thumbnail2x_url": "https://domain.com/thumbnail2x.png", // generated server-side
   "content_type": "image/png", // generated server-side
@@ -225,20 +225,21 @@ File event informs about a file being uploaded.
 <Section>
 <Text>
 
-Filled form event contains data from a form.
+Filled form event contains data from a form (prechat or postchat survey).
 
-| Field                                   | Req./Opt |                                                                Note |
+| Field                                   | Req./Opt |                                                               Notes |
 | --------------------------------------- | :------: | ------------------------------------------------------------------: |
-| `custom_id`                             | optional |                                                                   - |
 | `created_at`                            | required | Date & time format with a resolution of microseconds, `UTC string`. |
-| `properties`                            | optional |                                                                   - |
-| `recipients`                            | required |                          Possible values: `all` (default), `agents` |
-| `name`, `email`, `question`, `textarea` | optional |                                    For open questions (text answer) |
-| `radio`, `select`                       | optional |                                         For single-choice questions |
-| `checkbox`                              | optional |                                       For multiple-choice questions |
-| `group_chooser`                         | optional |                                          For group-choice questions |
+| `recipients`                            | required | Possible values: `all` (default), `agents` |
+| `checkbox`                              | optional | For multiple-choice questions |
+| `custom_id`                             | optional |                                                                     |
+| `email`, `name`, `question`, `textarea` | optional | For open questions (text answer) |
+| `group_chooser`                         | optional | For group-choice questions |    
+| `properties`                            | optional | The [Properties](#properties) object |
+| `radio`, `select`                       | optional | For single-choice questions |  
 
 </Text>
+
 <Code>
 <CodeResponse title={'Sample Filled form event'}>
 
@@ -315,7 +316,7 @@ Message event contains a text message to other chat users.
 | `postback`       | optional  | Appears in the message event only when triggered by a rich message. |
 | `postback.type`  | optional  | Required only if `postback.value` is present.                       |
 | `postback.value` | optional  | Required only if `postback.type` is present.                        |
-| `properties`     | optional  | The [properties](#properties) object                                |
+| `properties`     | optional  | [Properties](#properties) object                                |
 
 </Text>
 <Code>
@@ -371,7 +372,7 @@ Rich message event contains a rich message data structure.
 | `elements.image`                 | optional  | `image` properties are optional: `name`, `url`, `content_type`, `size`, `width`, `height`. |
 | `elements.subtitle`              | optional  |                                                                     |
 | `elements.title`                 | optional  |                                                                     |
-| `properties`                     | optional  | The [properties](#properties) object                                |
+| `properties`                     | optional  | [Properties](#properties) object                                |
 
 </Text>
 <Code>
@@ -485,7 +486,7 @@ System message event is native system event sent in specific situations.
 | --------------------- | :-------: | ----------------------------------------------------------------------------------------------------------: |
 | `custom_id`           | optional  |                                                                                                           - |
 | `created_at`          | required  |                                         Date & time format with a resolution of microseconds, `UTC string`. |
-| `recipients`          | required  | can take the following values: `all` (default for system events), `agents` (for events sent via send_event) |
+| `recipients`          | required  | Possiblejj values: `all` (default for system events), `agents` (for events sent via send_event) |
 | `system_message_type` | required  |                                                                                                           - |
 
 Here's the list of all system messages you might come across:
@@ -745,7 +746,7 @@ Here's the list of all system messages you might come across:
   "name": "Support Team",
   "email": "agent1@example.com",
   "present": true,
-  "events_seen_up_to": 1473433500,
+  "events_seen_up_to": "2017-10-12T15:19:21.010200Z",
   "avatar": "cdn.livechatinc.com/avatars/1.png",
   "routing_status": "accepting_chats"
 }
@@ -768,7 +769,7 @@ Here's the list of all system messages you might come across:
   "name": "Support Team",
   "email": "agent1@example.com",
   "present": true,
-  "events_seen_up_to": 1473433500,
+  "events_seen_up_to": "2017-10-12T15:19:21.010200Z",
   "avatar": "cdn.livechatinc.com/avatars/1.png",
   "routing_status": "accepting_chats",
   "permission": "administrator"
@@ -826,25 +827,25 @@ Here's the list of all system messages you might come across:
   "customer_last_event_created_at": "2017-10-12T15:19:21.010200Z",
   "created_at": "2017-10-11T15:19:21.010200Z",
   "present": true, // optional, applies only to customer located in chat object
-  "events_seen_up_to": 1473433500 // optional, applies only to customer located in chat object
+  "events_seen_up_to": "2017-10-12T15:19:21.010200Z"
 }
 ```
 
 </CodeResponse>
 
-| Field                            | Req./Opt. |                                      Note |
+| Field                            | Req./Opt. |                                     Notes |
 | -------------------------------- | :-------: | ----------------------------------------: |
-| `agent_last_event_created_at`    | optional  |                                         - |
-| `avatar`                         | optional  |                                         - |
-| `customer_last_event_created_at` | optional  |                                         - |
-| `created_at`                     | optional  |                                         - |
-| `email`                          | optional  |                                         - |
+| `agent_last_event_created_at`    | optional  |                                           |
+| `avatar`                         | optional  |                                           |
+| `customer_last_event_created_at` | optional  |                                           |
+| `created_at`                     | optional  |                                           |
+| `email`                          | optional  |                                           |
 | `fields`                         | optional  | Is not present when the chat is archived. |
-| `name`                           | optional  |                                         - |
-| `last_seen_timestamp`            | optional  |                                         - |
-| `last_visit`                     | optional  |                                         - |
-| `present`                        | optional  |                                         - |
-| `statistics`                     | optional  |                                         - |
+| `name`                           | optional  |                                           |
+| `events_seen_up_to`              |           | RFC 3339 datetime string                  |
+| `last_visit`                     | optional  |                                           |
+| `present`                        | optional  |                                           |
+| `statistics`                     | optional  |                                           |
 
 # Other common structures
 
@@ -1147,25 +1148,56 @@ curl -X POST \
 
 ```json
 {
-  "chats": [
-    {
-      "chat": {
-        "id": "PJ0MRSHTDG",
-        "users": [
-          // array of "User" objects
-        ],
-        "thread": {
-          // "Thread" object
-        }
-      }
-    }
-  ],
-  "pagination": {
-    "page": 1,
-    "total": 3 // total number of threads matching filters
-  }
+	"chats_summary": [{
+		"id": "PJ0MRSHTDG",
+		"users": [
+			// array of "User" objects
+		],
+		"last_event_per_type": { // last event of each type in chat
+			"message": {
+				"thread_id": "K600PKZON8",
+				"thread_order": 3,
+				"event": {
+					// "restricted_access": true
+					// or
+					// "Event > Message" object
+				}
+			},
+			"system_message": {
+				"thread_id": "K600PKZON6",
+				"thread_order": 1,
+				"event": {
+					// "restricted_access": true
+					// or
+					// "Event > System message" object
+				}
+			},
+			...
+		},
+		"last_thread_summary": {
+			"id": "K600PKZON8",
+			"order": 3,
+			"timestamp": 1473433500,
+			"user_ids": ["agent1@example.com"],
+			"properites": {
+			// "Properites" object
+			},
+			"tags": ["bug_report"]
+		},
+		"properites": {
+			// "Properites" object
+		},
+		"access": {
+			// "Access" object
+		},
+		"is_followed": false
+	}],
+	"found_chats": 2340,
+	"next_page_id": "MTUxNzM5ODEzMTQ5Ng==", // optional
+	"previous_page_id": "MTUxNzM5ODEzMTQ5Nw==" // optional
 }
 ```
+
 
 </CodeResponse>
 </Code>
@@ -2246,7 +2278,7 @@ https://api.livechatinc.com/v3.1/agent/action/update_chat_properties \
 | Parameter    | Required | Data type | Notes                                          |
 | ------------ | -------- | --------- | ---------------------------------------------- |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete property of. |
-| `properties` | Yes      | `object`  | Chat properties to delete. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| `properties` | Yes      | `object`  | Chat properties to delete. |
 
 #### Response
 
@@ -2347,7 +2379,7 @@ curl -X POST \
 | ------------ | -------- | --------- | -------------------------------------------------- |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete properties of.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to delete properties of. |
-| `properties` | Yes      | `object`  | Chat thread properties to delete. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| `properties` | Yes      | `object`  | Chat thread properties to delete. |
 
 #### Response
 
@@ -2452,7 +2484,7 @@ https://api.livechatinc.com/v3.1/agent/action/update_event_properties \
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete the properties of.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to delete the properties of. |
 | `event_id`   | Yes      | `string`  | Id of the event you want to delete the properties of.  |
-| `properties` | Yes      | `object`  | Event properties to delete. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| `properties` | Yes      | `object`  | Event properties to delete. |
 
 #### Response
 
@@ -2904,14 +2936,14 @@ https://api.livechatinc.com/v3.1/agent/action/update_agent \
 | **Method URL**         | `https://api.livechatinc.com/v3.1/agent/action/mark_events_as_seen`      |
 | **Required scopes**    | `chats--access:ro` `chats--all:ro`                                       |
 | **RTM API equivalent** | [`mark_events_as_seen`](rtm-reference/#mark-events-as-seen) |
-| **Webhook**            | [`last_seen_timestamp_updated`](#last_seen_timestamp_updated)            |
+| **Webhook**            | [`events_marked_as_seen`](#events_marked_as_seen)            |
 
 #### Request
 
-| Parameter    | Required | Data type   |     |
-| ------------ | -------- | ----------- | --- |
-| `chat_id`    | Yes      | `string`    |     |
-| `seen_up_to` | Yes      | `UTC string |
+| Parameter    | Required | Data type   | Notes |
+| ------------ | -------- | ----------- | ----- |
+| `chat_id`    | Yes      | `string`    |       |
+| `seen_up_to` | Yes      | `string`    | RFC 3339 date-time format |
 
 #### Response
 
@@ -3073,7 +3105,7 @@ Webhooks notify you when specific events are triggered. Webhook equivalents in A
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`chat_thread_properties_deleted`](#chat_thread_properties_deleted) [`chat_thread_properties_updated`](#chat_thread_properties_updated) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
 | **Thread tags** | [`chat_thread_tagged`](#chat_thread_tagged) [`chat_thread_untagged`](#chat_thread_untagged)                                                                                                                                                                                                                                                                         |
 | **Customers**   | [`customer_created`](#customer_created)                                                                                                                                                                                                                                                                                                                             |
-| **Other**       | [`last_seen_timestamp_updated`](#last_seen_timestamp_updated)                                                                                                                                                                                                                                                                                                       |
+| **Other**       | [`events_marked_as_seen`](#events_marked_as_seen)                                                                                                                                                                                                                                                                                                       |
 
 
 ## Chats
@@ -3635,7 +3667,7 @@ Webhooks notify you when specific events are triggered. Webhook equivalents in A
 
 ## Other
 
-### `last_seen_timestamp_updated`
+### `events_marked_as_seen`
 
 <CodeResponse title={'Sample webhook payload'}>
 
@@ -3643,7 +3675,7 @@ Webhooks notify you when specific events are triggered. Webhook equivalents in A
 {
   "user_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
   "chat_id": "PJ0MRSHTDG",
-  "timestamp": 123456789
+  "seen_up_to": "2017-10-12T15:19:21.010200Z"
 }
 ```
 
@@ -3653,8 +3685,8 @@ Webhooks notify you when specific events are triggered. Webhook equivalents in A
 
 |                     |                                                                                     |
 | ------------------- | ----------------------------------------------------------------------------------- |
-| **Action**          | `last_seen_timestamp_updated`                                                       |
-| **Push equivalent** | [`last_seen_timestamp_updated`](rtm-reference/#last_seen_timestamp_updated) |
+| **Action**          | `events_marked_as_seen`                                                       |
+| **Push equivalent** | [`events_marked_as_seen`](rtm-reference/#events_marked_as_seen) |
 
 # Errors
 

--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -184,6 +184,7 @@ File event informs about a file being uploaded.
 | ----------------------------------------------------- | :-------: | ------------------------------------------------------------------: |
 | `content_type`                                        | required  |       Supported image types: `image/png`, `image/jpeg`, `image/gif` |
 | `created_at`                                          | required  | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`                                                | required  | `file`                                                              |
 | `custom_id`                                           | optional  |                                                                   - |
 | `properties`                                          | optional  |                                                                   - |
 | `recipients`                                          | required  |                          Possible values: `all` (default), `agents` |
@@ -199,7 +200,7 @@ File event informs about a file being uploaded.
   "id": "0affb00a-82d6-4e07-ae61-56ba5c36f743", // generated server-side
   "custom_id": "31-0C-1C-07-DB-16",
   "type": "file",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "recipients": "all",
   "properties": {
@@ -231,6 +232,7 @@ Filled form event contains data from a form (prechat or postchat survey).
 | --------------------------------------- | :------: | ------------------------------------------------------------------: |
 | `created_at`                            | required | Date & time format with a resolution of microseconds, `UTC string`. |
 | `recipients`                            | required | Possible values: `all` (default), `agents` |
+| `type`                                  | required | `filled_form`                                                       |
 | `checkbox`                              | optional | For multiple-choice questions |
 | `custom_id`                             | optional |                                                                     |
 | `email`, `name`, `question`, `textarea` | optional | For open questions (text answer) |
@@ -248,7 +250,7 @@ Filled form event contains data from a form (prechat or postchat survey).
 	"id": "0affb00a-82d6-4e07-ae61-56ba5c36f743", // generated server-side
 	"custom_id": "31-0C-1C-07-DB-16",
 	"type": "filled_form",
-	"author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+	"author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
 	"created_at": "2017-10-12T15:19:21.010200Z",  // generated server-side
 	"recipients": "all",
 	"properties": {
@@ -312,6 +314,7 @@ Message event contains a text message to other chat users.
 | `created_at`     | required  | Date & time format with a resolution of microseconds, `UTC string`. |
 | `recipients`     | required  | Possible values: `all` (default), `agents`                          |
 | `text`           | required  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
+| `type`           | required  | `message`                                                           |
 | `custom_id`      | optional  |                                                                     |
 | `postback`       | optional  | Appears in the message event only when triggered by a rich message. |
 | `postback.type`  | optional  | Required only if `postback.value` is present.                       |
@@ -327,7 +330,7 @@ Message event contains a text message to other chat users.
   "id": "0affb00a-82d6-4e07-ae61-56ba5c36f743", // generated server-side
   "custom_id": "31-0C-1C-07-DB-16",
   "type": "message",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "text": "hello there",
   "postback": {
@@ -359,7 +362,8 @@ Rich message event contains a rich message data structure.
 | -------------------------------- | :-------: | ------------------------------------------------------------------: |
 | `created_at`                     | required  | Date & time format with a resolution of microseconds, `UTC string`. |
 | `recipients`                     | required  | Possible values: `all` (default), `agents` |
-| `template_id`                    | required  | Describes how the event should be presented in an app. | describes how the event should be presented in an app |
+| `template_id`                    | required  | Describes how the event should be presented in an app. | 
+| `type`                           | required  | `rich_message`                                                      |
 | `custom_id`                      | optional  |                                                                     |
 | `elements`                       | optional  | May contain 1 - 10 `element` objects.                               |
 | `elements.buttons`               | optional  | `buttons` may contain 1 - 11 `button` objects.                      |
@@ -383,7 +387,7 @@ Rich message event contains a rich message data structure.
   "id": "0affb00a-82d6-4e07-ae61-56ba5c36f743", // generated server-side
   "custom_id": "31-0C-1C-07-DB-16",
   "type": "rich_message",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "recipients": "all",
   "properties": {
@@ -443,10 +447,11 @@ Custom event is an event with customizable payload.
 
 | Field        | Req./Opt. |                                                                Note |
 | ------------ | :-------: | ------------------------------------------------------------------: |
+| `recipients` | required  |                          Possible values: `all` (default), `agents` |
+| `type`       | required  | `custom`                                                            |
 | `custom_id`  | optional  |                                                                   - |
 | `created_at` | required  | Date & time format with a resolution of microseconds, `UTC string`. |
 | `properties` | optional  |                                                                   - |
-| `recipients` | required  |                          Possible values: `all` (default), `agents` |
 
 </Text>
 <Code>
@@ -457,7 +462,7 @@ Custom event is an event with customizable payload.
   "id": "0affb00a-82d6-4e07-ae61-56ba5c36f743", // generated server-side
   "custom_id": "31-0C-1C-07-DB-16",
   "type": "custom",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "content": {
     "custom": {
@@ -482,12 +487,13 @@ Custom event is an event with customizable payload.
 
 System message event is native system event sent in specific situations.
 
-| Field                 | Req./Opt. |                                                                                                       Notes |
-| --------------------- | :-------: | ----------------------------------------------------------------------------------------------------------: |
-| `custom_id`           | optional  |                                                                                                           - |
-| `created_at`          | required  |                                         Date & time format with a resolution of microseconds, `UTC string`. |
-| `recipients`          | required  | Possible values: `all` (default for system events), `agents` (for events sent via `send_event`)             |
-| `system_message_type` | required  |                                                                                                           - |
+| Field                 | Req./Opt. |                                                                                          Notes |
+| --------------------- | :-------: | ---------------------------------------------------------------------------------------------: |
+| `created_at`          | required  |                           Date & time format with a resolution of microseconds, `UTC string`.  |
+| `recipients`          | required  | Possible values: `all` (default for system events), `agents` (for events sent via `send_event`)|
+| `type`                | required  | `system_message`                                                                               |
+| `system_message_type` | required  |                                                                                                |
+| `custom_id`           | optional  |                                                                                                |
 
 Here's the list of all system messages you might come across:
 

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -2461,7 +2461,7 @@ Sends an [Event](#events) object.
 | **Action**             | `send_event`                                                                             |
 | **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
 | **Web API equivalent** | [`send_event`](../#send-event)                                                           |
-| **Push message**       | -                                                                                        |
+| **Push message**       | [`incoming_event`](#incoming_event)                                                                                        |
 
 #### Request
 

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -182,7 +182,7 @@ File event informs about a file being uploaded.
 | `custom_id`                                           | optional  |                                                                   - |
 | `properties`                                          | optional  |                                                                   - |
 | `recipients`                                          | required  |                          Possible values: `all` (default), `agents` |
-| `url`                                                 | required  | Has to point to the LiveChat CDN.                                   |
+| `url`                                                 | required  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/agent-chat-api/#upload-file).|
 | `width`, `height`, `thumbnail_url`, `thumbnail2x_url` | optional  |                                                     Only for images |
 
 </Text>
@@ -481,7 +481,7 @@ System message event is native system event sent in specific situations.
 | --------------------- | :-------: | --------------------------------------------------------------------------------------------: |
 | `custom_id`           | optional  |                                                                                             - |
 | `created_at`          | required  |                           Date & time format with a resolution of microseconds, `UTC string`. |
-| `recipients`          | required  | Possible values: `all` (default for system events), `agents` (for events sent via send_event) |
+| `recipients`          | required  | Possible values: `all` (default for system events), `agents` (for events sent via `send_event`) |
 | `system_message_type` | required  |                                                                                             - |
 
 Here's the list of all system messages you might come across:
@@ -833,7 +833,7 @@ Here's the list of all system messages you might come across:
 | `email`                          | optional  |                                          |
 | `fields`                         | optional  | Isn't present when the chat is archived. |
 | `name`                           | optional  |                                          |
-| `events_seen_up_to`              |           | RFC 3339 datetime string                 |
+| `events_seen_up_to`              | optional  | RFC 3339 datetime string                 |
 | `last_visit`                     | optional  |                                          |
 | `present`                        | optional  |                                          |
 | `statistics`                     | optional  |                                          |

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -201,7 +201,7 @@ File event informs about a file being uploaded.
     // "Properties" object
   },
   "name": "image25.png", // generated server-side
-  "url": "https://domain.com/asdsfdsf.png",
+  "url": "https://domain.com/image25.png",
   "thumbnail_url": "https://domain.com/thumbnail.png", // generated server-side
   "thumbnail2x_url": "https://domain.com/thumbnail2x.png", // generated server-side
   "content_type": "image/png", // generated server-side

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -179,6 +179,7 @@ File event informs about a file being uploaded.
 | ----------------------------------------------------- | :-------: | ------------------------------------------------------------------: |
 | `content_type`                                        | required  |       Supported image types: `image/png`, `image/jpeg`, `image/gif` |
 | `created_at`                                          | required  | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`                                                | required  | `file`                                                              |
 | `custom_id`                                           | optional  |                                                                   - |
 | `properties`                                          | optional  |                                                                   - |
 | `recipients`                                          | required  |                          Possible values: `all` (default), `agents` |
@@ -194,7 +195,7 @@ File event informs about a file being uploaded.
   "id": "0affb00a-82d6-4e07-ae61-56ba5c36f743", // generated server-side
   "custom_id": "31-0C-1C-07-DB-16",
   "type": "file",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "recipients": "all",
   "properties": {
@@ -225,13 +226,14 @@ Filled form event contains data from a form (prechat or postchat survey).
 | Field                                   | Req./Opt |                                                               Notes |
 | --------------------------------------- | :------: | ------------------------------------------------------------------: |
 | `created_at`                            | required | Date & time format with a resolution of microseconds, `UTC string`. |
-| `recipients`                            | required | Possible values: `all` (default), `agents` |
-| `checkbox`                              | optional | For multiple-choice questions |
+| `recipients`                            | required | Possible values: `all` (default), `agents`                          |
+| `type`                                  | required | `filled_form`                                                       |
+| `checkbox`                              | optional | For multiple-choice questions                                       |
 | `custom_id`                             | optional |                                                                     |
-| `email`, `name`, `question`, `textarea` | optional | For open questions (text answer) |
-| `group_chooser`                         | optional | For group-choice questions |    
-| `properties`                            | optional | The [Properties](#properties) object |
-| `radio`, `select`                       | optional | For single-choice questions |  
+| `email`, `name`, `question`, `textarea` | optional | For open questions (text answer)                                    |
+| `group_chooser`                         | optional | For group-choice questions                                          |    
+| `properties`                            | optional | The [Properties](#properties) object                                |
+| `radio`, `select`                       | optional | For single-choice questions                                         |  
 
 </Text>
 
@@ -243,7 +245,7 @@ Filled form event contains data from a form (prechat or postchat survey).
 	"id": "0affb00a-82d6-4e07-ae61-56ba5c36f743", // generated server-side
 	"custom_id": "31-0C-1C-07-DB-16",
 	"type": "filled_form",
-	"author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+	"author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
 	"created_at": "2017-10-12T15:19:21.010200Z",  // generated server-side
 	"recipients": "all",
 	"properties": {
@@ -307,6 +309,7 @@ Message event contains a text message to other chat users.
 | `created_at`     | required  | Date & time format with a resolution of microseconds, `UTC string`. |
 | `recipients`     | required  | Possible values: `all` (default), `agents`                          |
 | `text`           | required  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
+| `type`           | required  | `message`                                                           |
 | `custom_id`      | optional  |                                                                     |
 | `postback`       | optional  | Appears in the message event only when triggered by a rich message. |
 | `postback.type`  | optional  | Required only if `postback.value` is present.                       |
@@ -322,7 +325,7 @@ Message event contains a text message to other chat users.
   "id": "0affb00a-82d6-4e07-ae61-56ba5c36f743", // generated server-side
   "custom_id": "31-0C-1C-07-DB-16",
   "type": "message",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "text": "hello there",
   "postback": {
@@ -354,7 +357,8 @@ Rich message event contains a rich message data structure.
 | -------------------------------- | :-------: | ------------------------------------------------------------------: |
 | `created_at`                     | required  | Date & time format with a resolution of microseconds, `UTC string`. |
 | `recipients`                     | required  | Possible values: `all` (default), `agents` |
-| `template_id`                    | required  | Describes how the event should be presented in an app. | describes how the event should be presented in an app |
+| `template_id`                    | required  | Describes how the event should be presented in an app.              |
+| `type`                           | required  | `rich_message`                                                      | 
 | `custom_id`                      | optional  |                                                                     |
 | `elements`                       | optional  | May contain 1 - 10 `element` objects.                               |
 | `elements.buttons`               | optional  | `buttons` may contain 1 - 11 `button` objects.                      |
@@ -378,7 +382,7 @@ Rich message event contains a rich message data structure.
   "id": "0affb00a-82d6-4e07-ae61-56ba5c36f743", // generated server-side
   "custom_id": "31-0C-1C-07-DB-16",
   "type": "rich_message",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "recipients": "all",
   "properties": {
@@ -438,10 +442,12 @@ Custom event is an event with customizable payload.
 
 | Field        | Req./Opt. |                                                                Note |
 | ------------ | :-------: | ------------------------------------------------------------------: |
+| `recipients` | required  |                          Possible values: `all` (default), `agents` |
+| `type`       | required  | `custom`                                                            |
 | `custom_id`  | optional  |                                                                     |
 | `created_at` | required  | Date & time format with a resolution of microseconds, `UTC string`. |
 | `properties` | optional  |                                                                     |
-| `recipients` | required  |                          Possible values: `all` (default), `agents` |
+
 
 </Text>
 <Code>
@@ -452,7 +458,7 @@ Custom event is an event with customizable payload.
   "id": "0affb00a-82d6-4e07-ae61-56ba5c36f743", // generated server-side
   "custom_id": "31-0C-1C-07-DB-16",
   "type": "custom",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "content": {
     "custom": {
@@ -477,12 +483,13 @@ Custom event is an event with customizable payload.
 
 System message event is native system event sent in specific situations.
 
-| Field                 | Req./Opt. |                                                                                          Note |
-| --------------------- | :-------: | --------------------------------------------------------------------------------------------: |
-| `custom_id`           | optional  |                                                                                             - |
-| `created_at`          | required  |                           Date & time format with a resolution of microseconds, `UTC string`. |
-| `recipients`          | required  | Possible values: `all` (default for system events), `agents` (for events sent via `send_event`) |
-| `system_message_type` | required  |                                                                                             - |
+| Field                 | Req./Opt. |                                                                                          Notes |
+| --------------------- | :-------: | ---------------------------------------------------------------------------------------------: |
+| `created_at`          | required  |                           Date & time format with a resolution of microseconds, `UTC string`.  |
+| `recipients`          | required  | Possible values: `all` (default for system events), `agents` (for events sent via `send_event`)|
+| `type`                | required  | `system_message`                                                                               |
+| `system_message_type` | required  |                                                                                                |
+| `custom_id`           | optional  |                                                                                                |
 
 Here's the list of all system messages you might come across:
 

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -826,17 +826,17 @@ Here's the list of all system messages you might come across:
 
 | Field                            | Req./Opt. |                                     Note |
 | -------------------------------- | :-------: | ---------------------------------------: |
-| `agent_last_event_created_at`    | optional  |                                        - |
-| `avatar`                         | optional  |                                        - |
-| `customer_last_event_created_at` | optional  |                                        - |
-| `created_at`                     | optional  |                                        - |
-| `email`                          | optional  |                                        - |
+| `agent_last_event_created_at`    | optional  |                                          |
+| `avatar`                         | optional  |                                          |
+| `customer_last_event_created_at` | optional  |                                          |
+| `created_at`                     | optional  |                                          |
+| `email`                          | optional  |                                          |
 | `fields`                         | optional  | Isn't present when the chat is archived. |
-| `name`                           | optional  |                                        - |
+| `name`                           | optional  |                                          |
 | `events_seen_up_to`              |           | RFC 3339 datetime string                 |
-| `last_visit`                     | optional  |                                        - |
-| `present`                        | optional  |                                        - |
-| `statistics`                     | optional  |                                        - |
+| `last_visit`                     | optional  |                                          |
+| `present`                        | optional  |                                          |
+| `statistics`                     | optional  |                                          |
 
 # Other common structures
 

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -182,7 +182,7 @@ File event informs about a file being uploaded.
 | `custom_id`                                           | optional  |                                                                   - |
 | `properties`                                          | optional  |                                                                   - |
 | `recipients`                                          | required  |                          Possible values: `all` (default), `agents` |
-| `system_message_type`                                 | required  |                                                                   - |
+| `url`                                                 | required  | Has to point to the LiveChat CDN.                                   |
 | `width`, `height`, `thumbnail_url`, `thumbnail2x_url` | optional  |                                                     Only for images |
 
 </Text>
@@ -220,20 +220,21 @@ File event informs about a file being uploaded.
 <Section>
 <Text>
 
-Filled form event contains data from a form.
+Filled form event contains data from a form (prechat or postchat survey).
 
-| Field                                   | Req./Opt |                                                                Note |
+| Field                                   | Req./Opt |                                                               Notes |
 | --------------------------------------- | :------: | ------------------------------------------------------------------: |
-| `custom_id`                             | optional |                                                                     |
 | `created_at`                            | required | Date & time format with a resolution of microseconds, `UTC string`. |
-| `properties`                            | optional |                                                                     |
-| `recipients`                            | required |                          Possible values: `all` (default), `agents` |
-| `name`, `email`, `question`, `textarea` | optional |                                    For open questions (text answer) |
-| `radio`, `select`                       | optional |                                         For single-choice questions |
-| `checkbox`                              | optional |                                       For multiple-choice questions |
-| `group_chooser`                         | optional |                                          For group-choice questions |
+| `recipients`                            | required | Possible values: `all` (default), `agents` |
+| `checkbox`                              | optional | For multiple-choice questions |
+| `custom_id`                             | optional |                                                                     |
+| `email`, `name`, `question`, `textarea` | optional | For open questions (text answer) |
+| `group_chooser`                         | optional | For group-choice questions |    
+| `properties`                            | optional | The [Properties](#properties) object |
+| `radio`, `select`                       | optional | For single-choice questions |  
 
 </Text>
+
 <Code>
 <CodeResponse title={'Sample Filled form event'}>
 
@@ -736,7 +737,7 @@ Here's the list of all system messages you might come across:
   "name": "Support Team",
   "email": "agent1@example.com",
   "present": true,
-  "events_seen_up_to": 1473433500,
+  "events_seen_up_to": "2017-10-12T15:19:21.010200Z",
   "avatar": "cdn.livechatinc.com/avatars/1.png",
   "routing_status": "accepting_chats"
 }
@@ -759,7 +760,7 @@ Here's the list of all system messages you might come across:
   "name": "Support Team",
   "email": "agent1@example.com",
   "present": true,
-  "events_seen_up_to": 1473433500,
+  "events_seen_up_to": "2017-10-12T15:19:21.010200Z",
   "avatar": "cdn.livechatinc.com/avatars/1.png",
   "routing_status": "accepting_chats",
   "permission": "administrator"
@@ -817,7 +818,7 @@ Here's the list of all system messages you might come across:
   "customer_last_event_created_at": "2017-10-12T15:19:21.010200Z",
   "created_at": "2017-10-11T15:19:21.010200Z",
   "present": true, // optional, applies only to customer located in chat object
-  "events_seen_up_to": 1473433500 // optional, applies only to customer located in chat object
+  "events_seen_up_to": "2017-10-12T15:19:21.010200Z" 
 }
 ```
 
@@ -832,7 +833,7 @@ Here's the list of all system messages you might come across:
 | `email`                          | optional  |                                        - |
 | `fields`                         | optional  | Isn't present when the chat is archived. |
 | `name`                           | optional  |                                        - |
-| `last_seen_timestamp`            | optional  |                                        - |
+| `events_seen_up_to`              |           | RFC 3339 datetime string                 |
 | `last_visit`                     | optional  |                                        - |
 | `present`                        | optional  |                                        - |
 | `statistics`                     | optional  |                                        - |
@@ -1139,40 +1140,6 @@ There's only one value allowed for a single property.
 
 </CodeSample>
 
-<!-- > **`get_chats_summary`** sample **request** with optional params
-
-```json
-{
-	"request_id": "12345", // optional
-	"action": "get_chats_summary",
-	"payload": {
-		"filters": {
-		"query": "search keyword",
-		"agent_ids": ["agent1@example.com"],
-		"date_from": "2016-09-01",
-		"date_to": "2016-10-01",
-		"properties": {
-			"rating": {
-				"score": {
-					"values": [1]
-				}
-			},
-			"rating": {
-				"comment": {
-					"exists": true
-				}
-			}
-		}
-	},
-	"pagination": {
-		"page": 1,
-		"limit": 25
-				}
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-```  -->
-
 <CodeResponse>
 
 ```json
@@ -1182,23 +1149,53 @@ There's only one value allowed for a single property.
   "type": "response",
   "success": true,
   "payload": {
-    "chats": [
-      {
-        "chat": {
-          "id": "PJ0MRSHTDG",
-          "users": [
-            // array of "User" objects
-          ],
-          "thread": {
-            // "Thread" object
-          }
-        }
-      }
-    ],
-    "pagination": {
-      "page": 1,
-      "total": 3
-    }
+    	"chats_summary": [{
+		    "id": "PJ0MRSHTDG",
+		    "users": [
+		    	// array of "User" objects
+		    ],
+		    "last_event_per_type": { // last event of each type in chat
+		    	"message": {
+		    		"thread_id": "K600PKZON8",
+		    		"thread_order": 3,
+		    		"event": {
+		    			// "restricted_access": true
+		    			// or
+		    			// "Event > Message" object
+		    		}
+		    	},
+		    	"system_message": {
+		    		"thread_id": "K600PKZON6",
+		    		"thread_order": 1,
+		    		"event": {
+		    			// "restricted_access": true
+		    			// or
+		    			// "Event > System message" object
+		    		}
+		    	},
+		    	...
+		    },
+		    "last_thread_summary": {
+		    	"id": "K600PKZON8",
+		    	"order": 3,
+		    	"timestamp": 1473433500,
+		    	"user_ids": ["agent1@example.com"],
+		    	"properites": {
+		    	// "Properites" object
+		    	},
+		    	"tags": ["bug_report"]
+		    },
+		    "properites": {
+		    	// "Properites" object
+		    },
+		    "access": {
+		    	// "Access" object
+		    },
+		    "is_followed": false
+	    }],
+	    "found_chats": 2340,
+	    "next_page_id": "MTUxNzM5ODEzMTQ5Ng==", // optional
+	    "previous_page_id": "MTUxNzM5ODEzMTQ5Nw==" // optional
   }
 }
 ```
@@ -2704,7 +2701,7 @@ Sends an [Event](#events) object.
 | Parameter    | Required | Data type | Notes                                           |
 | ------------ | -------- | --------- | ----------------------------------------------- |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete property for. |
-| `properties` | Yes      | `object`  | Chat properties to delete. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| `properties` | Yes      | `object`  | Chat properties to delete. |
 
 </Text>
 <Code>
@@ -2863,7 +2860,7 @@ Sends an [Event](#events) object.
 | ------------ | -------- | --------- | ------------------------------------------------- |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete property for.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to delete property for. |
-| `properties` | Yes      | `object`  | Chat thread properties to delete. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| `properties` | Yes      | `object`  | Chat thread properties to delete. |
 
 </Text>
 <Code>
@@ -2943,7 +2940,7 @@ Sends an [Event](#events) object.
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for. |
 | `event_id`   | Yes      | `string`  | Id of the event you want to set properties for.  |
-| `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| `properties` | Yes      | `object`  | Chat properties to set. |
 
 </Text>
 <Code>
@@ -4052,14 +4049,14 @@ Logs the Agent out.
 | **Action**             | `mark_events_as_seen`                                         |
 | **Required scopes**    | `chats--access:ro` `chats--all:ro`                            |
 | **Web API equivalent** | [`mark_events_as_seen`](../#mark-events-as-seen)              |
-| **Push message**       | [`last_seen_timestamp_updated`](#last_seen_timestamp_updated) |
+| **Push message**       | [`events_marked_as_seen`](#events_marked_as_seen) |
 
 #### Request
 
-| Parameter    | Required | Data type   |     |
-| ------------ | -------- | ----------- | --- |
-| `chat_id`    | Yes      | `string`    |     |
-| `seen_up_to` | Yes      | `UTC string`|
+| Parameter    | Required | Data type   | Notes |
+| ------------ | -------- | ----------- | ----- |
+| `chat_id`    | Yes      | `string`    |       |
+| `seen_up_to` | Yes      | `string`    | RFC 3339 date-time format |
 
 #### Response
 
@@ -4330,7 +4327,7 @@ Pushes are **server - client methods** used for keeping the application state up
 | **Thread tags** | [`chat_thread_tagged`](#chat_thread_tagged) [`chat_thread_untagged`](#chat_thread_untagged)                                                                                                                                                                                                                                                                         |
 | **Customers**   | [`customer_visit_started`](#customer_visit_started) [`customer_created`](#customer_created) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_banned`](#customer_banned) [`customer_visit_ended`](#customer_visit_ended)                                                                                         |
 | **Status**      | [`agent_updated`](#agent_updated) [`agent_disconnected`](#agent_disconnected)                                                                                                                                                                                                                                                                                       |
-| **Other**       | [`last_seen_timestamp_updated`](#last_seen_timestamp_updated) [`incoming_sneak_peek`](#incoming_sneak_peek) [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast)                                                                                                                                                   |
+| **Other**       | [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_sneak_peek`](#incoming_sneak_peek) [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast)                                                                                                                                                   |
 
 ## Chats
 
@@ -5160,7 +5157,7 @@ With this piece of information, the client is able to figure out where it should
 | **Action**             | `incoming_sneak_peek` |
 | **Webhook equivalent** | -                     |
 
-### `last_seen_timestamp_updated`
+### `events_marked_as_seen`
 
 <CodeResponse title={'Sample push payload'}>
 
@@ -5168,7 +5165,7 @@ With this piece of information, the client is able to figure out where it should
 {
   "user_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
   "chat_id": "PJ0MRSHTDG",
-  "timestamp": 123456789
+  "seen_up_to": "2017-10-12T15:19:21.010200Z"
 }
 ```
 
@@ -5178,8 +5175,8 @@ With this piece of information, the client is able to figure out where it should
 
 |                        |                                                                                     |
 | ---------------------- | ----------------------------------------------------------------------------------- |
-| **Action**             | `last_seen_timestamp_updated`                                                       |
-| **Webhook equivalent** | [`last_seen_timestamp_updated`](../#last_seen_timestamp_updated) |
+| **Action**             | `events_marked_as_seen`                                                       |
+| **Webhook equivalent** | [`events_marked_as_seen`](../#events_marked_as_seen) |
 
 ### `incoming_multicast`
 

--- a/content/messaging/customer-chat-api/index.mdx
+++ b/content/messaging/customer-chat-api/index.mdx
@@ -74,7 +74,7 @@ File event informs about a file being uploaded.
 | `custom_id`                                           | optional  |                                                                   - |
 | `properties`                                          | optional  |                                                                   - |
 | `recipients`                                          | required  |                          Possible values: `all` (default), `agents` |
-| `system_message_type`                                 | required  |                                                                   - |
+| `url`                                                 | required  |   Has to point to the LiveChat CDN.                                  |
 | `width`, `height`, `thumbnail_url`, `thumbnail2x_url` | optional  |                                                     Only for images |
 
 </Text>
@@ -117,19 +117,19 @@ File event informs about a file being uploaded.
 
 <Text>
 
-Filled form event contains data from a form.
+Filled form event contains data from a form (prechat or postchat survey).
 
-| Field                                   | Req./Opt |                                                                Note |
+| Field                                   | Req./Opt |                                                               Notes |
 | --------------------------------------- | :------: | ------------------------------------------------------------------: |
-| `custom_id`                             | optional |                                                                   - |
 | `created_at`                            | required | Date & time format with a resolution of microseconds, `UTC string`. |
-| `properties`                            | optional |                                                                   - |
-| `recipients`                            | required |                          Possible values: `all` (default), `agents` |
-| `name`, `email`, `question`, `textarea` | optional |                                    For open questions (text answer) |
-| `radio`, `select`                       | optional |                                         For single-choice questions |
-| `checkbox`                              | optional |                                       For multiple-choice questions |
-| `group_chooser`                         | optional |                                          For group-choice questions |
-
+| `recipients`                            | required | Possible values: `all` (default), `agents` |
+| `checkbox`                              | optional | For multiple-choice questions |
+| `custom_id`                             | optional |                                                                     |
+| `email`, `name`, `question`, `textarea` | optional | For open questions (text answer) |
+| `group_chooser`                         | optional | For group-choice questions |
+| `properties`                            | optional | The [Properties](#properties) object |
+| `radio`, `select`                       | optional | For single-choice questions |
+  
 </Text>
 
 <Code>
@@ -646,7 +646,7 @@ Here's the list of all system messages you might come across as a Customer:
     "custom field name": "custom field value"
   },
   "present": true,
-  "events_seen_up_to": 1473433500
+  "events_seen_up_to": "2017-10-12T15:19:21.010200Z"
 }
 ```
 
@@ -668,7 +668,7 @@ Here's the list of all system messages you might come across as a Customer:
   "name": "Support Team",
   "avatar": "cdn.livechatinc.com/avatars/1.png",
   "present": true,
-  "events_seen_up_to": 1473433500
+  "events_seen_up_to": "2017-10-12T15:19:21.010200Z"
 }
 ```
 
@@ -918,7 +918,7 @@ curl -X POST \
 | **Properties** | [`update_chat_properties`](#update-chat-properties) [`delete_chat_properties`](#delete-chat-properties) [`update_chat_thread_properties`](#update-chat-thread-properties) [`delete_chat_thread_properties`](#delete-chat-thread-properties) [`update_event_properties`](#update-event-properties) [`delete_event_properties`](#delete-event-properties) |
 | **Customers**  | [`update_customer`](#update-customer) [`set_customer_fields`](#set-customer-fields)                                                                                                                                                                                                                                                                     |
 | **Status**     | [`get_groups_status`](#get-groups-status)                                                                                                                                                                                                                                                                                                               |
-| **Other**      | [`get_form`](#get-form) [`get_predicted_agent`](#get-predicted-agent) [`get_url_details`](#get-url-details) [`mark_events_as_seen`](#mark-events-as-seen)                                                                                                                                                                                               |
+| **Other**      | [`check_goals`](#check-goals) [`get_form`](#get-form) [`get_predicted_agent`](#get-predicted-agent) [`get_url_details`](#get-url-details) [`mark_events_as_seen`](#mark-events-as-seen)                                                                                                                                                                                               |
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/521935b4232b6f924644#?env%5BLiveChat%20Web%20API%5D=W3sia2V5IjoiYXBpX3ZlcnNpb24iLCJ2YWx1ZSI6InYzLjEiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6ImFjY2Vzc190b2tlbiIsInZhbHVlIjoiZGFsOlRMSjdRc3RYUXNTeHVWOGI1aDFSZmciLCJlbmFibGVkIjp0cnVlfV0=)
 
@@ -1806,7 +1806,7 @@ curl -X POST \
 | Parameter    | Required | Data type | Notes                                            |
 | ------------ | -------- | --------- | ------------------------------------------------ |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete properties of. |
-| `properties` | Yes      | `object`  | Chat properties to delete. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| `properties` | Yes      | `object`  | Chat properties to delete. |
 
 #### Response
 
@@ -1878,7 +1878,7 @@ curl -X POST \
 | ------------ | -------- | --------- | ------------------------------------------------ |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for. |
-| `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| `properties` | Yes      | `object`  | Chat properties to set. |
 
 #### Response
 
@@ -1958,7 +1958,7 @@ curl -X POST \
 | ------------ | -------- | --------- | ------------------------------------------------------ |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete the properties of.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to delete the properties of. |
-| `properties` | Yes      | `object`  | Chat thread properties to delete. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| `properties` | Yes      | `object`  | Chat thread properties to delete. |
 
 #### Response
 
@@ -2189,7 +2189,7 @@ curl -X POST \
 | `name`    | No       | `string`  |                                  |
 | `email`   | No       | `string`  |                                  |
 | `avatar`  | No       | `string`  | The URL of the Customer's avatar |
-| `fields`  | No       | `object`  | A `"key": "value"` object        |
+| `fields`  | No       | `object`  | `key: value` format        |
 
 At least one optional parameter needs to be included in the request.
 
@@ -2246,14 +2246,14 @@ curl -X POST \
 |                        |                                                                        |
 | ---------------------- | ---------------------------------------------------------------------- |
 | **Method URL**         | `https://api.livechatinc.com/v3.1/customer/action/set_customer_fields` |
-| **RTM API equivalent** | [`get_customers`](rtm-reference/#get-customers)                        |
+| **RTM API equivalent** | [`set_customer_fields`](rtm-reference/#set-customer-fields)                        |
 | **Webhook**            | [`customer_updated`](#customer_updated)                                |
 
 #### Request
 
-| Parameter | Required | Data type | Notes                |
+| Parameter | Required | Data type |  Notes              |
 | --------- | -------- | --------- | -------------------- |
-| `fields`  | Yes      | `string`  | A `key:value` object |
+| `fields`  | Yes      | `object`  | `key:value` format |
 
 Users Agent and referrer are updated by default using the browser’s headers.
 
@@ -2322,7 +2322,7 @@ curl -X POST \
 | `all`     | No       | `bool`    | If set to `true`, you will get statuses of all the groups. |
 | `groups`  | No       | `array`   | A table of groups' IDs                                     |
 
-At least one optional parameter needs to be included in the request.
+One of the optional parameters needs to be included in the request.
 
 #### Response
 
@@ -2404,9 +2404,9 @@ Customer can use this method to trigger checking if [goals](https://www.livechat
 
 #### Request
 
-| Parameter         | Required | Data type |     |
-| ----------------- | -------- | --------- | --- |
-| `customer_fields` | Yes      | `string`  |     |
+| Parameter         | Required | Data type |  Notes   |
+| ----------------- | -------- | --------- | -------- |
+| `customer_fields` | Yes      | `object`  | `key:value` format |
 | `group_id`        | Yes      | `number`  |     |
 | `page_url`        | Yes      | `string`  |     |
 
@@ -2462,6 +2462,8 @@ curl -X POST \
 
 ### Get Form
 
+Returns an empty form of a <a href="https://www.livechatinc.com/help/chat-surveys/" target="_blank">prechat or postchat survey</a>.
+
 #### Specifics
 
 |                        |                                                             |
@@ -2479,14 +2481,11 @@ curl -X POST \
 
 #### Response
 
-| Parameter                         | Notes                                                                              |     |     |
-| --------------------------------- | ---------------------------------------------------------------------------------- | --- | --- |
-| `form`                            | If form is disabled, the `form` object won't be returned in the response.          |     |     |
-| `headers`                         | For headers; the field has no `answer` and is not sent in the `filled_form` event. |     |     |
-| `name, email, question, textarea` | For open questions (text area)                                                     |     |     |
-| `radio, select, checkbox`         | For single/multiple-choice questions                                               |     |     |
-| `group_chooser`                   | For group-choice questions                                                         |     |     |
-| `rating`                          | For rating; the field isn't sent in the `filled_form` event.                       |     |     |
+| Parameter  | Notes |
+| ---------- | -------- | 
+| `enabled`  |  If `enabled: false`, the `form` object is not returned. Prechat/postchat survey disabled in the LiveChat Agent App UI. |
+| `header`   | For headers; the field has no `answer`, therefore is not sent in the [Filled form](#filled-form) event. |    
+| `rating`   | For rating; the field has no `answer`, therefore is not sent in the [Filled form](#filled-form) event. |
 
 </Text>
 
@@ -2702,14 +2701,14 @@ curl -X POST \
 | ---------------------- | ---------------------------------------------------------------------- |
 | **Method URL**         | `https://api.livechatinc.com/v3.1/customer/action/mark_events_as_seen` |
 | **RTM API equivalent** | [`mark_events_as_seen`](rtm-reference/#mark-events-as-seen)            |
-| **Webhook**            | [`last_seen_timestamp_updated`](#last_seen_timestamp_updated)          |
+| **Webhook**            | [`events_marked_as_seen`](#events_marked_as_seen)          |
 
 #### Request
 
-| Parameter   | Required | Data type |     |
-| ----------- | -------- | --------- | --- |
-| `chat_id`   | Yes      | `string`  |     |
-| `timestamp` | No       | `number`  |     |
+| Parameter   | Required | Data type | Notes |
+| ----------- | -------- | --------- | ----- |
+| `chat_id`   | Yes      | `string`  |       |
+| `seen_up_to` | Yes      | `string`  | RFC 3339 date-time format|
 
 #### Response
 
@@ -2762,7 +2761,7 @@ Webhooks notify you when specific events are triggered. Webhooks equivalents in 
 | **Chat users**  | [`chat_user_added`](#chat_user_added) [`chat_user_removed`](#chat_user_removed)                                                                                                                                                                                                                                                                                     |
 | **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                            |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`chat_thread_properties_updated`](#chat_thread_properties_updated) [`chat_thread_properties_deleted`](#chat_thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
-| **Other**       | [`last_seen_timestamp_updated`](#last_seen_timestamp_updated)                                                                                                                                                                                                                                                                                                       |
+| **Other**       | [`events_marked_as_seen`](#events_marked_as_seen)                                                                                                                                                                                                                                                                                                       |
 
 ## Chats
 
@@ -3197,7 +3196,7 @@ Webhooks notify you when specific events are triggered. Webhooks equivalents in 
 
 ## Other
 
-### `last_seen_timestamp_updated`
+### `events_marked_as_seen`
 
 <CodeResponse title={'Sample webhook payload'}>
 
@@ -3206,7 +3205,7 @@ Webhooks notify you when specific events are triggered. Webhooks equivalents in 
   "user_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
   "chat_id": "PJ0MRSHTDG",
   "thread_id": "K600PKZON8",
-  "timestamp": 123456789
+  "seen_up_to": "2017-10-12T15:19:21.010200Z"
 }
 ```
 
@@ -3216,8 +3215,8 @@ Webhooks notify you when specific events are triggered. Webhooks equivalents in 
 
 |                     |                                                                                        |
 | ------------------- | -------------------------------------------------------------------------------------- |
-| **Action**          | `last_seen_timestamp_updated`                                                          |
-| **Push equivalent** | [`last_seen_timestamp_updated`](rtm-reference/#last_seen_timestamp_updated) |
+| **Action**          | `events_marked_as_seen`                                                          |
+| **Push equivalent** | [`events_marked_as_seen`](rtm-reference/#events_marked_as_seen) |
 
 # Contact us
 

--- a/content/messaging/customer-chat-api/index.mdx
+++ b/content/messaging/customer-chat-api/index.mdx
@@ -956,7 +956,7 @@ It returns [summaries](#chat-summary) of the chats a Customer participated in.
 ```shell
 curl -X POST \
   https://api.livechatinc.com/v3.1/customer/action/get_chats_summary?license_id=<license_id> \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{}'
 ```
@@ -1016,7 +1016,7 @@ curl -X POST \
 ```shell
 curl -X POST \
   https://api.livechatinc.com/v3.1/customer/action/get_chats_summary?license_id=<license_id> \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "offset": 0,
@@ -1061,7 +1061,7 @@ curl -X POST \
 ```shell
 curl -X POST \
   https://api.livechatinc.com/v3.1/customer/action/get_chat_threads_summary?license_id=<license_id> \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
 		  "chat_id": "PJ0MRSHTDG"
@@ -1096,20 +1096,6 @@ curl -X POST \
 
 </Section>
 
-<!-- > **`get_chat_threads_summary`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  https://api.livechatinc.com/v3.1/customer/action/get_chat_threads_summary?license_id=<license_id> \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "chat_id": "PJ0MRSHTDG",
-      "offset": 0,
-      "limit": 100
-      }'
-``` -->
-
 <Section>
 
 <Text>
@@ -1139,8 +1125,8 @@ curl -X POST \
 
 ```shell
 curl -X POST \
-  https://api.livechatinc.com/v3.1/customer/action/<action>?license_id=<license_id> \
-  -H 'Content-Type: <content-type>' \
+  https://api.livechatinc.com/v3.1/customer/action/get_chat_threads?license_id=<license_id> \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "chat_id": "PJ0MRSHTDG",
@@ -1224,7 +1210,7 @@ Starts a chat.
 
 ```shell
 curl -X POST \
-  https://api.livechatinc.com/v3.1/customer/action/<action>?license_id=<license_id> \
+  https://api.livechatinc.com/v3.1/customer/action/start_chat?license_id=<license_id> \
   -H 'Content-Type: <content-type>' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{}'
@@ -1246,44 +1232,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`start_chat`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  https://api.livechatinc.com/v3.1/customer/action/<action>?license_id=<license_id> \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "chat": {
-		    "access": {
-		      "group_ids": [1]
-		    },
-		  "properties": {
-		  	"source": {
-		  		"type": "facebook"
-		  	}
-		  },
-		  "thread": {
-		  	"events": [{
-		  		"type": "message",
-		  		"custom_id": "31-0C-1C-07-DB-16",
-		  		"text": "hello there"
-		  	}, {
-		  		"type": "system_message",
-		  		"custom_id": "31-0C-1C-07-DB-16",
-		  		"text": "hello there"
-		  	}],
-		  	"properties": {
-		  		"source": {
-		  			"type": "facebook"
-		    		}
-		    	}
-	      },
-      "continuous": true
-        }
-      }'
-``` -->
 
 <Section>
 
@@ -1329,7 +1277,7 @@ Used to restart an archived chat.
 
 ```shell
 curl -X POST \
-  https://api.livechatinc.com/v3.1/customer/action/<action>?license_id=<license_id> \
+  https://api.livechatinc.com/v3.1/customer/action/activate_chat?license_id=<license_id> \
   -H 'Content-Type: <content-type>' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
@@ -1354,46 +1302,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`activate_chat`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  https://api.livechatinc.com/v3.1/customer/action/<action>?license_id=<license_id> \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "chat": {
-        "id": "PJ0MRSHTDG",
-        "order": 343544565,
-        "access": {
-          "group_ids": [1]
-        },
-        "properties": {
-          "source": {
-            "type": "facebook"
-          }
-        },
-        "thread": {
-          "events": [{
-            "type": "message",
-            "custom_id": "31-0C-1C-07-DB-16",
-            "text": "hello there"
-          }, {
-            "type": "system_message",
-            "custom_id": "31-0C-1C-07-DB-16",
-            "text": "hello there"
-          }],
-          "properties": {
-            "source": {
-              "type": "facebook"
-                    }
-                  }
-                }
-              }
-            }
-      }'
-```-->
 
 <Section>
 
@@ -1429,7 +1337,7 @@ No response payload (`200 OK`).
 
 ```shell
 curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/close_thread??license_id=<license_id>' \
+  'https://api.livechatinc.com/v3.1/customer/action/close_thread?license_id=<license_id>' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
@@ -1549,7 +1457,7 @@ Uploads a file to the server as a temporary file. It returns a URL that expires 
 
 ```shell
 curl -X POST \
-  https://api.livechatinc.com/v3.1/customer/action/upload_filelicense_id=<license_id> \
+  https://api.livechatinc.com/v3.1/customer/action/upload_file?license_id=<license_id> \
   -H 'Authorization: Bearer <customer_access_token>' \
   -H 'Content-Type: multipart/form-data; boundary=--------------------------210197025774705439685896' \
   -H 'content-type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW' \
@@ -1609,7 +1517,7 @@ No response payload (`200 OK`).
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/send_rich_message_postback?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "chat_id": "PJ0MRSHTDG",
@@ -1627,24 +1535,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`send_rich_message_postback`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  https://api.livechatinc.com/v3.1/customer/action/send_rich_message_postback?license_id=<license_id> \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "chat_id": "PJ0MRSHTDG",
-        "thread_id": "K600PKZON8",
-        "event_id": "a0c22fdd-fb71-40b5-bfc6-a8a0bc3117f7",
-        "postback": {
-            "id": "Method URL_yes",
-            "toggled": true
-          }
-      }'
-``` -->
 
 <Section>
 
@@ -1680,7 +1570,7 @@ No response payload (`200 OK`).
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/send_sneak_peek?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "chat_id": "PJ0MRSHTDG",
@@ -1694,19 +1584,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`send_sneak_peek`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  https://api.livechatinc.com/v3.1/customer/action/send_sneak_peek?license_id=<license_id> \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "chat_id": "PJ0MRSHTDG",
-		  "sneak_peek_text": "hello world"
-      }'
-``` -->
 
 ## Properties
 
@@ -1744,7 +1621,7 @@ No response payload (`200 OK`).
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/update_chat_properties?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "chat_id": "PW94SJTGW6",
@@ -1762,24 +1639,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`update_chat_properties`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/update_chat_properties?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "chat_id": "PW94SJTGW6",
-        "properties": {
-            "bb9e5b2f1ab480e4a715977b7b1b4279": {
-                "score": 10,
-                "comment": "Thank you!"
-              }
-          }
-      }'
-``` -->
 
 <Section>
 
@@ -1821,7 +1680,7 @@ No response payload (`200 OK`).
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/delete_chat_properties?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "chat_id": "PW94SJTGW6",
@@ -1839,24 +1698,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`delete_chat_properties`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/delete_chat_properties?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "chat_id": "PW94SJTGW6",
-        "properties": {
-            "bb9e5b2f1ab480e4a715977b7b1b4279": [
-                "score",
-                "comment"
-              ]
-          }
-      }'
-``` -->
 
 <Section>
 
@@ -1893,7 +1734,7 @@ No response payload (`200 OK`).
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/update_chat_thread_properties?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "chat_id": "PW94SJTGW6",
@@ -1912,25 +1753,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`update_chat_thread_properties`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/update_chat_thread_properties?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "chat_id": "PW94SJTGW6",
-      "thread_id": "K600PKZON8",
-      "properties": {
-          "bb9e5b2f1ab480e4a715977b7b1b4279": {
-              "score": 10,
-              "comment": "Thank you!"
-              }
-          }
-      }'
-``` -->
 
 <Section>
 
@@ -1973,7 +1795,7 @@ No response payload (`200 OK`).
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/delete_chat_thread_properties?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "chat_id": "PW94SJTGW6",
@@ -1992,25 +1814,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`delete_chat_thread_properties`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/delete_chat_thread_properties?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "chat_id": "PW94SJTGW6",
-      "thread_id": "K600PKZON8",
-      "properties": {
-          "bb9e5b2f1ab480e4a715977b7b1b4279": [
-              "score",
-              "comment"
-              ]
-          }
-      }'
-``` -->
 
 <Section>
 
@@ -2048,7 +1851,7 @@ No response payload (`200 OK`).
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/update_event_properties?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "chat_id": "PW94SJTGW6",
@@ -2068,26 +1871,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`update_event_properties`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/update_event_properties?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "chat_id": "PW94SJTGW6",
-      "thread_id": "K600PKZON8",
-      "event_id": "2_EW2WQSA8",
-      "properties": {
-          "bb9e5b2f1ab480e4a715977b7b1b4279": {
-              "score": 10,
-              "comment": "Thank you!"
-              }
-          }
-      }'
-``` -->
 
 <Section>
 
@@ -2125,7 +1908,7 @@ No response payload (`200 OK`).
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/delete_event_properties?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "chat_id": "PWLW03ICW7",
@@ -2145,26 +1928,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`delete_event_properties`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/delete_event_properties?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "chat_id": "PWLW03ICW7",
-      "thread_id": "PWNWW5N6A8",
-      "event_id": "PWNWW5N6A8_1",
-      "properties": {
-          "rating": [
-              "score",
-              "comment"
-              ]
-          }
-      }'
-``` -->
 
 ## Customers
 
@@ -2206,7 +1969,7 @@ No response payload (`200 OK`).
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/update_customer?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "name": "John Doe"
@@ -2218,22 +1981,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`update_customer`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/update_customer?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "name": "John Doe",
-      "avatar": "https://domain.com/avatars/1.jpg",
-      "fields": {
-        "score": "low"
-          }
-      }'
-```-->
 
 <Section>
 
@@ -2270,7 +2017,7 @@ No response payload (`200 OK`).
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/set_customer_fields?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "fields": {
@@ -2284,20 +2031,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`set_customer_fields`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/set_customer_fields?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "fields": {
-		    "company_size": "10-100"
-      		}
-      }'
-```-->
 
 ## Status
 
@@ -2343,7 +2076,7 @@ No response payload (`200 OK`).
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/get_groups_status?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "all": true
@@ -2371,18 +2104,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`get_groups_status`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/get_groups_status?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "groups": [1, 2, 3, 4]
-      }'
-```-->
 
 ## Other
 
@@ -2423,15 +2144,15 @@ No response payload (`200 OK`).
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/check_goals?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
-      "page_url": "https://mypage.com",
-      "customer_fields": {
-        "field1": "value1"
+        "page_url": "https://mypage.com",
+        "customer_fields": {
+            "field1": "value1"
 	      },
 	    "group_id": 0
-      }'
+}'
 ```
 
 </CodeSample>
@@ -2439,22 +2160,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`check_goals`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/check_goals?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "page_url": "https://mypage.com",
-      "customer_fields": {
-        "field1": "value1"
-	      },
-	    "group_id": 0
-      }'
-``` -->
 
 <Section>
 
@@ -2496,7 +2201,7 @@ Returns an empty form of a <a href="https://www.livechatinc.com/help/chat-survey
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/get_form?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "group_id": 0,
@@ -2542,19 +2247,6 @@ curl -X POST \
 
 </Section>
 
-<!-- > **`get_form`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/get_form?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "group_id": 0,
-		  "type": "prechat"
-      }'
-```-->
-
 <Section>
 
 <Text>
@@ -2580,7 +2272,7 @@ Gets the predicted Agent - the one the Customer will chat with when the chat sta
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/get_predicted_agent?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{}'
 ```
@@ -2607,16 +2299,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`get_predicted_agent`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/get_predicted_agent?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{}'
-``` -->
 
 <Section>
 
@@ -2649,7 +2331,7 @@ It returns the info on a given URL.
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/get_url_details?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "url": "https://livechatinc.com"
@@ -2676,18 +2358,6 @@ curl -X POST \
 </Code>
 
 </Section>
-
-<!-- > **`get_url_details`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/get_url_details?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "url": "https://livechatinc.com"
-      }'
-``` -->
 
 <Section>
 
@@ -2723,7 +2393,7 @@ No response payload (`200 OK`).
 ```shell
 curl -X POST \
   'https://api.livechatinc.com/v3.1/customer/action/mark_events_as_seen?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
+  -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{
       "chat_id": "PJ0MRSHTDG",
@@ -2737,18 +2407,6 @@ curl -X POST \
 
 </Section>
 
-<!-- > **`mark_events_as_seen`** sample **request** with optional params
-
-```shell
-curl -X POST \
-  'https://api.livechatinc.com/v3.1/customer/action/mark_events_as_seen?license_id=<license_id>' \
-  -H 'Content-Type: <content-type>' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-      "chat_id": "PJ0MRSHTDG",
-      "seen_up_to": "2017-10-12T15:19:21.010200Z"
-      }'
-``` -->
 
 # Webhooks
 

--- a/content/messaging/customer-chat-api/index.mdx
+++ b/content/messaging/customer-chat-api/index.mdx
@@ -95,7 +95,7 @@ File event informs about a file being uploaded.
     // "Properties" object
   },
   "name": "image25.png", // generated server-side
-  "url": "https://domain.com/asdsfdsf.png",
+  "url": "https://domain.com/image25.png",
   "thumbnail_url": "https://domain.com/thumbnail.png", // generated server-side
   "thumbnail2x_url": "https://domain.com/thumbnail2x.png", // generated server-side
   "content_type": "image/png", // generated server-side

--- a/content/messaging/customer-chat-api/index.mdx
+++ b/content/messaging/customer-chat-api/index.mdx
@@ -2868,7 +2868,6 @@ Webhooks notify you when specific events are triggered. Webhooks equivalents in 
 {
   "user_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
   "chat_id": "PJ0MRSHTDG",
-  "thread_id": "K600PKZON8",
   "seen_up_to": "2017-10-12T15:19:21.010200Z"
 }
 ```

--- a/content/messaging/customer-chat-api/index.mdx
+++ b/content/messaging/customer-chat-api/index.mdx
@@ -74,7 +74,7 @@ File event informs about a file being uploaded.
 | `custom_id`                                           | optional  |                                                                   - |
 | `properties`                                          | optional  |                                                                   - |
 | `recipients`                                          | required  |                          Possible values: `all` (default), `agents` |
-| `url`                                                 | required  |   Has to point to the LiveChat CDN.                                  |
+| `url`                                                 | required  |   Has to point to the LiveChat CDN.It's recommended to use the URL returned by [`upload_file`](#upload-file).|
 | `width`, `height`, `thumbnail_url`, `thumbnail2x_url` | optional  |                                                     Only for images |
 
 </Text>
@@ -652,10 +652,10 @@ Here's the list of all system messages you might come across as a Customer:
 
 </CodeResponse>
 
-| Field    | Req./Opt. | Note |
+| Field    | Req./Opt. |      |
 | -------- | :-------: | ---: |
-| `avatar` | optional  |    - |
-| `fields` | optional  |    - |
+| `avatar` | optional  |      |
+| `fields` | optional  |      |
 
 ## Agent
 
@@ -2167,7 +2167,7 @@ curl -X POST \
 
 ### Get Form
 
-Returns an empty form of a <a href="https://www.livechatinc.com/help/chat-surveys/" target="_blank">prechat or postchat survey</a>.
+Returns an empty ticket form of a <a href="https://www.livechatinc.com/help/chat-surveys/" target="_blank">prechat or postchat survey</a>.
 
 #### Specifics
 

--- a/content/messaging/customer-chat-api/index.mdx
+++ b/content/messaging/customer-chat-api/index.mdx
@@ -71,6 +71,7 @@ File event informs about a file being uploaded.
 | ----------------------------------------------------- | :-------: | ------------------------------------------------------------------: |
 | `content_type`                                        | required  |       Supported image types: `image/png`, `image/jpeg`, `image/gif` |
 | `created_at`                                          | required  | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`                                                | required  | `file`                                                              |
 | `custom_id`                                           | optional  |                                                                   - |
 | `properties`                                          | optional  |                                                                   - |
 | `recipients`                                          | required  |                          Possible values: `all` (default), `agents` |
@@ -89,7 +90,7 @@ File event informs about a file being uploaded.
   "custom_id": "31-0C-1C-07-DB-16",
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "type": "file",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "recipients": "all",
   "properties": {
     // "Properties" object
@@ -123,6 +124,7 @@ Filled form event contains data from a form (prechat or postchat survey).
 | --------------------------------------- | :------: | ------------------------------------------------------------------: |
 | `created_at`                            | required | Date & time format with a resolution of microseconds, `UTC string`. |
 | `recipients`                            | required | Possible values: `all` (default), `agents` |
+| `type`                                  | required | `filled_form`                                                       |
 | `checkbox`                              | optional | For multiple-choice questions |
 | `custom_id`                             | optional |                                                                     |
 | `email`, `name`, `question`, `textarea` | optional | For open questions (text answer) |
@@ -142,7 +144,7 @@ Filled form event contains data from a form (prechat or postchat survey).
 	"custom_id": "31-0C-1C-07-DB-16",
 	"created_at": "2017-10-12T15:19:21.010200Z",  // generated server-side
 	"type": "filled_form",
-	"author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+	"author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
 	"recipients": "all",
 	"properties": {
 		// "Properties" object
@@ -208,6 +210,7 @@ Message event contains text message to other chat users.
 | `created_at`     | required  | Date & time format with a resolution of microseconds, `UTC string`. |
 | `recipients`     | required  | Possible values: `all` (default), `agents`                          |
 | `text`           | required  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
+| `type`           | required  | `message`                                                           |
 | `custom_id`      | optional  |                                                                     |
 | `postback`       | optional  | Appears in the message event only when triggered by a rich message. |
 | `postback.type`  | optional  | Required only if `postback.value` is present.                       |
@@ -226,7 +229,7 @@ Message event contains text message to other chat users.
   "custom_id": "31-0C-1C-07-DB-16",
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "type": "message",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "text": "hello there",
   "postback": {
     "id": "action_call",
@@ -260,7 +263,8 @@ Rich message event contains rich message data structure.
 | -------------------------------- | :-------: | ------------------------------------------------------------------: |
 | `created_at`                     | required  | Date & time format with a resolution of microseconds, `UTC string`. |
 | `recipients`                     | required  | Possible values: `all` (default), `agents` |
-| `template_id`                    | required  | Describes how the event should be presented in an app. | describes how the event should be presented in an app |
+| `template_id`                    | required  | Describes how the event should be presented in an app. | 
+| `type`                           | required  | `rich_message`                                                      |
 | `custom_id`                      | optional  |                                                                     |
 | `elements`                       | optional  | May contain 1 - 10 `element` objects.                               |
 | `elements.buttons`               | optional  | `buttons` may contain 1 - 11 `button` objects.                      |
@@ -279,7 +283,7 @@ Rich message event contains rich message data structure.
 
 <Code>
 
-<CodeResponse title={'Sample Message event'}>
+<CodeResponse title={'Sample Rich message event'}>
 
 ```json
 {
@@ -287,7 +291,7 @@ Rich message event contains rich message data structure.
   "custom_id": "31-0C-1C-07-DB-16",
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "type": "rich_message",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "recipients": "all",
   "properties": {
     // "Properties" object
@@ -349,16 +353,17 @@ Custom event is an event with customizable payload.
 
 | Field        | Req./Opt. |                                                                Note |
 | ------------ | :-------: | ------------------------------------------------------------------: |
+| `recipients` | required  |                          Possible values: `all` (default), `agents` |
+| `type`       | required  | `custom`                                                            |
 | `custom_id`  | optional  |                                                                   - |
 | `created_at` | required  | Date & time format with a resolution of microseconds, `UTC string`. |
 | `properties` | optional  |                                                                   - |
-| `recipients` | required  |                          Possible values: `all` (default), `agents` |
 
 </Text>
 
 <Code>
 
-<CodeResponse title={'Sample Rich message event'}>
+<CodeResponse title={'Sample Custom event'}>
 
 ```json
 {
@@ -366,7 +371,7 @@ Custom event is an event with customizable payload.
   "custom_id": "31-0C-1C-07-DB-16",
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "type": "custom",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "content": {
     "custom": {
       "nested": "json"
@@ -393,12 +398,13 @@ Custom event is an event with customizable payload.
 
 System message event is a native system event sent in specific situations.
 
-| Field                 | Req./Opt. |                                                                                                Note |
-| --------------------- | :-------: | --------------------------------------------------------------------------------------------------: |
-| `custom_id`           | optional  |                                                                                                   - |
-| `created_at`          | required  |                                 Date & time format with a resolution of microseconds, `UTC string`. |
-| `recipients`          | required  | Possible values: `all` (default for system events), `agents` (for the events sent via `send_event`) |
-| `system_message_type` | required  |                                                                                                   - |
+| Field                 | Req./Opt. |                                                                                          Notes |
+| --------------------- | :-------: | ---------------------------------------------------------------------------------------------: |
+| `created_at`          | required  |                           Date & time format with a resolution of microseconds, `UTC string`.  |
+| `recipients`          | required  | Possible values: `all` (default for system events), `agents` (for events sent via `send_event`)|
+| `type`                | required  | `system_message`                                                                               |
+| `system_message_type` | required  |                                                                                                |
+| `custom_id`           | optional  |                                                                                                |
 
 </Text>
 

--- a/content/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -100,7 +100,7 @@ File event informs about a file being uploaded.
     // "Properties" object
   },
   "name": "image25.png", // generated server-side
-  "url": "https://domain.com/asdsfdsf.png",
+  "url": "https://domain.com/image25.png",
   "thumbnail_url": "https://domain.com/thumbnail.png", // generated server-side
   "thumbnail2x_url": "https://domain.com/thumbnail2x.png", // generated server-side
   "content_type": "image/png", // generated server-side

--- a/content/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -79,7 +79,7 @@ File event informs about a file being uploaded.
 | `custom_id`                                           | optional  |                                                                   - |
 | `properties`                                          | optional  |                                                                   - |
 | `recipients`                                          | required  |                          Possible values: `all` (default), `agents` |
-| `url`                                                 | required  | Has to point to the LiveChat CDN.                                   |
+| `url`                                                 | required  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file).|
 | `width`, `height`, `thumbnail_url`, `thumbnail2x_url` | optional  |                                                     Only for images |
 
 </Text>
@@ -2677,18 +2677,6 @@ One of the optional parameters needs to be included in the request payload.
 
 </Section>
 
-<!-- > **`get_groups_status`** sample **request** with optional params
-
-```json
-{
-	"request_id": "12235", // optional
-	"action": "get_groups_status",
-	"payload": {
-		"groups": [1, 2, 3, 4]
-	}
-}
-``` -->
-
 ## Other
 
 <Section>
@@ -2697,7 +2685,7 @@ One of the optional parameters needs to be included in the request payload.
 
 ### Get Form
 
-Returns an empty form of a <a href="https://www.livechatinc.com/help/chat-surveys/" target="_blank">prechat or postchat survey</a>.
+Returns an empty ticket form of a <a href="https://www.livechatinc.com/help/chat-surveys/" target="_blank">prechat or postchat survey</a>.
 
 #### Specifics
 

--- a/content/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -79,7 +79,7 @@ File event informs about a file being uploaded.
 | `custom_id`                                           | optional  |                                                                   - |
 | `properties`                                          | optional  |                                                                   - |
 | `recipients`                                          | required  |                          Possible values: `all` (default), `agents` |
-| `system_message_type`                                 | required  |                                                                   - |
+| `url`                                                 | required  | Has to point to the LiveChat CDN.                                   |
 | `width`, `height`, `thumbnail_url`, `thumbnail2x_url` | optional  |                                                     Only for images |
 
 </Text>
@@ -122,18 +122,18 @@ File event informs about a file being uploaded.
 
 <Text>
 
-Filled form event contains data from a form.
+Filled form event contains data from a form (prechat or postchat survey).
 
-| Field                                   | Req./Opt |                                                                Note |
+| Field                                   | Req./Opt |                                                               Notes |
 | --------------------------------------- | :------: | ------------------------------------------------------------------: |
-| `custom_id`                             | optional |                                                                   - |
 | `created_at`                            | required | Date & time format with a resolution of microseconds, `UTC string`. |
-| `properties`                            | optional |                                                                   - |
-| `recipients`                            | required |                          Possible values: `all` (default), `agents` |
-| `name`, `email`, `question`, `textarea` | optional |                                    For open questions (text answer) |
-| `radio`, `select`                       | optional |                                         For single-choice questions |
-| `checkbox`                              | optional |                                       For multiple-choice questions |
-| `group_chooser`                         | optional |                                          For group-choice questions |
+| `recipients`                            | required | Possible values: `all` (default), `agents` |
+| `checkbox`                              | optional | For multiple-choice questions |
+| `custom_id`                             | optional |                                                                     |
+| `email`, `name`, `question`, `textarea` | optional | For open questions (text answer) |
+| `group_chooser`                         | optional | For group-choice questions |    
+| `properties`                            | optional | The [Properties](#properties) object |
+| `radio`, `select`                       | optional | For single-choice questions |  
 
 </Text>
 
@@ -651,7 +651,7 @@ Here's the list of all system messages you might come across as a Customer:
     "custom field name": "custom field value"
   },
   "present": true,
-  "events_seen_up_to": 1473433500
+  "events_seen_up_to": "2017-10-12T15:19:21.010200Z"
 }
 ```
 
@@ -673,7 +673,7 @@ Here's the list of all system messages you might come across as a Customer:
   "name": "Support Team",
   "avatar": "cdn.livechatinc.com/avatars/1.png",
   "present": true,
-  "events_seen_up_to": 1473433500
+  "events_seen_up_to": "2017-10-12T15:19:21.010200Z"
 }
 ```
 
@@ -1871,7 +1871,7 @@ Closes the thread. Sending messages to this thread will no longer be possible.
 | Parameter    | Required | Data type | Notes                                            |
 | ------------ | -------- | --------- | ------------------------------------------------ |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete properties of. |
-| `properties` | Yes      | `object`  | Chat properties to delete. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| `properties` | Yes      | `object`  | Chat properties to delete. |
 
 </Text>
 
@@ -1912,24 +1912,6 @@ Closes the thread. Sending messages to this thread will no longer be possible.
 </Code>
 
 </Section>
-
-<!-- > **`delete_chat_properties`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "delete_chat_properties",
-	"payload": {
-		"chat_id": "PW94SJTGW6",
-        "properties": {
-            "bb9e5b2f1ab480e4a715977b7b1b4279": [
-                "score",
-                "comment"
-            ]
-        }
-	}
-}
-``` -->
 
 <Section>
 
@@ -2042,7 +2024,7 @@ Closes the thread. Sending messages to this thread will no longer be possible.
 | ------------ | -------- | --------- | ------------------------------------------------------ |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete the properties of.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to delete the properties of. |
-| `properties` | Yes      | `object`  | Chat thread properties to delete. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| `properties` | Yes      | `object`  | Chat thread properties to delete. |
 
 </Text>
 
@@ -2084,25 +2066,6 @@ Closes the thread. Sending messages to this thread will no longer be possible.
 </Code>
 
 </Section>
-
-<!-- > **`delete_chat_thread_properties`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "delete_chat_thread_properties",
-	"payload": {
-		"chat_id": "PW94SJTGW6",
-        "thread_id": "K600PKZON8",
-        "properties": {
-            "bb9e5b2f1ab480e4a715977b7b1b4279": [
-                "score",
-                "comment"
-            ]
-        }
-	}
-}
-``` -->
 
 <Section>
 
@@ -2172,26 +2135,6 @@ Closes the thread. Sending messages to this thread will no longer be possible.
 
 </Section>
 
-<!-- > **`update_event_properties`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "update_event_properties",
-	"payload": {
-		"chat_id": "PW94SJTGW6",
-        "thread_id": "K600PKZON8",
-        "event_id": "2_EW2WQSA8",
-        "properties": {
-            "bb9e5b2f1ab480e4a715977b7b1b4279": {
-                "score": 10,
-                "comment": "Thank you!"
-            }
-        }
-	}
-}
-``` -->
-
 <Section>
 
 <Text>
@@ -2213,7 +2156,7 @@ Closes the thread. Sending messages to this thread will no longer be possible.
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete the properties of.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to delete the properties of. |
 | `event_id`   | Yes      | `string`  | Id of the event you want to delete the properties of.  |
-| `properties` | Yes      | `object`  | Event properties to delete.  You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| `properties` | Yes      | `object`  | Event properties to delete.  |
 
 </Text>
 
@@ -2304,7 +2247,7 @@ Closes the thread. Sending messages to this thread will no longer be possible.
 | `name`    | No       | `string`  |                               |
 | `email`   | No       | `string`  |                               |
 | `avatar`  | No       | `string`  | URL of the Customer's avatar. |
-| `fields`  | No       | `object`  | A `"key": "value"` object     |
+| `fields`  | No       | `object`  | `key: value` format           |
 
 At least one optional parameter needs to be included in the request payload.
 
@@ -2445,14 +2388,14 @@ Agent and referrer are updated by default using the browser’s headers.
 |                        |                                                                 |
 | ---------------------- | --------------------------------------------------------------- |
 | **Action**             | `set_customer_fields`                                           |
-| **Web API equivalent** | [`get_customers`](../#get-customers) |
+| **Web API equivalent** | [`set_customer_fields`](../#set-customer-fields) |
 | **Push message**       | [`customer_updated`](#customer_updated)                         |
 
 #### Request
 
 | Parameter | Required | Data type | Notes                |
 | --------- | -------- | --------- | -------------------- |
-| `fields`  | Yes      | `string`  | A `key:value` object |
+| `fields`  | Yes      | `object`  | `key:value` format |
 
 Agent and referrer are updated by default using the browser’s headers.
 
@@ -2683,7 +2626,7 @@ It returns the initial state of the current Customer.
 | `all`     | No       | `bool`    | If set to `true`, you will get statuses of all the groups. |
 | `groups`  | No       | `array`   | A table of a groups' IDs                                   |
 
-At least one optional parameter needs to be included in the request payload.
+One of the optional parameters needs to be included in the request payload.
 
 #### Response
 
@@ -2754,6 +2697,8 @@ At least one optional parameter needs to be included in the request payload.
 
 ### Get Form
 
+Returns an empty form of a <a href="https://www.livechatinc.com/help/chat-surveys/" target="_blank">prechat or postchat survey</a>.
+
 #### Specifics
 
 |                        |                                                       |
@@ -2771,14 +2716,11 @@ At least one optional parameter needs to be included in the request payload.
 
 #### Response
 
-| Parameter                         | Notes                                                                              |     |     |
-| --------------------------------- | ---------------------------------------------------------------------------------- | --- | --- |
-| `form`                            | If form is disabled, the`form` object won't be returned in the response.           |     |     |
-| `headers`                         | For headers; the field has no `answer` and is not sent in the `filled_form` event. |     |     |
-| `name, email, question, textarea` | For open questions (text area)                                                     |     |     |
-| `radio, select, checkbox`         | For single/multiple-choice questions                                               |     |     |
-| `group_chooser`                   | For group-choice questions                                                         |     |     |
-| `rating`                          | For rating; the field isn't sent in the `filled_form` event.                       |     |     |
+| Parameter  | Notes |
+| ---------- | -------- | 
+| `enabled`  |  If `enabled: false`, the `form` object is not returned. Prechat/postchat survey disabled in the LiveChat Agent App UI. |
+| `header`   | For headers; the field has no `answer`, therefore is not sent in the [Filled form](#filled-form) event. |    
+| `rating`   | For rating; the field has no `answer`, therefore is not sent in the [Filled form](#filled-form) event. |
 
 </Text>
 
@@ -3003,14 +2945,14 @@ It returns the info on a given URL.
 | ---------------------- | --------------------------------------------------------------------------- |
 | **Action**             | `mark_events_as_seen`                                                       |
 | **Web API equivalent** | [`mark_events_as_seen`](../#mark-events-as-seen) |
-| **Push message**       | [`last_seen_timestamp_updated`](#last_seen_timestamp_updated)               |
+| **Push message**       | [`events_marked_as_seen`](#events_marked_as_seen)               |
 
 #### Request
 
-| Parameter    | Required | Data type   |     |
-| ------------ | -------- | ----------- | --- |
-| `chat_id`    | Yes      | `string`    |     |
-| `seen_up_to` | Yes      | `UTC string |
+| Parameter    | Required | Data type   | Notes |
+| ------------ | -------- | ----------- | ----- |
+| `chat_id`    | Yes      | `string`    |       |
+| `seen_up_to` | Yes      | `string`    | RFC 3339 date-time format |
 
 #### Response
 
@@ -3079,7 +3021,7 @@ Pushes are **server - client methods** used for keeping the application state up
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`chat_thread_properties_updated`](#chat_thread_properties_updated) [`chat_thread_properties_deleted`](#chat_thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
 | **Customers**   | [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                                         |
 | **Status**      | [`customer_disconnected`](#customer_disconnected)                                                                                                                                                                                                                                                                                                                   |
-| **Other**       | [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`last_seen_timestamp_updated`](#last_seen_timestamp_updated)                                                                                                                                                                                                 |
+| **Other**       | [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`events_marked_as_seen`](#events_marked_as_seen)                                                                                                                                                                                                 |
 
 ## Chats
 
@@ -3716,7 +3658,7 @@ The `customer_temporarily_blocked` reason can also return the correct timeout in
 | **Action**             | `incoming_multicast` |
 | **Webhook equivalent** | -                    |
 
-### `last_seen_timestamp_updated`
+### `events_marked_as_seen`
 
 <CodeResponse title={'Sample push payload'}>
 
@@ -3725,7 +3667,7 @@ The `customer_temporarily_blocked` reason can also return the correct timeout in
   "user_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
   "chat_id": "PJ0MRSHTDG",
   "thread_id": "K600PKZON8",
-  "timestamp": 123456789
+  "seen_up_to": "2017-10-12T15:19:21.010200Z"
 }
 ```
 
@@ -3735,8 +3677,8 @@ The `customer_temporarily_blocked` reason can also return the correct timeout in
 
 |                        |                                                                                        |
 | ---------------------- | -------------------------------------------------------------------------------------- |
-| **Action**             | `last_seen_timestamp_updated`                                                          |
-| **Webhook equivalent** | [`last_seen_timestamp_updated`](../#last_seen_timestamp_updated) |
+| **Action**             | `events_marked_as_seen`                                                          |
+| **Webhook equivalent** | [`events_marked_as_seen`](../#events_marked_as_seen) |
 
 # Contact us
 

--- a/content/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -76,6 +76,7 @@ File event informs about a file being uploaded.
 | ----------------------------------------------------- | :-------: | ------------------------------------------------------------------: |
 | `content_type`                                        | required  |       Supported image types: `image/png`, `image/jpeg`, `image/gif` |
 | `created_at`                                          | required  | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`                                                | required  | `file`                                                              |
 | `custom_id`                                           | optional  |                                                                   - |
 | `properties`                                          | optional  |                                                                   - |
 | `recipients`                                          | required  |                          Possible values: `all` (default), `agents` |
@@ -94,7 +95,7 @@ File event informs about a file being uploaded.
   "custom_id": "31-0C-1C-07-DB-16",
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "type": "file",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "recipients": "all",
   "properties": {
     // "Properties" object
@@ -128,6 +129,7 @@ Filled form event contains data from a form (prechat or postchat survey).
 | --------------------------------------- | :------: | ------------------------------------------------------------------: |
 | `created_at`                            | required | Date & time format with a resolution of microseconds, `UTC string`. |
 | `recipients`                            | required | Possible values: `all` (default), `agents` |
+| `type`                                  | required | `filled_form`                                                       |
 | `checkbox`                              | optional | For multiple-choice questions |
 | `custom_id`                             | optional |                                                                     |
 | `email`, `name`, `question`, `textarea` | optional | For open questions (text answer) |
@@ -147,7 +149,7 @@ Filled form event contains data from a form (prechat or postchat survey).
 	"custom_id": "31-0C-1C-07-DB-16",
 	"created_at": "2017-10-12T15:19:21.010200Z",  // generated server-side
 	"type": "filled_form",
-	"author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+	"author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
 	"recipients": "all",
 	"properties": {
 		// "Properties" object
@@ -213,6 +215,7 @@ Message event contains text message to other chat users.
 | `created_at`     | required  | Date & time format with a resolution of microseconds, `UTC string`. |
 | `recipients`     | required  | Possible values: `all` (default), `agents`                          |
 | `text`           | required  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
+| `type`           | required  | `message`                                                           |
 | `custom_id`      | optional  |                                                                     |
 | `postback`       | optional  | Appears in the message event only when triggered by a rich message. |
 | `postback.type`  | optional  | Required only if `postback.value` is present.                       |
@@ -231,7 +234,7 @@ Message event contains text message to other chat users.
   "custom_id": "31-0C-1C-07-DB-16",
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "type": "message",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "text": "hello there",
   "postback": {
     "id": "action_call",
@@ -265,7 +268,8 @@ Rich message event contains rich message data structure.
 | -------------------------------- | :-------: | ------------------------------------------------------------------: |
 | `created_at`                     | required  | Date & time format with a resolution of microseconds, `UTC string`. |
 | `recipients`                     | required  | Possible values: `all` (default), `agents` |
-| `template_id`                    | required  | Describes how the event should be presented in an app. | describes how the event should be presented in an app |
+| `template_id`                    | required  | Describes how the event should be presented in an app. |
+| `type`                           | required  | `rich_message`                                                      |
 | `custom_id`                      | optional  |                                                                     |
 | `elements`                       | optional  | May contain 1 - 10 `element` objects.                               |
 | `elements.buttons`               | optional  | `buttons` may contain 1 - 11 `button` objects.                      |
@@ -284,7 +288,7 @@ Rich message event contains rich message data structure.
 
 <Code>
 
-<CodeResponse title={'Sample Message event'}>
+<CodeResponse title={'Sample Rich message event'}>
 
 ```json
 {
@@ -292,7 +296,7 @@ Rich message event contains rich message data structure.
   "custom_id": "31-0C-1C-07-DB-16",
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "type": "rich_message",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "recipients": "all",
   "properties": {
     // "Properties" object
@@ -354,16 +358,17 @@ Custom event is an event with customizable payload.
 
 | Field        | Req./Opt. |                                                                Note |
 | ------------ | :-------: | ------------------------------------------------------------------: |
+| `recipients` | required  |                          Possible values: `all` (default), `agents` |
+| `type`       | required  | `custom`                                                            |
 | `custom_id`  | optional  |                                                                   - |
 | `created_at` | required  | Date & time format with a resolution of microseconds, `UTC string`. |
 | `properties` | optional  |                                                                   - |
-| `recipients` | required  |                          Possible values: `all` (default), `agents` |
 
 </Text>
 
 <Code>
 
-<CodeResponse title={'Sample Rich message event'}>
+<CodeResponse title={'Sample Custom event'}>
 
 ```json
 {
@@ -371,7 +376,7 @@ Custom event is an event with customizable payload.
   "custom_id": "31-0C-1C-07-DB-16",
   "created_at": "2017-10-12T15:19:21.010200Z", // generated server-side
   "type": "custom",
-  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c", // generated server-side
   "content": {
     "custom": {
       "nested": "json"
@@ -398,12 +403,13 @@ Custom event is an event with customizable payload.
 
 System message event is a native system event sent in specific situations.
 
-| Field                 | Req./Opt. |                                                                                                Note |
-| --------------------- | :-------: | --------------------------------------------------------------------------------------------------: |
-| `custom_id`           | optional  |                                                                                                   - |
-| `created_at`          | required  |                                 Date & time format with a resolution of microseconds, `UTC string`. |
-| `recipients`          | required  | Possible values: `all` (default for system events), `agents` (for the events sent via `send_event`) |
-| `system_message_type` | required  |                                                                                                   - |
+| Field                 | Req./Opt. |                                                                                          Notes |
+| --------------------- | :-------: | ---------------------------------------------------------------------------------------------: |
+| `created_at`          | required  |                           Date & time format with a resolution of microseconds, `UTC string`.  |
+| `recipients`          | required  | Possible values: `all` (default for system events), `agents` (for events sent via `send_event`)|
+| `type`                | required  | `system_message`                                                                               |
+| `system_message_type` | required  |                                                                                                |
+| `custom_id`           | optional  |                                                                                                |
 
 </Text>
 

--- a/content/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -3660,7 +3660,6 @@ The `customer_temporarily_blocked` reason can also return the correct timeout in
 {
   "user_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
   "chat_id": "PJ0MRSHTDG",
-  "thread_id": "K600PKZON8",
   "seen_up_to": "2017-10-12T15:19:21.010200Z"
 }
 ```


### PR DESCRIPTION
- `check goals` added to table
- `timestamp` replaced with `seen_up_to` + correct reference in tables
- push and webhook `events_marked_as_seen`
- more info in the `get_form` method description 
- file event parameters updated 
- correct response for get chat threads in Agent API