### PR TITLE
remove redundant block quote in CodeResponse from "Create a ticket" in Configuration API v2

### DIFF
--- a/content/management/configuration-api-v2/index.mdx
+++ b/content/management/configuration-api-v2/index.mdx
@@ -3734,8 +3734,6 @@ curl "https://api.livechatinc.com/tickets" \
 
 <CodeResponse>
 
->
-
 ```json
 {
   "pages": 1,


### PR DESCRIPTION
There was a redundant block quote left inside a `<CodeResponse>` from https://developers.livechatinc.com/docs/management/configuration-api-v2/#create-a-ticket, which caused a pretty nasty visual bug:

![image](https://user-images.githubusercontent.com/47242672/67264034-327a3c00-f4aa-11e9-9145-dc4386cfac87.png)

Removing that has fixed it:

![image](https://user-images.githubusercontent.com/47242672/67264043-3b6b0d80-f4aa-11e9-871d-83fbe15a1944.png)
