### PR TITLE
update unpkg customer-sdk packages address in docs

### DIFF
--- a/content/extending-ui/extending-chat-widget/customer-sdk/index.mdx
+++ b/content/extending-ui/extending-chat-widget/customer-sdk/index.mdx
@@ -107,7 +107,7 @@ const CustomerSDK = require('@livechat/customer-sdk')
 <CodeSample>
 
 ```
-<script src="https://unpkg.com/@livechat/customer-sdk@2"></script>
+<script src="https://unpkg.com/@livechat/customer-sdk"></script>
 ```
 
 </CodeSample>


### PR DESCRIPTION
https://unpkg.com/@livechat/customer-sdk@2 isn't valid, changed it to https://unpkg.com/@livechat/customer-sdk, so that user would be correctly redirected to the newest version while using

PR in chat-widget: https://github.com/livechat/chat-window/pull/4917