### PR TITLE
Fixing links in Chat SDK docs

### DIFF
--- a/content/messaging/chat-sdk/index.mdx
+++ b/content/messaging/chat-sdk/index.mdx
@@ -17,13 +17,8 @@ Thanks to that, you have the flexibility to cover the functionalities you need f
 
 If Messaging APIs seem too intimidating or you just want to build something real quick, **Chat SDK** is your way to go.
 
-<SectionLink to={"https://www.npmjs.com/package/@livechat/chat-sdk"}>
-  Chat SDK on NPM
-</SectionLink>
-
-<SectionLink to={"https://github.com/livechat/chat-sdk/"}>
-  Chat SDK on GitHub
-</SectionLink>
+- <a href="https://www.npmjs.com/package/@livechat/chat-sdk/" target="_blank" rel="noopener noreferrer">Chat SDK on NPM</a>
+- <a href="https://github.com/livechat/chat-sdk/" target="_blank" rel="noopener noreferrer">Chat SDK on GitHub</a>
 
 ## Versioning
 


### PR DESCRIPTION
- links in Section component didn't work