### PR TITLE
v3.2: add webhook follow_up_requested

### DIFF
--- a/content/management/changelog/index.mdx
+++ b/content/management/changelog/index.mdx
@@ -20,6 +20,7 @@ Since the migration is still ongoing, different parts will be successively moved
 - There's a new field, `license_id`, in all [webhooks](/management/configuration-api/v3.2/#webhooks).
 - From now on, it's possible to define properties in [2 new locations](/management/configuration-api/v3.2/#property-locations): `license` and `group`.
 - There are 4 new methods: [**Set License Properties**](/management/configuration-api/v3.2/#set-license-properties), [**Get License Properties**](/management/configuration-api/v3.2/#get-license-properties), [**Set Group Properties**](/management/configuration-api/v3.2/#set-group-properties), [**Get Group Properties**](/management/configuration-api/v3.2/#get-group-properties).
+- There's new webhook: [`follow_up_requested`](/management/configuration-api/v3.2/#follow_up_requested).
 
 ## [v3.1] - 2019-09-17
 

--- a/content/management/configuration-api/v3.2/index.mdx
+++ b/content/management/configuration-api/v3.2/index.mdx
@@ -1079,7 +1079,7 @@ Here's what you need to know about **webhooks**:
 | **Thread tags** | [`chat_thread_tagged`](#chat_thread_tagged) [`chat_thread_untagged`](#chat_thread_untagged)                                                                                                                                                                                                                                                                         |
 | **Status**      | [`agent_status_changed`](#agent_status_changed) [`agent_deleted`](#agent_deleted)| 
 | **Customers**   | [`customer_created`](#customer_created)                                                                                                                                                                                                                                                                                                                             |
-| **Other**       | [`events_marked_as_seen`](#events_marked_as_seen)                                                                                                                                                                                                                                                                                                       |
+| **Other**       | [`events_marked_as_seen`](#events_marked_as_seen) [`follow_up_requested`](#follow_up_requested)                                                                                                                                                                                                                                                                     |
 
 
 </Text>
@@ -2228,6 +2228,52 @@ Here's what you need to know about **webhooks**:
     "user_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
     "chat_id": "PJ0MRSHTDG",
     "seen_up_to": "2017-10-12T15:19:21.010200Z"
+  },
+  "additional_data": {
+    "chat_properties": { //optional
+        // chat properties
+    }
+  }
+}
+```
+
+</CodeResponse>
+
+</Code>
+
+</Section>
+
+<Section>
+
+<Text>
+
+### `follow_up_requested`
+
+Informs that the customer requested follow up for the conversation. It is sent when either there was no agent in the chat or the customer didn't read all the messages from the agent.
+
+#### Specifics
+
+|                     |                                                           |
+| ------------------- | --------------------------------------------------------- |
+| **Action**          | `follow_up_requested`                                     |
+| **Push equivalent in** | n/a                                                    |
+
+</Text>
+
+<Code>
+
+<CodeResponse title={'Sample webhook'}>
+
+```json
+{
+  "webhook_id": "<webhook_id>",
+  "secret_key": "<secret_key>",
+  "action": "follow_up_requested",
+  "license_id": 104130623,
+  "payload": {
+    "customer_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+    "chat_id": "PJ0MRSHTDG",
+    "thread_id": "K600PKZON8",
   },
   "additional_data": {
     "chat_properties": { //optional


### PR DESCRIPTION
This new webhook supports following filters:
`chat_member_ids`
`only_my_chat`

Allowed additional data:
`chat_properties`