### PR TITLE
Added a note on filters in Create and Update Bot Agent methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ yarn-error.log
 .pnp.js
 # Yarn Integrity file
 .yarn-integrity
+
+# zshrc
+.zshrc

--- a/content/management/configuration-api/index.mdx
+++ b/content/management/configuration-api/index.mdx
@@ -75,23 +75,23 @@ Unlike Agents, Bot Agents don't have passwords or emails - you cannot log in as 
 
 #### Request
 
-| Request object                       | Type       | Required | Notes                                                                |
-| ------------------------------------ | ---------- | -------- | -------------------------------------------------------------------- |
-| `name`                               | `string`   | Yes      | Display name                                                         |
-| `status` __*__                       | `string`   | Yes      | Agent status                                                         |
-| `avatar`                             | `string`   | No       | Avatar URL                                                           |
-| `max_chats_count`                    | `int`      | No       | Max. number of incoming chats that can be routed to an Agent; default: 6. |
-| `default_group_priority` __***__     | `string`   | No       | The default routing priority for a group without defined priority. |
-| `groups`                             | `object[]` | No       | Groups an Agent belongs to.                                          |
-| `groups[].id`                        | `uint`     | Yes      | Group ID; required only when `group`'s included.                     |
-| `groups[].priority` __**__           | `string`   | Yes      | Agent's priority in a group; required only when `group`'s included.    |
-| `webhooks`                           | `object`   | No       | Webhooks sent to the Agent; for more info on possible values and payload, see [Webhooks](#webhooks).     |
-| `webhooks.url`                       | `string`   | Yes      | Destination URL for webhooks; required only when `webhooks` is included.       |
-| `webhooks.secret_key`                | `string`   | Yes      | Secret sent in webhooks to verify webhook's source; required only when `webhooks`'s included.  |
-| `webhooks.actions`                   | `object[]` | Yes      | [Triggering actions](#triggering-actions); required only when `webhooks`'s included.  |
-| `webhooks.actions[].name`            | `string`   | Yes      | The name of the triggering action; required only when `webhooks` is included. |
-| `webhooks.actions[].filters`         | `object`   | No       | Filters to check if a webhook should be triggered.                      |
-| `webhooks.actions[].additional_data` | `string[]` | No       | Additional data that will arrive with webhooks.                        |
+| Request object                       | Type       | Required | Notes                                                                                                                   |
+| ------------------------------------ | ---------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `name`                               | `string`   | Yes      | Display name                                                                                                            |
+| `status` __*__                       | `string`   | Yes      | Agent status                                                                                                            |
+| `avatar`                             | `string`   | No       | Avatar URL                                                                                                              |
+| `max_chats_count`                    | `int`      | No       | Max. number of incoming chats that can be routed to an Agent; default: 6.                                               |
+| `default_group_priority` __***__     | `string`   | No       | The default routing priority for a group without defined priority.                                                      |
+| `groups`                             | `object[]` | No       | Groups an Agent belongs to.                                                                                             |
+| `groups[].id`                        | `uint`     | Yes      | Group ID; required only when `group`'s included.                                                                        |
+| `groups[].priority` __**__           | `string`   | Yes      | Agent's priority in a group; required only when `group`'s included.                                                     |
+| `webhooks`                           | `object`   | No       | Webhooks sent to the Agent; for more info on possible values and payload, see [Webhooks](#webhooks).                    |
+| `webhooks.url`                       | `string`   | Yes      | Destination URL for webhooks; required only when `webhooks` is included.                                                |
+| `webhooks.secret_key`                | `string`   | Yes      | Secret sent in webhooks to verify webhook's source; required only when `webhooks`'s included.                           |
+| `webhooks.actions`                   | `object[]` | Yes      | [Triggering actions](#triggering-actions); required only when `webhooks`'s included.                                    |
+| `webhooks.actions[].name`            | `string`   | Yes      | The name of the triggering action; required only when `webhooks` is included.                                           |
+| `webhooks.actions[].filters`         | `object`   | No       | Filters to check if a webhook should be triggered. For more info on filters, see [Register webhook](#register-webhook). |
+| `webhooks.actions[].additional_data` | `string[]` | No       | Additional data that will arrive with webhooks.                                                                         |
 
 
 __*__ The table below presents the possible values for the `status` parameter:
@@ -208,24 +208,24 @@ curl -X POST \
 
 #### Request
 
-| Parameter                            | Required | Data type  | Notes                                                                                         |
-| ------------------------------------ | -------- | ---------- | --------------------------------------------------------------------------------------------- |
-| `id`                                 | Yes      | `string`   | Bot Agent ID                                                                                  |
-| `name`                               | No       | `string`   | Display name                                                                                  |
-| `avatar`                             | No       | `string`   | Avatar URL                                                                                    |
-| `status` __*__                       | No       | `string`   | Agent status                                                                                  |
-| `max_chats_count`                    | No       | `int`      | Maximum incoming chats that can be routed to an Agent.                                        |
-| `groups`                             | No       | `object[]` | Groups an Agent belongs to                                                                    |
-| `groups[].id`                        | Yes      | `uint`     | Group ID, required only when `groups`'s present.                                              |
-| `groups[].priority` __**__           | Yes      |  `string`  | Agent's priority in the group; required only when `groups` is included.                       |
-| `default_group_priority` __***__     | No       | `string`   | The default routing priority for a group without defined priority.                            |
-| `webhooks`                           | No       | `object`   | Webhooks sent to an Agent                                                                     |
-| `webhooks.url`                       | Yes      | `string`   | Destination URL for webhooks; required only when `webhooks` is present.                       |
-| `webhooks.secret_key`                | Yes      | `string`   | Secret sent in webhooks to verify the webhook's source; required when `webhooks` is included. |
-| `webhooks.actions`                   | Yes      | `object[]` | [Triggering actions](#triggering-actions); required only when `webhooks` is included.         |
-| `webhooks.actions[].name`            | Yes      | `string`   | The name of the triggering action; required only when `webhooks` is included.                 |
-| `webhooks.actions[].filters`         | No       | `object`   | Filters to check if a webhook should be triggered.                                            |
-| `webhooks.actions[].additional_data` | No       | `string[]` | Additional data arriving with the webhook.                                                    |
+| Parameter                            | Required | Data type  | Notes                                                                                                                   |
+| ------------------------------------ | -------- | ---------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `id`                                 | Yes      | `string`   | Bot Agent ID                                                                                                            |
+| `name`                               | No       | `string`   | Display name                                                                                                            |
+| `avatar`                             | No       | `string`   | Avatar URL                                                                                                              |
+| `status` __*__                       | No       | `string`   | Agent status                                                                                                            |
+| `max_chats_count`                    | No       | `int`      | Maximum incoming chats that can be routed to an Agent.                                                                  |
+| `groups`                             | No       | `object[]` | Groups an Agent belongs to                                                                                              |
+| `groups[].id`                        | Yes      | `uint`     | Group ID, required only when `groups`'s present.                                                                        |
+| `groups[].priority` __**__           | Yes      |  `string`  | Agent's priority in the group; required only when `groups` is included.                                                 |
+| `default_group_priority` __***__     | No       | `string`   | The default routing priority for a group without defined priority.                                                      |
+| `webhooks`                           | No       | `object`   | Webhooks sent to an Agent                                                                                               |
+| `webhooks.url`                       | Yes      | `string`   | Destination URL for webhooks; required only when `webhooks` is present.                                                 |
+| `webhooks.secret_key`                | Yes      | `string`   | Secret sent in webhooks to verify the webhook's source; required when `webhooks` is included.                           |
+| `webhooks.actions`                   | Yes      | `object[]` | [Triggering actions](#triggering-actions); required only when `webhooks` is included.                                   |
+| `webhooks.actions[].name`            | Yes      | `string`   | The name of the triggering action; required only when `webhooks` is included.                                           |
+| `webhooks.actions[].filters`         | No       | `object`   | Filters to check if a webhook should be triggered. For more info on filters, see [Register webhook](#register-webhook). |
+| `webhooks.actions[].additional_data` | No       | `string[]` | Additional data arriving with the webhook.                                                                              |
 
 __*__ The table below presents the possible values for the `status` parameter:
 
@@ -296,9 +296,9 @@ curl -X POST \
 
 #### Request
 
-| Parameter          | Required | Type     | Notes                                                            |
-| ------------------------ | -------- | -------- | ---------------------------------------------------------------- |
-| `all`                |  No      | `bool` |  Get all Bot Agents, if `false` returns only caller's Bot Agents, default value is `false`|
+| Parameter | Required | Type     | Notes                                                            |
+| ----------| -------- | -------- | ---------------------------------------------------------------- |
+| `all`     |  No      | `bool`   |  Get all Bot Agents, if `false` returns only caller's Bot Agents, default value is `false`|
 
 </Text>
 <Code>
@@ -322,7 +322,7 @@ curl -X POST \
     "bot_agents": [{
         "id": "5c9871d5372c824cbf22d860a707a578",
         "name": "John Doe",
-        "avatar": "livechat.s3.amazonaws.com/1011121/all/avatars/bdd8924fcbcdbddbeaf60c19b238b0b0.jpg",
+        "avatar": "https://domain.com/avatar.jpg",
         "status": "accepting chats"
     }]
 }
@@ -374,7 +374,7 @@ curl -X POST \
     "bot_agent": {
         "id": "5c9871d5372c824cbf22d860a707a578",
         "name": "John Doe",
-        "avatar": "livechat.s3.amazonaws.com/1011121/all/avatars/bdd8924fcbcdbddbeaf60c19b238b0b0.jpg",
+        "avatar": "https://domain.com/avatar.jpg",
         "status": "accepting chats",
         "application": {
             "client_id": "asXdesldiAJSq9padj"
@@ -2054,9 +2054,9 @@ curl -X POST \
 
 #### Request
 
-| Parameter | Required     | Data type | Notes      |
-| -------------- | -------- | -------- | ---------- |
-| `webhook_id`   | Yes | `string`      | Webhook ID |
+| Parameter    | Required | Data type| Notes      |
+| -------------| -------- | -------- | ---------- |
+| `webhook_id` | Yes      | `string` | Webhook ID |
 
 
 #### Response

--- a/content/management/configuration-api/v3.2/index.mdx
+++ b/content/management/configuration-api/v3.2/index.mdx
@@ -2266,8 +2266,8 @@ curl -X POST \
         "url": "http://myservice.com/webhooks",
         "description": "Test webhook",
         "action": "thread_closed",
-        "secret_key": "laudla991lamda0pnoaa0"  
-		  }'
+        "secret_key": "laudla991lamda0pnoaa0"
+      }'
 ```
 
 </CodeSample>
@@ -2382,8 +2382,8 @@ curl -X POST \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <your_access_token>' \
   -d '{
-        "webhook_id": "pqi8oasdjahuakndw9nsad9na"
-		  }'
+        "webhook_id": "pqi8oasdjahuakndw9nsad9na"        
+      }'
 ```
 
 </CodeSample>

--- a/content/management/configuration-api/v3.2/index.mdx
+++ b/content/management/configuration-api/v3.2/index.mdx
@@ -297,7 +297,7 @@ curl -X POST \
     "bot_agents": [{
         "id": "5c9871d5372c824cbf22d860a707a578",
         "name": "John Doe",
-        "avatar": "livechat.s3.amazonaws.com/1011121/all/avatars/bdd8924fcbcdbddbeaf60c19b238b0b0.jpg",
+        "avatar": "https://domain.com/avatar.jpg",
         "status": "accepting chats"
     }]
 }
@@ -355,7 +355,7 @@ curl -X POST \
     "bot_agent": {
         "id": "5c9871d5372c824cbf22d860a707a578",
         "name": "John Doe",
-        "avatar": "livechat.s3.amazonaws.com/1011121/all/avatars/bdd8924fcbcdbddbeaf60c19b238b0b0.jpg",
+        "avatar": "https://domain.com/avatar.jpg",
         "status": "accepting chats",
         "application": {
             "client_id": "asXdesldiAJSq9padj"

--- a/content/management/configuration-api/v3.2/index.mdx
+++ b/content/management/configuration-api/v3.2/index.mdx
@@ -68,21 +68,21 @@ Unlike Agents, Bot Agents don't have passwords or emails - you cannot log in as 
 
 #### Request
 
-| Request object                       | Type       | Required | Notes                                                                |
-| ------------------------------------ | ---------- | -------- | -------------------------------------------------------------------- |
-| `name`                               | `string`   | Yes      | Display name                                                         |
-| `avatar`                             | `string`   | No       | Avatar URL                                                           |
-| `max_chats_count`                    | `int`      | No       | Max. number of incoming chats that can be routed to an Agent; default: 6. |
-| `groups`                             | `object[]` | No       | Groups an Agent belongs to.                                          |
-| `groups[].id`                        | `uint`     | Yes      | Group ID; required only when `group`'s included.                     |
-| `groups[].priority` __*__            | `string`   | Yes      | Agent's priority in a group; required only when `group`'s included.    |
-| `webhooks`                           | `object`   | No       | Webhooks sent to the Agent; for more info on possible values and payload, see [Webhooks](#webhooks).     |
-| `webhooks.url`                       | `string`   | Yes      | Destination URL for webhooks; required only when `webhooks` is included.       |
-| `webhooks.secret_key`                | `string`   | Yes      | Secret sent in webhooks to verify webhook's source; required only when `webhooks`'s included.  |
-| `webhooks.actions`                   | `object[]` | Yes      | [Triggering actions](#triggering-actions); required only when `webhooks`'s included.  |
-| `webhooks.actions[].name`            | `string`   | Yes      | The name of the triggering action; required only when `webhooks` is included. |
-| `webhooks.actions[].filters`         | `object`   | No       | Filters to check if a webhook should be triggered.                      |
-| `webhooks.actions[].additional_data` | `string[]` | No       | Additional data that will arrive with webhooks.                        |
+| Request object                       | Type       | Required | Notes                                                                                                                  |
+| ------------------------------------ | ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `name`                               | `string`   | Yes      | Display name                                                                                                           |
+| `avatar`                             | `string`   | No       | Avatar URL                                                                                                             |
+| `max_chats_count`                    | `int`      | No       | Max. number of incoming chats that can be routed to an Agent; default: 6.                                              |
+| `groups`                             | `object[]` | No       | Groups an Agent belongs to.                                                                                            |
+| `groups[].id`                        | `uint`     | Yes      | Group ID; required only when `group`'s included.                                                                       |
+| `groups[].priority` __*__            | `string`   | Yes      | Agent's priority in a group; required only when `group`'s included.                                                    |
+| `webhooks`                           | `object`   | No       | Webhooks sent to the Agent; for more info on possible values and payload, see [Webhooks](#webhooks).                   |
+| `webhooks.url`                       | `string`   | Yes      | Destination URL for webhooks; required only when `webhooks` is included.                                               |
+| `webhooks.secret_key`                | `string`   | Yes      | Secret sent in webhooks to verify webhook's source; required only when `webhooks`'s included.                          |
+| `webhooks.actions`                   | `object[]` | Yes      | [Triggering actions](#triggering-actions); required only when `webhooks`'s included.                                   |
+| `webhooks.actions[].name`            | `string`   | Yes      | The name of the triggering action; required only when `webhooks` is included.                                          |
+| `webhooks.actions[].filters`         | `object`   | No       | Filters to check if a webhook should be triggered. For more info on filters, see [Register webhook](#register-webhook).|
+| `webhooks.actions[].additional_data` | `string[]` | No       | Additional data that will arrive with webhooks.                                                                        |
 
 __*__ The table below presents the possible values for the `groups[].priority` parameter:
 
@@ -177,7 +177,6 @@ curl -X POST \
 
 ### Update Bot Agent
 
-
 #### Specifics
 
 |  |  |
@@ -187,23 +186,23 @@ curl -X POST \
 
 #### Request
 
-| Parameter                            | Required | Data type | Notes                                                                                          |
-| ------------------------------------ | -------- | --------- | ---------------------------------------------------------------------------------------------- |
-| `id`                                 | Yes      | `string`  | Bot Agent ID                                                                                   |
-| `name`                               | No       | `string`  | Display name                                                                                   |
-| `avatar`                             | No       | `string`  | Avatar URL                                                                                     |
-| `max_chats_count`                    | No       | `int`     | Maximum incoming chats that can be routed to an Agent.                                         |
-| `groups`                             | No       | `object[]`| Groups an Agent belongs to                                                                     |                                        
-| `groups[].id`                        | Yes      | `uint`    | Group ID, required only when `groups`'s present.                                               |
-| `groups[].priority` __*__            | Yes      | `string`  | Agent's priority in the group; required only when `groups` is included.                        |
-| `default_group_priority` __**__      | No       | `string`  | The default routing priority for a group without defined priority.                             |
-| `webhooks`                           | No       | `object`  | Webhooks sent to an Agent                                                                      |
-| `webhooks.url`                       | Yes      | `string`  | Destination URL for webhooks; required only when `webhooks` is present.                        |
-| `webhooks.secret_key`                | Yes      | `string`  | Secret sent in webhooks to verify the webhook's source; required when `webhooks` is included.  |
-| `webhooks.actions`                   | Yes      | `object[]`| [Triggering actions](#triggering-actions); required only when `webhooks` is included.          |
-| `webhooks.actions[].name`            | Yes      | `string`  | The name of the triggering action; required only when `webhooks` is included.                  |
-| `webhooks.actions[].filters`         | No       | `object`  | Filters to check if a webhook should be triggered.                                             |
-| `webhooks.actions[].additional_data` | No       | `string[]`| Additional data arriving with the webhook.                                                     |
+| Parameter                            | Required | Data type | Notes                                                                                                                   |
+| ------------------------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `id`                                 | Yes      | `string`  | Bot Agent ID                                                                                                            |
+| `name`                               | No       | `string`  | Display name                                                                                                            |
+| `avatar`                             | No       | `string`  | Avatar URL                                                                                                              |
+| `max_chats_count`                    | No       | `int`     | Maximum incoming chats that can be routed to an Agent.                                                                  |
+| `groups`                             | No       | `object[]`| Groups an Agent belongs to                                                                                              |                                        
+| `groups[].id`                        | Yes      | `uint`    | Group ID, required only when `groups`'s present.                                                                        |
+| `groups[].priority` __*__            | Yes      | `string`  | Agent's priority in the group; required only when `groups` is included.                                                 |
+| `default_group_priority` __**__      | No       | `string`  | The default routing priority for a group without defined priority.                                                      |
+| `webhooks`                           | No       | `object`  | Webhooks sent to an Agent                                                                                               |
+| `webhooks.url`                       | Yes      | `string`  | Destination URL for webhooks; required only when `webhooks` is present.                                                 |
+| `webhooks.secret_key`                | Yes      | `string`  | Secret sent in webhooks to verify the webhook's source; required when `webhooks` is included.                           |
+| `webhooks.actions`                   | Yes      | `object[]`| [Triggering actions](#triggering-actions); required only when `webhooks` is included.                                   |
+| `webhooks.actions[].name`            | Yes      | `string`  | The name of the triggering action; required only when `webhooks` is included.                                           |
+| `webhooks.actions[].filters`         | No       | `object`  | Filters to check if a webhook should be triggered. For more info on filters, see [Register webhook](#register-webhook). |
+| `webhooks.actions[].additional_data` | No       | `string[]`| Additional data arriving with the webhook.                                                                              |
 
 __*__ The table below presents the possible values for the `groups[].priority` parameter:
 


### PR DESCRIPTION
- Added links to "Register webhook" in the Create Bot Agent and Update Bot Agent methods, as the `.filters` param isn't described in these methods