### PR TITLE
API- 5443 ID in group_chooser

### DIFF
--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -19,7 +19,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - The method **Update Customer** ([Web](/messaging/agent-chat-api/v3.2/#update-customer) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#update-customer)), which used to return the Customer data structure, now has no response payload.
 - The method **Get Chat Threads** ([Web](/messaging/agent-chat-api/v3.2/#get-chat-threads) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#get-chat-threads)) now requires `thread_ids`. Also, it no longer returns `threads_summary` in the response.
 - The [**Property**](/messaging/agent-chat-api/v3.2/#properties) data structure now has the same format in requests as in responses and pushes.
-- `id` field is present in `group_chooser field`, in thread events of type `pre_chat`.
+- There's a new parameter `id` in the [Form field](/messaging/agent-chat-api/v3.2/#form-fields) data structure (`fields.answer.id` for the `group_chooser` field type).  It's a unique identifier for each option Customers can choose.
 
 ### Removed
 - The **Update Agent** method was removed.

--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -19,6 +19,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - The method **Update Customer** ([Web](/messaging/agent-chat-api/v3.2/#update-customer) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#update-customer)), which used to return the Customer data structure, now has no response payload.
 - The method **Get Chat Threads** ([Web](/messaging/agent-chat-api/v3.2/#get-chat-threads) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#get-chat-threads)) now requires `thread_ids`. Also, it no longer returns `threads_summary` in the response.
 - The [**Property**](/messaging/agent-chat-api/v3.2/#properties) data structure now has the same format in requests as in responses and pushes.
+- `id` field is present in `group_chooser field`, in thread events of type `pre_chat`.
 
 ### Removed
 - The **Update Agent** method was removed.

--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -19,7 +19,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - The method **Update Customer** ([Web](/messaging/agent-chat-api/v3.2/#update-customer) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#update-customer)), which used to return the Customer data structure, now has no response payload.
 - The method **Get Chat Threads** ([Web](/messaging/agent-chat-api/v3.2/#get-chat-threads) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#get-chat-threads)) now requires `thread_ids`. Also, it no longer returns `threads_summary` in the response.
 - The [**Property**](/messaging/agent-chat-api/v3.2/#properties) data structure now has the same format in requests as in responses and pushes.
-- There's a new parameter `id` in the [Form field](/messaging/agent-chat-api/v3.2/#form-fields) data structure (`fields.answer.id` for the `group_chooser` field type).  It's a unique identifier for each option Customers can choose.
+- There's a new parameter `id` in the [Form field](/messaging/agent-chat-api/v3.2/#form-fields) data structure (`fields.answer.id` for the `group_chooser` field type).  It's an identifier for each option Customers can choose.
 
 ### Removed
 - The **Update Agent** method was removed.

--- a/content/messaging/agent-chat-api/v3.2/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/index.mdx
@@ -315,6 +315,7 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 		"id": "154417206262605324",
 		"label": "Choose department",
 		"answer": {
+      "id": "2",
 			"group_id": 1,
 			"label": "Marketing"
 		}
@@ -1031,7 +1032,7 @@ A component of the [Filled form](#filled-form) event.
 | `id`                    | yes      | `string`                | Field id, for all field types                                                                            |
 | `label`                 | yes      | `string`                | Field label; for all field types                                                                         |
 | `answer`                | yes      | `any`                   | For all field types                                                                                      |
-| `answer.id`             | yes      | `string`                | Answer id; for all field types                                                                           |
+| `answer.id`             | yes      | `string`                | A unique identifier of each option a Customer can choose. For all field types.                           |
 | `answer.label`          | yes      | `string`                | Answer label; for all field types                                                                        |
 | `answer.group_id`       | yes      | `number`                | For `group_chooser`                                                                                      |
 
@@ -1073,6 +1074,7 @@ A component of the [Filled form](#filled-form) event.
 		"id": "154417206262605324",
 		"label": "Choose department",
 		"answer": {
+      "id": "2",
 			"group_id": 1,
 			"label": "Marketing"
 		}

--- a/content/messaging/agent-chat-api/v3.2/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/index.mdx
@@ -1032,7 +1032,7 @@ A component of the [Filled form](#filled-form) event.
 | `id`                    | yes      | `string`                | Field id, for all field types                                                                            |
 | `label`                 | yes      | `string`                | Field label; for all field types                                                                         |
 | `answer`                | yes      | `any`                   | For all field types                                                                                      |
-| `answer.id`             | yes      | `string`                | A unique identifier of each option a Customer can choose. For all field types.                           |
+| `answer.id`             | yes      | `string`                | An identifier of each option a Customer can choose. For all field types.                           |
 | `answer.label`          | yes      | `string`                | Answer label; for all field types                                                                        |
 | `answer.group_id`       | yes      | `number`                | For `group_chooser`                                                                                      |
 

--- a/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
@@ -1030,7 +1030,7 @@ A component of the [Filled form](#filled-form) event.
 | `id`                    | yes      | `string`                | Field id, for all field types                                                                            |
 | `label`                 | yes      | `string`                | Field label; for all field types                                                                         |
 | `answer`                | yes      | `any`                   | For all field types                                                                                      |
-| `answer.id`             | yes      | `string`                | A unique identifier of each option a Customer can choose. For all field types.                           |
+| `answer.id`             | yes      | `string`                | An identifier of each option a Customer can choose. For all field types.                           |
 | `answer.label`          | yes      | `string`                | Answer label; for all field types                                                                        |
 | `answer.group_id`       | yes      | `number`                | For `group_chooser`                                                                                      |
 

--- a/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
@@ -316,6 +316,7 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 		"id": "154417206262605324",
 		"label": "Choose department",
 		"answer": {
+      "id": "2",
 			"group_id": 1,
 			"label": "Marketing"
 		}
@@ -910,7 +911,7 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
 ```json
 {
   "access": {
-    "group_ids": [1, 2]
+  "group_ids": [1, 2]
   }
 }
 ```
@@ -1029,7 +1030,7 @@ A component of the [Filled form](#filled-form) event.
 | `id`                    | yes      | `string`                | Field id, for all field types                                                                            |
 | `label`                 | yes      | `string`                | Field label; for all field types                                                                         |
 | `answer`                | yes      | `any`                   | For all field types                                                                                      |
-| `answer.id`             | yes      | `string`                | Answer id; for all field types                                                                           |
+| `answer.id`             | yes      | `string`                | A unique identifier of each option a Customer can choose. For all field types.                           |
 | `answer.label`          | yes      | `string`                | Answer label; for all field types                                                                        |
 | `answer.group_id`       | yes      | `number`                | For `group_chooser`                                                                                      |
 
@@ -1071,6 +1072,7 @@ A component of the [Filled form](#filled-form) event.
 		"id": "154417206262605324",
 		"label": "Choose department",
 		"answer": {
+      "id": "2",
 			"group_id": 1,
 			"label": "Marketing"
 		}

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -34,6 +34,8 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 - Method **Send Event** now returns only `event_id` instead of the whole [Event data structure](/messaging/customer-chat-api/#events).
 - Method **Start Chat** ([Web](/messaging/customer-chat-api/#start-chat) & [RTM](/messaging/customer-chat-api/rtm-reference/#start-chat)) now returns only `chat_id`, `thread_id` and optionally `event_ids` if requested. It used to return the whole Chat data structure.
 - Method **Activate Chat** ([Web](/messaging/customer-chat-api/#activate-chat) & [RTM](/messaging/customer-chat-api/rtm-reference/#activate-chat)) now returns only `thread_id` and optionally `event_ids` if requested. It used to return the whole Chat data structure.
+- In `get_form` there is new field available `id`(type: string) in `form.fields.options` for type: `group_chooser`.
+- `id` field is present in `group_chooser field`, in thread events of type `pre_chat`.
 
 ### Removed
 - The **Send File** method was removed.

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -19,7 +19,7 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 ### Changed
 - Method **Update Customer** ([Web](/messaging/customer-chat-api/v3.2/#update-customer) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#update-customer)), which used to return the Customer data structure, now has no response payload.
 - The [**Property**](/messaging/customer-chat-api/v3.2/#properties) data structure now has the same format in requests as in responses and pushes.
-- There's a new field `id` in the [Form field](/messaging/customer-chat-api/v3.2/#form-fields) data structure (`fields.answer.id` for the `group_chooser` field type).  It's a unique identifier for each option Customers can choose. The `id` is now returned by the **Get Form** method ([Web](/messaging/customer-chat-api/v3.2/#get-form) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#get-form)) (`form.fields.options` for the `group_chooser` field type).
+- There's a new field `id` in the [Form field](/messaging/customer-chat-api/v3.2/#form-fields) data structure (`fields.answer.id` for the `group_chooser` field type).  It's an identifier for each option Customers can choose. The `id` is now returned by the **Get Form** method ([Web](/messaging/customer-chat-api/v3.2/#get-form) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#get-form)) (`form.fields.options` for the `group_chooser` field type).
 
 ## [v3.1] - 2019-09-17
 

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -19,6 +19,7 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 ### Changed
 - Method **Update Customer** ([Web](/messaging/customer-chat-api/v3.2/#update-customer) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#update-customer)), which used to return the Customer data structure, now has no response payload.
 - The [**Property**](/messaging/customer-chat-api/v3.2/#properties) data structure now has the same format in requests as in responses and pushes.
+- There's a new field `id` in the [Form field](/messaging/customer-chat-api/v3.2/#form-fields) data structure (`fields.answer.id` for the `group_chooser` field type).  It's a unique identifier for each option Customers can choose. The `id` is now returned by the **Get Form** method ([Web](/messaging/customer-chat-api/v3.2/#get-form) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#get-form)) (`form.fields.options` for the `group_chooser` field type).
 
 ## [v3.1] - 2019-09-17
 
@@ -34,8 +35,6 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 - Method **Send Event** now returns only `event_id` instead of the whole [Event data structure](/messaging/customer-chat-api/#events).
 - Method **Start Chat** ([Web](/messaging/customer-chat-api/#start-chat) & [RTM](/messaging/customer-chat-api/rtm-reference/#start-chat)) now returns only `chat_id`, `thread_id` and optionally `event_ids` if requested. It used to return the whole Chat data structure.
 - Method **Activate Chat** ([Web](/messaging/customer-chat-api/#activate-chat) & [RTM](/messaging/customer-chat-api/rtm-reference/#activate-chat)) now returns only `thread_id` and optionally `event_ids` if requested. It used to return the whole Chat data structure.
-- In `get_form` there is new field available `id`(type: string) in `form.fields.options` for type: `group_chooser`.
-- `id` field is present in `group_chooser field`, in thread events of type `pre_chat`.
 
 ### Removed
 - The **Send File** method was removed.

--- a/content/messaging/customer-chat-api/v3.2/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/index.mdx
@@ -202,6 +202,7 @@ Filled form event contains data from a form (prechat or postchat survey).
 		"id": "154417206262605324",
 		"label": "Choose department",
 		"answer": {
+      "id": "2",
 			"group_id": 1,
 			"label": "Marketing"
 		}
@@ -846,7 +847,7 @@ A component of the [Filled form](#filled-form) event.
 | `id`                    | yes      | `string`                | Field id, for all field types                                                                            |
 | `label`                 | yes      | `string`                | Field label; for all field types                                                                         |
 | `answer`                | yes      | `any`                   | For all field types                                                                                      |
-| `answer.id`             | yes      | `string`                | Answer id; for all field types                                                                           |
+| `answer.id`             | yes      | `string`                | A unique identifier of each option a Customer can choose. For all field types.                           |
 | `answer.label`          | yes      | `string`                | Answer label; for all field types                                                                        |
 | `answer.group_id`       | yes      | `number`                | For `group_chooser`                                                                                      |
 
@@ -888,6 +889,7 @@ A component of the [Filled form](#filled-form) event.
 		"id": "154417206262605324",
 		"label": "Choose department",
 		"answer": {
+      "id": "2",
 			"group_id": 1,
 			"label": "Marketing"
 		}
@@ -2497,29 +2499,52 @@ curl -X POST \
 
 ```json
 {
-  "form": {
-    "id": "156630109416307809",
-    "fields": [
-      {
-        "id": "15663010941630615",
-        "type": "header",
-        "label": "Welcome to our LiveChat! Please fill in the form below before starting the chat."
-      },
-      {
-        "id": "156630109416307759",
-        "type": "name",
-        "label": "Name:",
-        "required": false
-      },
-      {
-        "id": "15663010941630515",
-        "type": "email",
-        "label": "E-mail:",
-        "required": false
-      }
-    ]
-  },
-  "enabled": true
+    "form": {
+        "id": "157986144052005549",
+        "fields": [
+            {
+                "id": "157986144052003238",
+                "type": "header",
+                "label": "Welcome to our LiveChat! Please fill in the form below before starting the chat."
+            },
+            {
+                "id": "157986144052008371",
+                "type": "name",
+                "label": "Name:",
+                "required": false
+            },
+            {
+                "id": "157986144052005782",
+                "type": "email",
+                "label": "E-mail:",
+                "required": false
+            },
+            {
+                "id": "157986144052009331",
+                "type": "group_chooser",
+                "label": "Choose a department:",
+                "required": true,
+                "options": [
+                    {
+                        "id": "0",
+                        "group_id": 1,
+                        "label": "Marketing"
+                    },
+                    {
+                        "id": "1",
+                        "group_id": 2,
+                        "label": "Sales"
+                    },
+                    {
+                        "id": "2",
+                        "group_id": 0,
+                        "label": "General"
+                    }
+                ]
+            }
+        ]
+    },
+    "enabled": true
 }
 ```
 

--- a/content/messaging/customer-chat-api/v3.2/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/index.mdx
@@ -847,7 +847,7 @@ A component of the [Filled form](#filled-form) event.
 | `id`                    | yes      | `string`                | Field id, for all field types                                                                            |
 | `label`                 | yes      | `string`                | Field label; for all field types                                                                         |
 | `answer`                | yes      | `any`                   | For all field types                                                                                      |
-| `answer.id`             | yes      | `string`                | A unique identifier of each option a Customer can choose. For all field types.                           |
+| `answer.id`             | yes      | `string`                | An identifier of each option a Customer can choose. For all field types.                           |
 | `answer.label`          | yes      | `string`                | Answer label; for all field types                                                                        |
 | `answer.group_id`       | yes      | `number`                | For `group_chooser`                                                                                      |
 

--- a/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
@@ -213,6 +213,7 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 		"id": "154417206262605324",
 		"label": "Choose department",
 		"answer": {
+      "id": "2",
 			"group_id": 1,
 			"label": "Marketing"
 		}
@@ -858,7 +859,7 @@ A component of the [Filled form](#filled-form) event.
 | `id`                    | yes      | `string`                | Field id, for all field types                                                                            |
 | `label`                 | yes      | `string`                | Field label; for all field types                                                                         |
 | `answer`                | yes      | `any`                   | For all field types                                                                                      |
-| `answer.id`             | yes      | `string`                | Answer id; for all field types                                                                           |
+| `answer.id`             | yes      | `string`                | A unique identifier of each option a Customer can choose. For all field types.                           |
 | `answer.label`          | yes      | `string`                | Answer label; for all field types                                                                        |
 | `answer.group_id`       | yes      | `number`                | For `group_chooser`                                                                                      |
 
@@ -900,6 +901,7 @@ A component of the [Filled form](#filled-form) event.
 		"id": "154417206262605324",
 		"label": "Choose department",
 		"answer": {
+      "id": "2",
 			"group_id": 1,
 			"label": "Marketing"
 		}
@@ -2778,31 +2780,52 @@ Returns an empty ticket form of a <a href="https://www.livechatinc.com/help/chat
 
 ```json
 {
-  "payload": {
     "form": {
-      "id": "156630109416307809",
-      "fields": [
-        {
-          "id": "15663010941630615",
-          "type": "header",
-          "label": "Welcome to our LiveChat! Please fill in the form below before starting the chat."
-        },
-        {
-          "id": "156630109416307759",
-          "type": "name",
-          "label": "Name:",
-          "required": false
-        },
-        {
-          "id": "15663010941630515",
-          "type": "email",
-          "label": "E-mail:",
-          "required": false
-        }
-      ]
+        "id": "157986144052005549",
+        "fields": [
+            {
+                "id": "157986144052003238",
+                "type": "header",
+                "label": "Welcome to our LiveChat! Please fill in the form below before starting the chat."
+            },
+            {
+                "id": "157986144052008371",
+                "type": "name",
+                "label": "Name:",
+                "required": false
+            },
+            {
+                "id": "157986144052005782",
+                "type": "email",
+                "label": "E-mail:",
+                "required": false
+            },
+            {
+                "id": "157986144052009331",
+                "type": "group_chooser",
+                "label": "Choose a department:",
+                "required": true,
+                "options": [
+                    {
+                        "id": "0",
+                        "group_id": 1,
+                        "label": "Marketing"
+                    },
+                    {
+                        "id": "1",
+                        "group_id": 2,
+                        "label": "Sales"
+                    },
+                    {
+                        "id": "2",
+                        "group_id": 0,
+                        "label": "General"
+                    }
+                ]
+            }
+        ]
     },
     "enabled": true
-  }
 }
 ```
 

--- a/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
@@ -859,7 +859,7 @@ A component of the [Filled form](#filled-form) event.
 | `id`                    | yes      | `string`                | Field id, for all field types                                                                            |
 | `label`                 | yes      | `string`                | Field label; for all field types                                                                         |
 | `answer`                | yes      | `any`                   | For all field types                                                                                      |
-| `answer.id`             | yes      | `string`                | A unique identifier of each option a Customer can choose. For all field types.                           |
+| `answer.id`             | yes      | `string`                | An identifier of each option a Customer can choose. For all field types.                           |
 | `answer.label`          | yes      | `string`                | Answer label; for all field types                                                                        |
 | `answer.group_id`       | yes      | `number`                | For `group_chooser`                                                                                      |
 


### PR DESCRIPTION
Copy of the branch: _API-5443-update-docs-about-id-in-group-chooser_ made to have a feature branch.

There's a new parameter `id` in the **Form field** data structure (`fields.answer.id` for the `group_chooser` field type).  It's a unique identifier for each option Customers can choose. This `id` is also returned by the **Get Form** method.