### PR TITLE
API-5396 Add User to Chat require_active_thread

### DIFF
--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -19,6 +19,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - The method **Update Customer** ([Web](/messaging/agent-chat-api/v3.2/#update-customer) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#update-customer)), which used to return the Customer data structure, now has no response payload.
 - The method **Get Chat Threads** ([Web](/messaging/agent-chat-api/v3.2/#get-chat-threads) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#get-chat-threads)) now requires `thread_ids`. Also, it no longer returns `threads_summary` in the response.
 - The [**Property**](/messaging/agent-chat-api/v3.2/#properties) data structure now has the same format in requests as in responses and pushes.
+- The **Add User to Chat** method ([Web](/messaging/agent-chat-api/v3.2/#add-user-to-chat) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#add-user-to-chat)) accepts an optional parameter `require_active_thread`.
 
 ### Removed
 - The **Update Agent** method was removed.

--- a/content/messaging/agent-chat-api/v3.2/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/index.mdx
@@ -2142,11 +2142,12 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 
 #### Request
 
-| Request object | Required | Type     | Notes                                  |
-| -------------- | -------- | -------- | -------------------------------------- |
-| `chat_id`      | Yes      | `string` |                                        |
-| `user_id`      | Yes      | `string` |                                        |
-| `user_type`    | Yes      | `string` | Possible values: `agent` or `customer` |
+| Request object          | Required | Type     | Notes                                                                   |
+| ----------------------- | -------- | -------- | ----------------------------------------------------------------------- |
+| `chat_id`               | Yes      | `string` |                                                                         |
+| `user_id`               | Yes      | `string` |                                                                         |
+| `user_type`             | Yes      | `string` | Possible values: `agent` or `customer`                                  |
+| `require_active_thread` | No       | `bool`   | If `true` only adds user if chat has an active thread; default `false`. |
 
 #### Response
 
@@ -2164,7 +2165,8 @@ No response payload (`200 OK`).
   -d '{
       "chat_id": "PW94SJTGW6",
       "user_id": "agent1@example.com",
-      "user_type": "agent"
+      "user_type": "agent",
+      "require_active_thread": "true"
       }'
 ```
 
@@ -3369,19 +3371,20 @@ You can create and manage webhooks via the [Configuration API](/management/confi
 
 #### Possible errors
 
-| Type                        | Default Message               | Notes                                                   |
-| --------------------------- | ----------------------------- | ------------------------------------------------------- |
-| `authentication`            | Authentication error          | An invalid or expired access token.                     |
-| `authorization`             | Authorization error           | User is not allowed to perform the action.              |
-| `entity_too_large`          | Upload limit exceeded (10MB). | Client's request is too large.                          |
-| `internal`                  | Internal server error         |                                                         |
-| `license_expired`           | License expired               | The end of license trial or subcription.                |
-| `license_not_found`         | License not found             | License with the specified ID doesn't exist.            |
-| `misdirected_request`**\*** | Wrong region                  | Client's request should be performed to another region. |
-| `request_timeout`           | Request timed out             | Timeout threshold is 15 seconds.                        |
-| `unsupported_version`       | Unsupported version           | Unsupported protocol version.                           |
-| `validation`                | Wrong format of request       |                                                         |
-| `wrong_product_version`     | Wrong product version         | License is not LiveChat 3 (probably still LiveChat 2).  |
+| Type                        | Default Message               | Notes                                                     |
+| --------------------------- | ----------------------------- | --------------------------------------------------------- |
+| `authentication`            | Authentication error          | An invalid or expired access token.                       |
+| `authorization`             | Authorization error           | User is not allowed to perform the action.                |
+| `entity_too_large`          | Upload limit exceeded (10MB). | Client's request is too large.                            |
+| `internal`                  | Internal server error         |                                                           |
+| `license_expired`           | License expired               | The end of license trial or subcription.                  |
+| `license_not_found`         | License not found             | License with the specified ID doesn't exist.              |
+| `misdirected_request`**\*** | Wrong region                  | Client's request should be performed to another region.   |
+| `request_timeout`           | Request timed out             | Timeout threshold is 15 seconds.                          |
+| `unsupported_version`       | Unsupported version           | Unsupported protocol version.                             |
+| `validation`                | Wrong format of request       |                                                           |
+| `wrong_product_version`     | Wrong product version         | License is not LiveChat 3 (probably still LiveChat 2).    |
+| `chat_inactive`             | No active chat thread         | Action requiring active thread performed on chat with no active thread |
 
 \* `misdirected_request` error returns also correct `region` in optional `data` object.
 With this information client is able to figure out where he should be connected.

--- a/content/messaging/agent-chat-api/v3.2/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/index.mdx
@@ -2147,7 +2147,7 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 | `chat_id`               | Yes      | `string` |                                                                         |
 | `user_id`               | Yes      | `string` |                                                                         |
 | `user_type`             | Yes      | `string` | Possible values: `agent` or `customer`                                  |
-| `require_active_thread` | No       | `bool`   | If `true` only adds user if chat has an active thread; default `false`. |
+| `require_active_thread` | No       | `bool`   | If `true`, it adds a user to a chat only if that chat has an active thread; default `false`. |
 
 #### Response
 
@@ -3371,20 +3371,20 @@ You can create and manage webhooks via the [Configuration API](/management/confi
 
 #### Possible errors
 
-| Type                        | Default Message               | Notes                                                     |
-| --------------------------- | ----------------------------- | --------------------------------------------------------- |
-| `authentication`            | Authentication error          | An invalid or expired access token.                       |
-| `authorization`             | Authorization error           | User is not allowed to perform the action.                |
-| `entity_too_large`          | Upload limit exceeded (10MB). | Client's request is too large.                            |
-| `internal`                  | Internal server error         |                                                           |
-| `license_expired`           | License expired               | The end of license trial or subcription.                  |
-| `license_not_found`         | License not found             | License with the specified ID doesn't exist.              |
-| `misdirected_request`**\*** | Wrong region                  | Client's request should be performed to another region.   |
-| `request_timeout`           | Request timed out             | Timeout threshold is 15 seconds.                          |
-| `unsupported_version`       | Unsupported version           | Unsupported protocol version.                             |
-| `validation`                | Wrong format of request       |                                                           |
-| `wrong_product_version`     | Wrong product version         | License is not LiveChat 3 (probably still LiveChat 2).    |
-| `chat_inactive`             | No active chat thread         | Action requiring active thread performed on chat with no active thread |
+| Type                        | Default Message               | Notes                                                     
+| --------------------------- | ----------------------------- | --------------------------------------------------------- 
+| `authentication`            | Authentication error          | An invalid or expired access token.                       
+| `authorization`             | Authorization error           | User is not allowed to perform the action.                
+| `entity_too_large`          | Upload limit exceeded (10MB). | Client's request is too large.                            
+| `internal`                  | Internal server error         |                                                           
+| `license_expired`           | License expired               | The end of license trial or subcription.                  
+| `license_not_found`         | License not found             | License with the specified ID doesn't exist.              
+| `misdirected_request`**\*** | Wrong region                  | Client's request should be performed to another region.   
+| `request_timeout`           | Request timed out             | Timeout threshold is 15 seconds.                          
+| `unsupported_version`       | Unsupported version           | Unsupported protocol version.                             
+| `validation`                | Wrong format of request       |                                                           
+| `wrong_product_version`     | Wrong product version         | License is not LiveChat 3 (probably still LiveChat 2).    
+| `chat_inactive`             | No active chat thread         | An action that requires an active thread performed on a chat with no active threads. 
 
 \* `misdirected_request` error returns also correct `region` in optional `data` object.
 With this information client is able to figure out where he should be connected.

--- a/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
@@ -2457,7 +2457,7 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 | `chat_id`               | Yes      | `string` |                                                                         |
 | `user_id`               | Yes      | `string` |                                                                         |
 | `user_type`             | Yes      | `string` | Possible values: `agent` or `customer`                                  |
-| `require_active_thread` | No       | `bool`   | If `true` only adds user if chat has an active thread; default `false`. |
+| `require_active_thread` | No       | `bool`   | If `true`, it adds a user to a chat only if that chat has an active thread; default `false`. |
 
 </Text>
 <Code>
@@ -5210,21 +5210,21 @@ Informs about messages sent via the `multicast` method or by the system.
 
 #### Possible errors
 
-| Type                             | Default Message               | Notes                                                              |
-| -------------------------------- | ----------------------------- | ------------------------------------------------------------------ |
-| `authentication`                 | Authentication error          | An invalid or expired access token.                                |
-| `authorization`                  | Authorization error           | User is not allowed to perform the action.                         |
-| `internal`                       | Internal server error         |                                                                    |
-| `license_expired`                | License expired               | The end of license trial or subcription.                            |
-| `pending_requests_limit_reached` | Requests limit reached        | The limit of pending requests within one websocket connection has been reached. The limit is 10.|
-| `requester_already_offline`      | Requester offline             | The method is only allowed for the logged in Agents (via RTM API). |
-| `requester_awaiting_approval`    | Requester&nbsp;awaiting&nbsp;approval   | A new Agent hasn't been approved by the license owner yet.     |
-| `request_timeout`                | Request timed out             | Timeout threshold is 15 seconds.                                    |
-| `requester_suspended`            | Requester suspended           | The rights of a given Agent have been withdrawn by the license owner.|
-| `validation`                     | Wrong format of request       |                                                                    |
-| `wrong_product_version`          | Wrong product version         | License is not LiveChat 3 (probably still LiveChat 2).             |
-| `seats_limit_exceeded`           | Seats limit exceeded          | Displayed on the attempt of logging in. All seats within a given license are already taken.|
-| `chat_inactive`                  | No active chat thread         | Action requiring active thread performed on chat with no active thread          |
+| Type                             | Default Message               | Notes                                                              
+| -------------------------------- | ----------------------------- | ------------------------------------------------------------------ 
+| `authentication`                 | Authentication error          | An invalid or expired access token.                                
+| `authorization`                  | Authorization error           | User is not allowed to perform the action.                         
+| `internal`                       | Internal server error         |                                                                    
+| `license_expired`                | License expired               | The end of license trial or subcription.                            
+| `pending_requests_limit_reached` | Requests limit reached        | The limit of pending requests within one websocket connection has been reached. The limit is 10.
+| `requester_already_offline`      | Requester offline             | The method is only allowed for the logged in Agents (via RTM API). 
+| `requester_awaiting_approval`    | Requester&nbsp;awaiting&nbsp;approval | A new Agent hasn't been approved by the license owner yet.     
+| `request_timeout`                | Request timed out             | Timeout threshold is 15 seconds.                                    
+| `requester_suspended`            | Requester suspended           | The rights of a given Agent have been withdrawn by the license owner.
+| `validation`                     | Wrong format of request       |                                                                    
+| `wrong_product_version`          | Wrong product version         | License is not LiveChat 3 (probably still LiveChat 2).             
+| `seats_limit_exceeded`           | Seats limit exceeded          | Displayed on the attempt of logging in. All seats within a given license are already taken.
+| `chat_inactive`                  | No active chat thread         | An action that requires an active thread performed on a chat with no active threads.          
 
 \* `misdirected_request` error returns also correct `region` in optional `data` object.
 With this information client is able to figure out where he should be connected.

--- a/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
@@ -2452,11 +2452,12 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 
 #### Request
 
-| Request object | Required | Type     | Notes                                  |
-| -------------- | -------- | -------- | -------------------------------------- |
-| `chat_id`      | Yes      | `string` |                                        |
-| `user_id`      | Yes      | `string` |                                        |
-| `user_type`    | Yes      | `string` | Possible values: `agent` or `customer` |
+| Request object          | Required | Type     | Notes                                                                   |
+| ----------------------- | -------- | -------- | ----------------------------------------------------------------------- |
+| `chat_id`               | Yes      | `string` |                                                                         |
+| `user_id`               | Yes      | `string` |                                                                         |
+| `user_type`             | Yes      | `string` | Possible values: `agent` or `customer`                                  |
+| `require_active_thread` | No       | `bool`   | If `true` only adds user if chat has an active thread; default `false`. |
 
 </Text>
 <Code>
@@ -2468,7 +2469,8 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
   "payload": {
     "chat_id": "PW94SJTGW6",
     "user_id": "agent1@example.com",
-    "user_type": "agent"
+    "user_type": "agent",
+    "require_active_thread": "true"
   }
 }
 ```
@@ -5222,6 +5224,7 @@ Informs about messages sent via the `multicast` method or by the system.
 | `validation`                     | Wrong format of request       |                                                                    |
 | `wrong_product_version`          | Wrong product version         | License is not LiveChat 3 (probably still LiveChat 2).             |
 | `seats_limit_exceeded`           | Seats limit exceeded          | Displayed on the attempt of logging in. All seats within a given license are already taken.|
+| `chat_inactive`                  | No active chat thread         | Action requiring active thread performed on chat with no active thread          |
 
 \* `misdirected_request` error returns also correct `region` in optional `data` object.
 With this information client is able to figure out where he should be connected.


### PR DESCRIPTION
Method **Add User to Chat** has a new optional parameter `require_active_thread`. 
This is a copy of the branch _API-5396-add-user-require-active_ created to have a feature branch.

Proofreading done.