### PR TITLE
Updates in errors, send event, and chat_user_added push

### DIFF
--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -2241,16 +2241,18 @@ https://api.livechatinc.com/v3.1/agent/action/remove_user_from_chat \
 
 ### Send Event
 
-Sends an [Event](#events) object.
+Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request. 
+
+It's possible to write to a chat without joining it. The user sending an event will be automatically added to the chat with the `present` parameter set to `false` (see [`chat_user_added`](/messaging/agent-chat-api/rtm-reference/#chat_user_added)). **Sample use case:** a Bot Agent that sends messages visible to all chat participants without actually joining the chat.
 
 #### Specifics
 
-|                        |                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------- |
-| **Method URL**         | `https://api.livechatinc.com/v3.1/agent/action/send_event`                               |
-| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
-| **RTM API equivalent** | [`send_event`](rtm-reference/#send-event)                                                |
-| **Webhook**            | [`incoming_event`](/management/configuration-api/#incoming_event)                        |
+|                        |                                                                                          
+| ---------------------- | ---------------------------------------------------------------------------------------- 
+| **Method URL**         | `https://api.livechatinc.com/v3.1/agent/action/send_event`                               
+| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` 
+| **RTM API equivalent** | [`send_event`](rtm-reference/#send-event)                                                
+| **Webhook**            | [`incoming_event`](/management/configuration-api/#incoming_event)                        
 
 #### Request
 

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -2478,16 +2478,18 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 
 ### Send Event
 
-Sends an [Event](#events) object.
+Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request. 
+
+It's possible to write to a chat without joining it. The user sending an event will be automatically added to the chat with the `present` parameter set to `false` (see [`chat_user_added`](#chat_user_added)). **Sample use case:** a Bot Agent that sends messages visible to all chat participants without actually joining the chat.
 
 #### Specifics
 
-|                        |                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------- |
-| **Action**             | `send_event`                                                                             |
-| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
-| **Web API equivalent** | [`send_event`](../#send-event)                                                           |
-| **Push message**       | [`incoming_event`](#incoming_event)                                                                                        |
+|                        |                                                                                          
+| ---------------------- | ---------------------------------------------------------------------------------------- 
+| **Action**             | `send_event`                                                                             
+| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` 
+| **Web API equivalent** | [`send_event`](../#send-event)                                                           
+| **Push message**       | [`incoming_event`](#incoming_event)                                                                                        
 
 #### Request
 
@@ -4567,6 +4569,8 @@ Informs that a chat was transferred to a different group or to an Agent.
 
 ### `chat_user_added`
 Informs that a user (Customer or Agent) was added to a chat.
+
+This push can be emitted with `user.present` set to `false` when a user writes to a chat without joining it. You can achieve that via the [Send Event](#send-event) method.  
 
 <CodeResponse title={'Sample push payload'}>
 

--- a/content/messaging/agent-chat-api/v3.2/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/index.mdx
@@ -2235,16 +2235,18 @@ https://api.livechatinc.com/v3.2/agent/action/remove_user_from_chat \
 
 ### Send Event
 
-Sends an [Event](#events) object.
+Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request. 
+
+It's possible to write to a chat without joining it. The user sending an event will be automatically added to the chat with the `present` parameter set to `false` (see [`chat_user_added`](/messaging/agent-chat-api/v3.2/rtm-reference/#chat_user_added)). **Sample use case:** a Bot Agent that sends messages visible to all chat participants without actually joining the chat.
 
 #### Specifics
 
-|                        |                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------- |
-| **Method URL**         | `https://api.livechatinc.com/v3.2/agent/action/send_event`                               |
-| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
-| **RTM API equivalent** | [`send_event`](rtm-reference/#send-event)                                                |
-| **Webhook**            | [`incoming_event`](/management/configuration-api/#incoming_event)                        |
+|                        |                                                                                          
+| ---------------------- | ---------------------------------------------------------------------------------------- 
+| **Method URL**         | `https://api.livechatinc.com/v3.2/agent/action/send_event`                               
+| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` 
+| **RTM API equivalent** | [`send_event`](rtm-reference/#send-event)                                                
+| **Webhook**            | [`incoming_event`](/management/configuration-api/#incoming_event)                        
 
 #### Request
 

--- a/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
@@ -2581,16 +2581,18 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 
 ### Send Event
 
-Sends an [Event](#events) object.
+Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request. 
+
+It's possible to write to a chat without joining it. The user sending an event will be automatically added to the chat with the `present` parameter set to `false` (see [`chat_user_added`](#chat_user_added)). **Sample use case:** a Bot Agent that sends messages visible to all chat participants without actually joining the chat.
 
 #### Specifics
 
-|                        |                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------- |
-| **Action**             | `send_event`                                                                             |
-| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
-| **Web API equivalent** | [`send_event`](../#send-event)                                                           |
-| **Push message**       | [`incoming_event`](#incoming_event)                                                                                        |
+|                        |                                                                                          
+| ---------------------- | ---------------------------------------------------------------------------------------- 
+| **Action**             | `send_event`                                                                             
+| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` 
+| **Web API equivalent** | [`send_event`](../#send-event)                                                           
+| **Push message**       | [`incoming_event`](#incoming_event)                                                       
 
 #### Request
 
@@ -2619,20 +2621,6 @@ Sends an [Event](#events) object.
 ```
 
 </CodeSample>
-
-<!-- > **`send_event`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "send_event",
-	"payload": {
-		  "event_id": "K600PKZON8"
-		},
-	}
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 
@@ -4462,6 +4450,8 @@ Informs that a chat was transferred to a different group or to an Agent.
 
 ### `chat_user_added`
 Informs that a user (Customer or Agent) was added to a chat.
+
+This push can be emitted with `user.present` set to `false` when a user writes to a chat without joining it. You can achieve that via the [Send Event](#send-event) method.  
 
 <CodeResponse title={'Sample push payload'}>
 

--- a/content/messaging/customer-chat-api/index.mdx
+++ b/content/messaging/customer-chat-api/index.mdx
@@ -1496,13 +1496,15 @@ curl -X POST \
 
 ### Send Event
 
+Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request. 
+
 #### Specifics
 
-|                        |                                                               |
-| ---------------------- | ------------------------------------------------------------- |
-| **Method URL**         | `https://api.livechatinc.com/v3.1/customer/action/send_event` |
-| **RTM API equivalent** | [`send_event`](rtm-reference/#send-event)                     |
-| **Webhook**            | [`incoming_event`](/management/configuration-api/#incoming_event)                           |
+|                        |                                                               
+| ---------------------- | ------------------------------------------------------------- 
+| **Method URL**         | `https://api.livechatinc.com/v3.1/customer/action/send_event` 
+| **RTM API equivalent** | [`send_event`](rtm-reference/#send-event)                     
+| **Webhook**            | [`incoming_event`](/management/configuration-api/#incoming_event)                           
 
 #### Request
 
@@ -2561,25 +2563,36 @@ Here's what you need to know about **webhooks**:
 
 </CodeResponse>
 
+<Section>
+
+<Text>
+
 #### Possible errors
 
-| Type                        | Default Message               | Notes                                                              |
-| --------------------------- | ----------------------------- | ------------------------------------------------------------------ |
-| `authentication`            | Authentication error          | An invalid or expired access token.                                |
-| `authorization`             | Authorization error           | Agent is not allowed to perform the action.                        |
-| `entity_too_large`          | Upload limit exceeded (10MB). | Client's request is too large.                                     |
-| `internal`                  | Internal server error         |                                                                    |
-| `license_expired`           | License expired               | The end of license trial or subcription.                           |
-| `license_not_found`         | License not found             | License with the specified ID doesn't exist.                       |
-| `misdirected_request`__*__  | Wrong region                  | Client's request should be performed to another region.            |
-| `validation`                | Wrong format of request       |                                                                    |
-| `request_timeout`           | Request timed out             | Timeout threshold is 15 seconds.                                   |
-| `unsupported_version`       | Unsupported version           | Unsupported protocol version.                                      |
-| `wrong_product_version`     | Wrong product version         | License is not LiveChat 3 (probably still LiveChat 2).             |
+| Type                        | Default Message               | Notes                                                        
+| --------------------------- | ----------------------------- | -------------------------------------------------------------
+| `authentication`            | Authentication error          | An invalid or expired access token.                          
+| `authorization`             | Authorization error           | Agent is not allowed to perform the action.                  
+| `customer_banned`           | Customer is banned            | The customer had been banned.       
+| `entity_too_large`          | Upload limit exceeded (10MB). | Client's request is too large.  
+| `greeting_not_found`        | Greeting not found            |         
+| `group_not_found`           | Group not found               |
+| `group_offline`             | Group is offline              | Thrown in response to [Get Predicted Agent](#get-predicted-agent).   
+| `group_unavailable`         | No&nbsp;agent&nbsp;available&nbsp;for&nbsp;group  | Thrown in response to [Get Predicted Agent](#get-predicted-agent). The group is online, but there are no available Agents. 
+| `groups_offline`            | Groups offline                | 
+| `internal`                  | Internal server error         |                                                              
+| `license_expired`           | License expired               | The end of license trial or subcription.                     
+| `license_not_found`         | License not found             | License with the specified ID doesn't exist.                 
+| `misdirected_request`       | Wrong region                  | Client's request should be performed to another region. It returns the correct `region` in the optional `data` object. 
+| `not_found`                 | Not found                     |    
+| `validation`                | Wrong format of request       |                                                              
+| `request_timeout`           | Request timed out             | Timeout threshold is 15 seconds.                             
+| `unsupported_version`       | Unsupported version           | Unsupported protocol version.                                
+| `wrong_product_version`     | Wrong product version         | License is not LiveChat 3 (probably still LiveChat 2).       
 
+</Text>
 
-__*)__  `misdirected_request` error returns also correct `region` in optional `data` object.
-With this information client is able to figure out where he should be connected.
+</Section>
 
 # Contact us
 

--- a/content/messaging/customer-chat-api/index.mdx
+++ b/content/messaging/customer-chat-api/index.mdx
@@ -2584,7 +2584,6 @@ Here's what you need to know about **webhooks**:
 | `license_expired`           | License expired               | The end of license trial or subcription.                     
 | `license_not_found`         | License not found             | License with the specified ID doesn't exist.                 
 | `misdirected_request`       | Wrong region                  | Client's request should be performed to another region. It returns the correct `region` in the optional `data` object. 
-| `not_found`                 | Not found                     |    
 | `validation`                | Wrong format of request       |                                                              
 | `request_timeout`           | Request timed out             | Timeout threshold is 15 seconds.                             
 | `unsupported_version`       | Unsupported version           | Unsupported protocol version.                                

--- a/content/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -3692,7 +3692,6 @@ Informs that a user has seen events up to a specific time.
 | `group_unavailable`               | No&nbsp;agent&nbsp;available&nbsp;for&nbsp;group      | Thrown in response to [Get Predicted Agent](#get-predicted-agent). The group is online, but there are no available Agents. 
 | `groups_offline`                  | Groups offline                    | 
 | `internal`                        | Internal server error             |                                                                                                             
-| `not_found`                       | Not found                         |    
 | `license_expired`                 | License expired                   | The end of license trial or subcription.                                                                    
 | `pending_requests_limit_reached`  | Requests&nbsp;limit&nbsp;reached  | The limit of pending requests within one websocket connection has been reached. The limit is 10.            
 | `request_timeout`                 | Request timed out                 | Timeout threshold is 15 seconds.                                                                            

--- a/content/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -1557,13 +1557,16 @@ Closes the thread. Sending messages to this thread will no longer be possible.
 
 ### Send Event
 
+Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request. 
+
 #### Specifics
 
-|                        |                                                           |
-| ---------------------- | --------------------------------------------------------- |
-| **Action**             | `send_event`                                              |
-| **Web API equivalent** | [`send_event`](../#send-event) |
-| **Push message**       | [`incoming_event`](#incoming_event)                       |
+|                        |                                                           
+| ---------------------- | --------------------------------------------------------- 
+| **Action**             | `send_event`                                              
+| **Web API equivalent** | [`send_event`](../#send-event) 
+| **Push message**       | [`incoming_event`](#incoming_event)                       
+
 
 #### Request
 
@@ -3085,6 +3088,8 @@ Informs that a chat was transferred to a different group or to an Agent.
 ### `chat_user_added`
 Informs that a user (Customer or Agent) was added to a chat.
 
+This push can be emitted with `user.present` set to `false` when a user writes to a chat without joining it. You can achieve that via the [Send Event](/messaging/agent-chat-api/#send-event) method. 
+
 <CodeResponse title={'Sample push payload'}>
 
 ```json
@@ -3547,20 +3552,20 @@ Informs that a Customer was disconnected. The payload contains the reason of Cus
 
 #### Possible reasons
 
-| Type                                 | Notes                                                                                                                                |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `access_token_expired`               | Access token lifetime has elapsed.                                                                                                   |
-| `connection_timeout`                 | Has not received [`ping`](#authentication) from the client for some time, or it's been too long since the connection was authorized. |
-| `customer_banned`                    | Customer has been banned.                                                                                                            |
-| `customer_temporarily_blocked`**\*** | Customer tried reconnecting too many times after the `too_many_connections` error had occurred.                                      |
-| `inactivity_timeout`                 | Customer didn't chat or change the page in the past 30 minutes.                                                                      |
-| `internal_error`                     | Internal error                                                                                                                       |
-| `license_not_found`                  | The license with the specified ID doesn't exist.                                                                                     |
-| `misdirected_connection` **\*\***    | Customer connected to a server in the wrong region.                                                                                  |
-| `product_version_changed`            | The product version has changed.                                                                                                     |
-| `too_many_connections`               | Customer has reached the maximum number of connections.                                                                              |
-| `too_many_unauthorized_connections`  | The maximum number of unauthorized connections has been reached.                                                                     |
-| `unsupported_version`                | Connecting to an unsupported version of the Customer Chat API.                                                                       |
+| Type                                 | Notes                                                                                                                                
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ 
+| `access_token_expired`               | Access token lifetime has elapsed.                                                                                                   
+| `connection_timeout`                 | Has not received [`ping`](#authentication) from the client for some time, or it's been too long since the connection was authorized. 
+| `customer_banned`                    | Customer has been banned.                                                                                                            
+| `customer_temporarily_blocked`**\*** | Customer tried reconnecting too many times after the `too_many_connections` error had occurred.                                                   
+| `inactivity_timeout`                 | Customer didn't chat or change the page in the past 30 minutes.                                                                      
+| `internal`                           | Internal error                                                                                                                       
+| `license_not_found`                  | The license with the specified ID doesn't exist.                                                                                     
+| `misdirected_connection` **\*\***    | Customer connected to a server in the wrong region.                                                                                  
+| `product_version_changed`            | The product version has changed.                                                                                                     
+| `too_many_connections`               | Customer has reached the maximum number of connections.                                                                              
+| `too_many_unauthorized_connections`  | The maximum number of unauthorized connections has been reached.                                                                     
+| `unsupported_version`                | Connecting to an unsupported version of the Customer Chat API.                                                                       
 
 **\*)**
 The `misdirected_connection` reason can also return the correct region in an optional data object. With this piece of information, client is able to figure out where it should be connected.
@@ -3670,21 +3675,35 @@ Informs that a user has seen events up to a specific time.
 
 </CodeResponse>
 
+<Section>
+
+<Text>
+
 #### Possible errors
 
-| Type                              | Default Message                   | Notes                                                                                                       |
-| --------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `authentication`                  | Authentication error              | An invalid or expired access token.                                                                         |
-| `authorization`                   | Authorization error               | User is not allowed to perform the action.                                                                  |
-| `internal`                        | Internal server error             |                                                                                                             |
-| `license_expired`                 | License expired                   | The end of license trial or subcription.                                                                    |
-| `pending_requests_limit_reached`  | Requests&nbsp;limit&nbsp;reached  | The limit of pending requests within one websocket connection has been reached. The limit is 10.            |
-| `request_timeout`                 | Request timed out                 | Timeout threshold is 15 seconds.                                                                            |
-| `users_limit_reached`             | Users limit reached               | Displayed on the attempt of logging in. The limit of online Customers for a given license has been reached. |
-| `unsupported_version`             | Unsupported version               | Unsupported protocol version.                                                                               |
-| `validation`                      | Wrong format of request           |                                                                                                             |
-| `wrong_product_version`           | Wrong product version             | License is not LiveChat 3 (probably still LiveChat 2).                                                      |
+| Type                              | Default Message                   | Notes                                                                                                       
+| --------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------- 
+| `authentication`                  | Authentication error              | An invalid or expired access token.                                                                         
+| `authorization`                   | Authorization error               | User is not allowed to perform the action.                                                                  
+| `customer_banned`                 | Customer is banned                | The customer had been banned.       
+| `greeting_not_found`              | Greeting not found                |         
+| `group_not_found`                 | Group not found                   |
+| `group_offline`                   | Group is offline                  | Thrown in response to [Get Predicted Agent](#get-predicted-agent).   
+| `group_unavailable`               | No&nbsp;agent&nbsp;available&nbsp;for&nbsp;group      | Thrown in response to [Get Predicted Agent](#get-predicted-agent). The group is online, but there are no available Agents. 
+| `groups_offline`                  | Groups offline                    | 
+| `internal`                        | Internal server error             |                                                                                                             
+| `not_found`                       | Not found                         |    
+| `license_expired`                 | License expired                   | The end of license trial or subcription.                                                                    
+| `pending_requests_limit_reached`  | Requests&nbsp;limit&nbsp;reached  | The limit of pending requests within one websocket connection has been reached. The limit is 10.            
+| `request_timeout`                 | Request timed out                 | Timeout threshold is 15 seconds.                                                                            
+| `users_limit_reached`             | Users limit reached               | Displayed on the attempt of logging in. The limit of online Customers for a given license has been reached. 
+| `unsupported_version`             | Unsupported version               | Unsupported protocol version.                                                                               
+| `validation`                      | Wrong format of request           |                                                                                                             
+| `wrong_product_version`           | Wrong product version             | License is not LiveChat 3 (probably still LiveChat&nbsp;2).                                                      
 
+</Text>
+
+</Section>
 
 # Contact us
 

--- a/content/messaging/customer-chat-api/v3.2/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/index.mdx
@@ -2855,7 +2855,6 @@ You can create and manage webhooks via the [Configuration API](/management/confi
 | `license_expired`           | License expired               | The end of license trial or subcription.                     
 | `license_not_found`         | License not found             | License with the specified ID doesn't exist.                 
 | `misdirected_request`       | Wrong region                  | Client's request should be performed to another region.  It returns the correct `region` in the optional `data` object.     
-| `not_found`                 | Not found                     |    
 | `validation`                | Wrong format of request       |                                                              
 | `request_timeout`           | Request timed out             | Timeout threshold is 15 seconds.                             
 | `unsupported_version`       | Unsupported version           | Unsupported protocol version.                                

--- a/content/messaging/customer-chat-api/v3.2/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/index.mdx
@@ -1472,13 +1472,15 @@ curl -X POST \
 
 ### Send Event
 
+Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request. 
+
 #### Specifics
 
-|                        |                                                                   |
-| ---------------------- | ----------------------------------------------------------------- |
-| **Method URL**         | `https://api.livechatinc.com/v3.2/customer/action/send_event`     |
-| **RTM API equivalent** | [`send_event`](rtm-reference/#send-event)                         |
-| **Webhook**            | [`incoming_event`](/management/configuration-api/#incoming_event) |
+|                        |                                                                   
+| ---------------------- | ----------------------------------------------------------------- 
+| **Method URL**         | `https://api.livechatinc.com/v3.2/customer/action/send_event`     
+| **RTM API equivalent** | [`send_event`](rtm-reference/#send-event)                         
+| **Webhook**            | [`incoming_event`](/management/configuration-api/#incoming_event) 
 
 #### Request
 
@@ -2802,10 +2804,6 @@ curl -X POST \
 
 </Section>
 
-<Section>
-
-<Text>
-
 # Webhooks
 
 Here's what you need to know about **webhooks**:
@@ -2836,27 +2834,40 @@ You can create and manage webhooks via the [Configuration API](/management/confi
 
 </CodeResponse>
 
+<Section>
+
+<Text>
+
 #### Possible errors
 
-| Type                        | Default Message               | Notes                                                              |
-| --------------------------- | ----------------------------- | ------------------------------------------------------------------ |
-| `authentication`            | Authentication error          | An invalid or expired access token.                                |
-| `authorization`             | Authorization error           | Agent is not allowed to perform the action.                        |
-| `entity_too_large`          | Upload limit exceeded (10MB). | Client's request is too large.                                     |
-| `internal`                  | Internal server error         |                                                                    |
-| `license_expired`           | License expired               | The end of license trial or subcription.                           |
-| `license_not_found`         | License not found             | License with the specified ID doesn't exist.                       |
-| `misdirected_request`__*__  | Wrong region                  | Client's request should be performed to another region.            |
-| `validation`                | Wrong format of request       |                                                                    |
-| `request_timeout`           | Request timed out             | Timeout threshold is 15 seconds.                                   |
-| `unsupported_version`       | Unsupported version           | Unsupported protocol version.                                      |
-| `wrong_product_version`     | Wrong product version         | License is not LiveChat 3 (probably still LiveChat 2).             |
+| Type                        | Default Message               | Notes                                                        
+| --------------------------- | ----------------------------- | -------------------------------------------------------------
+| `authentication`            | Authentication error          | An invalid or expired access token.                          
+| `authorization`             | Authorization error           | Agent is not allowed to perform the action.                  
+| `customer_banned`           | Customer is banned            | The customer had been banned.       
+| `entity_too_large`          | Upload limit exceeded (10MB). | Client's request is too large.  
+| `greeting_not_found`        | Greeting not found            |         
+| `group_not_found`           | Group not found               |
+| `group_offline`             | Group is offline              | Thrown in response to [Get Predicted Agent](#get-predicted-agent).   
+| `group_unavailable`         | No agent available for group  | Thrown in response to [Get Predicted Agent](#get-predicted-agent). The group is online, but there are no available Agents. 
+| `groups_offline`            | Groups offline                | 
+| `internal`                  | Internal server error         |                                                              
+| `license_expired`           | License expired               | The end of license trial or subcription.                     
+| `license_not_found`         | License not found             | License with the specified ID doesn't exist.                 
+| `misdirected_request`       | Wrong region                  | Client's request should be performed to another region.  It returns the correct `region` in the optional `data` object.     
+| `not_found`                 | Not found                     |    
+| `validation`                | Wrong format of request       |                                                              
+| `request_timeout`           | Request timed out             | Timeout threshold is 15 seconds.                             
+| `unsupported_version`       | Unsupported version           | Unsupported protocol version.                                
+| `wrong_product_version`     | Wrong product version         | License is not LiveChat 3 (probably still LiveChat 2).       
+          
+</Text>
+
+</Section>
 
 # Contact us
 
 If you found a bug or a typo, you can let us know directly on GitHub.
 In case of any questions or feedback, don't hesitate to contact us at [developers@livechatinc.com](mailto:developers@livechatinc.com). We'll be happy to hear from you!
 
-</Text>
 
-</Section>

--- a/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
@@ -1632,18 +1632,6 @@ Closes the thread. Sending messages to this thread will no longer be possible.
 
 </Section>
 
-<!-- > **`close_thread`** sample **request** with optional params
-
-```json
-{
-	"request_id": "657", // optional
-	"action": "close_thread",
-	"payload": {
-		"chat_id": "PJ0MRSHTDG"
-	}
-}
-``` -->
-
 ## Events
 
 <Section>
@@ -1652,13 +1640,15 @@ Closes the thread. Sending messages to this thread will no longer be possible.
 
 ### Send Event
 
+Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request. 
+
 #### Specifics
 
-|                        |                                                           |
-| ---------------------- | --------------------------------------------------------- |
-| **Action**             | `send_event`                                              |
-| **Web API equivalent** | [`send_event`](../#send-event) |
-| **Push message**       | [`incoming_event`](#incoming_event)                       |
+|                        |                                                           
+| ---------------------- | --------------------------------------------------------- 
+| **Action**             | `send_event`                                              
+| **Web API equivalent** | [`send_event`](../#send-event) 
+| **Push message**       | [`incoming_event`](#incoming_event)                       
 
 #### Request
 
@@ -3314,7 +3304,9 @@ Informs that a chat was transferred to a different group or to an Agent.
 ## Chat users
 
 ### `chat_user_added`
-Informs that a user (Customer or Agent) was added to a chat.
+Informs that a user (Customer or Agent) was added to a chat. 
+
+This push can be emitted with `user.present` set to `false` when a user writes to a chat without joining it. You can achieve that via the [Send Event](/messaging/agent-chat-api/v3.2/rtm-reference/#send-event) method.  
 
 <CodeResponse title={'Sample push payload'}>
 
@@ -3761,20 +3753,20 @@ Informs that a Customer was disconnected. The payload contains the reason of Cus
 
 #### Possible reasons
 
-| Type                                 | Notes                                                                                                                                |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `access_token_expired`               | Access token lifetime has elapsed.                                                                                                   |
-| `connection_timeout`                 | Has not received [`ping`](#authentication) from the client for some time, or it's been too long since the connection was authorized. |
-| `customer_banned`                    | Customer has been banned.                                                                                                            |
-| `customer_temporarily_blocked`**\*** | Customer tried reconnecting too many times after the `too_many_connections` error had occurred.                                      |
-| `inactivity_timeout`                 | Customer didn't chat or change the page in the past 30 minutes.                                                                      |
-| `internal_error`                     | Internal error                                                                                                                       |
-| `license_not_found`                  | The license with the specified ID doesn't exist.                                                                                     |
-| `misdirected_connection` **\*\***    | Customer connected to a server in the wrong region.                                                                                  |
-| `product_version_changed`            | The product version has changed.                                                                                                     |
-| `too_many_connections`               | Customer has reached the maximum number of connections.                                                                              |
-| `too_many_unauthorized_connections`  | The maximum number of unauthorized connections has been reached.                                                                     |
-| `unsupported_version`                | Connecting to an unsupported version of the Customer Chat API.                                                                       |
+| Type                                 | Notes                                                                                                                                
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ 
+| `access_token_expired`               | Access token lifetime has elapsed.                                                                                                   
+| `connection_timeout`                 | Has not received [`ping`](#authentication) from the client for some time, or it's been too long since the connection was authorized. 
+| `customer_banned`                    | Customer has been banned.                                                                                                            
+| `customer_temporarily_blocked`**\*** | Customer tried reconnecting too many times after the `too_many_connections` error had occurred.                                         
+| `inactivity_timeout`                 | Customer didn't chat or change the page in the past 30 minutes.                                                                      
+| `internal_error`                     | Internal error                                                                                                                       
+| `license_not_found`                  | The license with the specified ID doesn't exist.                                                                                     
+| `misdirected_connection` **\*\***    | Customer connected to a server in the wrong region.                                                                                  
+| `product_version_changed`            | The product version has changed.                                                                                                     
+| `too_many_connections`               | Customer has reached the maximum number of connections.                                                                              
+| `too_many_unauthorized_connections`  | The maximum number of unauthorized connections has been reached.                                                                     
+| `unsupported_version`                | Connecting to an unsupported version of the Customer Chat API.                                                                       
 
 **\*)**
 The `misdirected_connection` reason can also return the correct region in an optional data object. With this piece of information, client is able to figure out where it should be connected.
@@ -3988,23 +3980,38 @@ Informs about a greeting rejected by the Customer. Also, the push is sent when a
 
 </CodeResponse>
 
+<Section>
+
+<Text>
+
 #### Possible errors
 
-| Type                              | Default Message                   | Notes                                                                                                       |
-| --------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `authentication`                  | Authentication error              | An invalid or expired access token.                                                                         |
-| `authorization`                   | Authorization error               | User is not allowed to perform the action.                                                                  |
-| `internal`                        | Internal server error             |                                                                                                             |
-| `license_expired`                 | License expired                   | The end of license trial or subcription.                                                                    |
-| `pending_requests_limit_reached`  | Requests&nbsp;limit&nbsp;reached  | The limit of pending requests within one websocket connection has been reached. The limit is 10.            |
-| `request_timeout`                 | Request timed out                 | Timeout threshold is 15 seconds.                                                                            |
-| `users_limit_reached`             | Users limit reached               | Displayed on the attempt of logging in. The limit of online Customers for a given license has been reached. |
-| `unsupported_version`             | Unsupported version               | Unsupported protocol version.                                                                               |
-| `validation`                      | Wrong format of request           |                                                                                                             |
-| `wrong_product_version`           | Wrong product version             | License is not LiveChat 3 (probably still LiveChat 2).                                                      |
+| Type                              | Default Message                   | Notes                                                                                                       
+| --------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------- 
+| `authentication`                  | Authentication error              | An invalid or expired access token.                                                                         
+| `authorization`                   | Authorization error               | User is not allowed to perform the action.                                                                  
+| `customer_banned`                 | Customer is banned                | The customer had been banned.       
+| `greeting_not_found`              | Greeting not found                |         
+| `group_not_found`                 | Group not found                   |
+| `group_offline`                   | Group is offline                  | Thrown in response to [Get Predicted Agent](#get-predicted-agent).   
+| `group_unavailable`               | No agent available for group      | Thrown in response to [Get Predicted Agent](#get-predicted-agent). The group is online, but there are no available Agents. 
+| `groups_offline`                  | Groups offline                    | 
+| `internal`                        | Internal server error             |                                                                                                             
+| `not_found`                       | Not found                         |    
+| `license_expired`                 | License expired                   | The end of license trial or subcription.                                                                    
+| `pending_requests_limit_reached`  | Requests limit reached            | The limit of pending requests within one websocket connection has been reached. The limit is 10.            
+| `request_timeout`                 | Request timed out                 | Timeout threshold is 15 seconds.                                                                            
+| `users_limit_reached`             | Users limit reached               | Displayed on the attempt of logging in. The limit of online Customers for a given license has been reached. 
+| `unsupported_version`             | Unsupported version               | Unsupported protocol version.                                                                               
+| `validation`                      | Wrong format of request           |                                                                                                             
+| `wrong_product_version`           | Wrong product version             | License is not LiveChat 3 (probably still LiveChat&nbsp;2).                                                      
 
+</Text>
+
+</Section>
 
 # Contact us
 
 If you found a bug or a typo, you can let us know directly on GitHub.
 In case of any questions or feedback, don't hesitate to contact us at [developers@livechatinc.com](mailto:developers@livechatinc.com). We'll be happy to hear from you!
+

--- a/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
@@ -3760,7 +3760,7 @@ Informs that a Customer was disconnected. The payload contains the reason of Cus
 | `customer_banned`                    | Customer has been banned.                                                                                                            
 | `customer_temporarily_blocked`**\*** | Customer tried reconnecting too many times after the `too_many_connections` error had occurred.                                         
 | `inactivity_timeout`                 | Customer didn't chat or change the page in the past 30 minutes.                                                                      
-| `internal_error`                     | Internal error                                                                                                                       
+| `internal`                           | Internal error                                                                                                                       
 | `license_not_found`                  | The license with the specified ID doesn't exist.                                                                                     
 | `misdirected_connection` **\*\***    | Customer connected to a server in the wrong region.                                                                                  
 | `product_version_changed`            | The product version has changed.                                                                                                     
@@ -3769,10 +3769,11 @@ Informs that a Customer was disconnected. The payload contains the reason of Cus
 | `unsupported_version`                | Connecting to an unsupported version of the Customer Chat API.                                                                       
 
 **\*)**
-The `misdirected_connection` reason can also return the correct region in an optional data object. With this piece of information, client is able to figure out where it should be connected.
+The `customer_temporarily_blocked` reason can also return the correct timeout in an optional data object. With this piece of information, client is able to figure out how much time a customer should wait before attempting to reconnect again.
 
 **\*\*)**
-The `customer_temporarily_blocked` reason can also return the correct timeout in an optional data object. With this piece of information, client is able to figure out how much time a customer should wait before attempting to reconnect again.
+The `misdirected_connection` reason can also return the correct region in an optional data object. With this piece of information, client is able to figure out where it should be connected.
+
 
 ## Other
 
@@ -3997,7 +3998,6 @@ Informs about a greeting rejected by the Customer. Also, the push is sent when a
 | `group_unavailable`               | No agent available for group      | Thrown in response to [Get Predicted Agent](#get-predicted-agent). The group is online, but there are no available Agents. 
 | `groups_offline`                  | Groups offline                    | 
 | `internal`                        | Internal server error             |                                                                                                             
-| `not_found`                       | Not found                         |    
 | `license_expired`                 | License expired                   | The end of license trial or subcription.                                                                    
 | `pending_requests_limit_reached`  | Requests limit reached            | The limit of pending requests within one websocket connection has been reached. The limit is 10.            
 | `request_timeout`                 | Request timed out                 | Timeout threshold is 15 seconds.                                                                            


### PR DESCRIPTION
- Added missing errors to Customer API (rtm&web, 3.1, 3.2)
- Changed errors formatting
- Updated the description of the `send_event` method - mentioned it's possible to chat without joining the chat. (Agent API, RTM & Web, 3.1, 3.2)
- Added a similar note to chat_user_added (Agent and Customer RTM 3.1, 3.2)