### PR TITLE
API-5201: Update changelog with new agent managing methods

### DIFF
--- a/content/management/changelog/index.mdx
+++ b/content/management/changelog/index.mdx
@@ -23,6 +23,7 @@ Since the migration is still ongoing, different parts will be successively moved
 - From now on, it's possible to define properties in [2 new locations](/management/configuration-api/v3.2/#property-locations): `license` and `group`.
 - There are 6 new methods: [**Set License Properties**](/management/configuration-api/v3.2/#set-license-properties), [**Get License Properties**](/management/configuration-api/v3.2/#get-license-properties), [**Delete License Properties**](/management/configuration-api/v3.2/#delete-license-properties), [**Set Group Properties**](/management/configuration-api/v3.2/#set-group-properties), [**Get Group Properties**](/management/configuration-api/v3.2/#get-group-properties), [**Delete Group Properties**](/management/configuration-api/v3.2/#delete-group-properties).
 - There's a new webhook: [`follow_up_requested`](/management/configuration-api/v3.2/#follow-up-requested).
+- New methods for managing agent resource: [**Get Agent**](/management/configuration-api/v3.2/#get-agent), [**Get Agents**](/management/configuration-api/v3.2/#get-agents), [**Update Agent**](/management/configuration-api/v3.2/#update-agent).
 
 ### Changed
 

--- a/content/management/configuration-api/v3.2/index.mdx
+++ b/content/management/configuration-api/v3.2/index.mdx
@@ -2486,6 +2486,216 @@ curl -X POST \
 
 </Section>
 
+# Agents
+
+Agent is instance of user that communicates with customers. Agent object consists of many fields, some of them are accessible by requester to view and modify, while some of them are just read-only.
+
+## Methods
+
+
+| HTTP method  | The Agents API endpoint |
+|-------|--------|
+| `POST`|`https://api.livechatinc.com/v3.2/configuration/action/<action>`   |
+
+
+| Required header   |      Value      |   |
+|----------|:-------------:|------:|
+| `Content-Type`	 |  `application/json`  |  |
+
+<Section>
+
+<Text>
+
+### Get Agent 
+
+
+#### Specifics
+
+|  |  |
+|-------|--------|
+| Method URL   | `https://api.livechatinc.com/v3.2/configuration/action/get_agent`  |
+| Required scopes| `agents--my:ro` `agents--all:ro` |
+
+#### Request
+
+| Request object                       | Type       | Required | Notes                                                                                                                  |
+| ------------------------------------ | ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `id`                                 | `string`   | Yes      | ID of agent                                                                                                            |
+| `fields`.__*__                       | `string[]` | No       | Filter out desired agent fields, get all fields if empty                                                               |
+
+
+__*__ The table below presents the possible values for the `fields[]` parameter:
+
+| Possible value | Notes         |
+| -------------  |:-------------:|
+| `email`        | Agent email  |
+| `job`          | Agent job title  |
+| `login_status` | Current agent login status  |
+
+</Text>
+
+<Code>
+
+<CodeSample path={'REQUEST'}>
+
+```shell
+curl -X POST \
+  https://api.livechatinc.com/v3.2/configuration/action/get_agent \
+  -H 'Authorization: Bearer <your_access_token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+      "id": "agent@domain.com",
+      "fields": [
+        "email",
+        "onboarding_completed"
+      ]
+      }'
+```
+
+</CodeSample>
+
+<CodeResponse>
+
+```json
+{
+    "email": "agent@domain.com",
+    "id": "agent@domain.com",
+    "onboarding_completed": "0"
+}
+```
+
+</CodeResponse>
+
+</Code>
+
+</Section>
+
+<Section>
+
+<Text>
+
+### Get Agents
+
+
+#### Specifics
+
+|  |  |
+|-------|--------|
+| Method URL   | `https://api.livechatinc.com/v3.2/configuration/action/get_agents`  |
+| Required scopes|  `agents--all:ro`  |
+
+#### Request
+
+| Parameter             | Required | Type       | Notes                                       |
+| --------------------- | -------- | ---------- | ------------------------------------------- |
+| `fields`              |  No      | `string[]` | Agent fields to filter out                  |
+| `group_ids`           |  No      | `int[]`    | Groups from which agents we want to receive |
+
+
+#### Response
+
+No response payload (`200 OK`).
+
+</Text>
+
+<Code>
+
+<CodeSample path={'REQUEST'}>
+
+```shell
+curl -X POST \
+  https://api.livechatinc.com/v3.2/configuration/action/remove_bot_agent \
+  -H 'Authorization: Bearer <your_access_token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "fields": [
+            "email",
+            "onboarding_completed"
+        ],
+        "group_ids": [
+            0,
+            1
+        ]
+    }'
+```
+
+</CodeSample>
+
+<CodeResponse>
+
+```json
+[
+    {
+        "email": "agent1@domain.com",
+        "id": "agent1@domain.com",
+        "onboarding_completed": "0"
+    },
+    {
+        "email": "agent2@domain.com",
+        "id": "agent2@domain.com",
+        "onboarding_completed": "1"
+    },
+]
+```
+
+</CodeResponse>
+
+</Code>
+
+</Section>
+
+<Section>
+
+<Text>
+
+### Update Agent
+
+#### Specifics
+
+|  |  |
+|-------|--------|
+| Method URL     | `https://api.livechatinc.com/v3.2/configuration/action/update`  |
+| Required scopes| `agents--my:rw` `agents--all:rw` (to update other Agents within the same license) |
+
+#### Request
+
+| Parameter                            | Required | Data type | Notes                                                                                                                   |
+| ------------------------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `id`                                 | Yes      | `string`  | Agent ID                                                                                                                |
+| `nick`                               | No       | `string`  | Agent nickname                                                                                                          |
+| `job`                                | No       | `string`  | Agent job title                                                                                                         |
+| `name`                               | No       | `string`  | Display name                                                                                                            |
+| `mobile`                             | No       | `string`  | Agent mobile phone number                                                                                               |
+
+
+#### Response
+
+No response payload (`200 OK`).
+
+</Text>
+
+<Code>
+
+<CodeSample path={'REQUEST'}>
+
+
+```shell
+curl -X POST \
+  https://api.livechatinc.com/v3.0/configuration/action/update_bot_agent \
+  -H 'Authorization: Bearer <your_access_token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+          "id": "agent1@domain.com",
+          "mobile": "+48 123 456 789"
+      }'
+```
+
+</CodeSample>
+
+</Code>
+
+</Section>
+
 # Contact us
 
 If you found a bug or a typo, you can let us know directly on GitHub. In case of any questions or feedback, don't hesitate to contact us at [developers@livechatinc.com] (mailto:developers@livechatinc.com). We'll be happy to hear from you!

--- a/content/management/configuration-api/v3.2/index.mdx
+++ b/content/management/configuration-api/v3.2/index.mdx
@@ -2586,11 +2586,12 @@ curl -X POST \
 
 #### Request
 
-| Parameter             | Required | Type       | Notes                                       |
-| --------------------- | -------- | ---------- | ------------------------------------------- |
-| `fields`              |  No      | `string[]` | Agent fields to filter out                  |
-| `group_ids`           |  No      | `int[]`    | Groups from which agents we want to receive |
+| Parameter             | Required | Type       | Notes                                                                                     |
+| --------------------- | -------- | ---------- | ----------------------------------------------------------------------------------------- |
+| `fields`              |  No      | `string[]` | Agent fields to filter out (May contain up to 5 elements when provided with `group_ids`)  |
+| `group_ids`           |  No      | `int[]`    | Groups from which agents we want to receive (when provided `fields` are required)         |
 
+If `group_ids` are provided then also `fields` is mandatory and could not exceed 5 elements.
 
 #### Response
 
@@ -2604,7 +2605,7 @@ No response payload (`200 OK`).
 
 ```shell
 curl -X POST \
-  https://api.livechatinc.com/v3.2/configuration/action/remove_bot_agent \
+  https://api.livechatinc.com/v3.2/configuration/action/get_agents \
   -H 'Authorization: Bearer <your_access_token>' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -2654,7 +2655,7 @@ curl -X POST \
 
 |  |  |
 |-------|--------|
-| Method URL     | `https://api.livechatinc.com/v3.2/configuration/action/update`  |
+| Method URL     | `https://api.livechatinc.com/v3.2/configuration/action/update_agent`  |
 | Required scopes| `agents--my:rw` `agents--all:rw` (to update other Agents within the same license) |
 
 #### Request
@@ -2681,7 +2682,7 @@ No response payload (`200 OK`).
 
 ```shell
 curl -X POST \
-  https://api.livechatinc.com/v3.0/configuration/action/update_bot_agent \
+  https://api.livechatinc.com/v3.0/configuration/action/update_agent \
   -H 'Authorization: Bearer <your_access_token>' \
   -H 'Content-Type: application/json' \
   -d '{


### PR DESCRIPTION
Proposal of interfaces:

Get Agent resource
- Get agent for given agent ID
Action: `get_agent`
Scope: `agents--my:ro`/`agents--all:ro`
Request payload:
`id` - required
`fields` - if provided at least one argument required otherwise all fields visible for the user will be returned.
```
{
    "id": {agent_id}
    "fields": [
        "{agent_field_name}",
        ...
    ]
}
```
Response:
```
{
    "{field_name}": "{field_value}",
    ...
}
```
Get Agent resource
- Get all agents from the license
Action: `get_agents`
Scope: `agents--my:rw`
Request payload:
`fields` - if provided at least one argument required otherwise all fields visible for the user will be returned.
`group_ids` - has to be present if `fields` are provided also when `group_ids` is provided `fields` can't exceed 5 elements.
```
{
    "fields": [
        "{agent_field_name}",
        ...
    ],
    "group_ids": [
        "{group_id}",
        ...
]
}
```
Response:
```
[
    {
        "id": {agent_id},
        "property_name": "property_value",
        ....
    },
    ...
]
```
Update Agent resource
- Updates agent with given parameters
Action: `update_agent`
Scopes: `agents--my:rw`/`agents--all:rw`
Request payload:
`id` - required
`fields` - at least one required
```
{
    "id": {agent_id},
        "{agent_field_name}": "{agent_field_value}",
        ...
}
```
Response:
```
{}
```