### PR TITLE
Fix scopes & open chat widget

### DIFF
--- a/content/getting-started/installing-livechat/ios-widget/index.mdx
+++ b/content/getting-started/installing-livechat/ios-widget/index.mdx
@@ -6,7 +6,7 @@ title: "LiveChat for iOS"
 tagline: "Embed LiveChat in your iOS app."
 desc: "Learn how to embed LiveChat in your iOS app. Let your users contact agents directly from the mobile application.."
 ---
-import { openChatWindow } from '../../../utils/index'
+import { openChatWindow } from "utils/index";
 
 # Introduction
 

--- a/content/getting-started/installing-livechat/ios-widget/index.mdx
+++ b/content/getting-started/installing-livechat/ios-widget/index.mdx
@@ -142,7 +142,7 @@ Sample apps can be found in the `Examples` folder. Samples for both Swift and Ob
 
 ## Getting help
 
-If you have any questions or want to provide feedback, <a href="#" onClick={openChatWindow}>chat with us!</a>
+If you have any questions or want to provide feedback, <a href="#open-chat" onClick={openChatWindow}>chat with us!</a>
 
 ## License
 

--- a/content/getting-started/installing-livechat/ios-widget/index.mdx
+++ b/content/getting-started/installing-livechat/ios-widget/index.mdx
@@ -6,6 +6,7 @@ title: "LiveChat for iOS"
 tagline: "Embed LiveChat in your iOS app."
 desc: "Learn how to embed LiveChat in your iOS app. Let your users contact agents directly from the mobile application.."
 ---
+import { openChatWindow } from '../../../utils/index'
 
 # Introduction
 
@@ -141,7 +142,7 @@ Sample apps can be found in the `Examples` folder. Samples for both Swift and Ob
 
 ## Getting help
 
-If you have any questions or want to provide feedback, [chat with us!](https://secure-lc.livechatinc.com/licence/8413431/open_chat.cgi)
+If you have any questions or want to provide feedback, <a href="#" onClick={openChatWindow}>chat with us!</a>
 
 ## License
 

--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -112,14 +112,14 @@ The table shows scopes dependency of accessing chat parts:
 
 | Scope                           | role          | Description                                                                                                                                                                           |
 | ------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `chats--all:ro`                 | normal        | Read permission for conversation and meta data of all license chats                                                                                                                   |
+| `chats--all:ro`                 | administrator | Read permission for conversation and meta data of all license chats                                                                                                                   |
 | `chats--access:ro`              | normal        | Read permission for conversation and meta data of chats with requester access                                                                                                         |
 | `chats--my:ro`                  | normal        | Read permission for conversation and meta data of the chats with requester presence                                                                                                   |
-| `chats.conversation--all:rw`    | normal        | Write permission for conversation data of all license chats and Read permission for conversation and meta data of all license chats (`chats--all:ro`)                                 |
+| `chats.conversation--all:rw`    | administrator | Write permission for conversation data of all license chats and Read permission for conversation and meta data of all license chats (`chats--all:ro`)                                 |
 | `chats.conversation--access:rw` | normal        | Write permission for conversation data of chats with requester access and Read permission for conversation and meta data of chats with requester access (`chats--access:ro`)          |
 | `chats.conversation--my:rw`     | normal        | Read/write permission for conversation data of chats with requester presence and Read permission for conversation and meta data of the chats with requester presence (`chats--my:ro`) |
 | `chats--all:rw`                 | administrator | Read/write permission for conversation and meta data of all license chats                                                                                                             |
-| `chats--access:rw`              | administrator | Read/write permission for conversation and meta data of chats with requester access                                                                                                   |
+| `chats--access:rw`              | normal        | Read/write permission for conversation and meta data of chats with requester access                                                                                                   |
 | `chats--my:rw`                  | normal        | Read/write permission for conversation and meta data of chats with requester presence                                                                                                 |
 
 - chats conversation data applies to:

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -134,14 +134,14 @@ The table shows scopes dependency of accessing chat parts:
 
 | Scope                           | role          | Description                                                                                                                                                                           |
 | ------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `chats--all:ro`                 | normal        | Read permission for conversation and meta data of all license chats                                                                                                                   |
+| `chats--all:ro`                 | administrator | Read permission for conversation and meta data of all license chats                                                                                                                   |
 | `chats--access:ro`              | normal        | Read permission for conversation and meta data of chats with requester access                                                                                                         |
 | `chats--my:ro`                  | normal        | Read permission for conversation and meta data of the chats with requester presence                                                                                                   |
-| `chats.conversation--all:rw`    | normal        | Write permission for conversation data of all license chats and Read permission for conversation and meta data of all license chats (`chats--all:ro`)                                 |
+| `chats.conversation--all:rw`    | administrator | Write permission for conversation data of all license chats and Read permission for conversation and meta data of all license chats (`chats--all:ro`)                                 |
 | `chats.conversation--access:rw` | normal        | Write permission for conversation data of chats with requester access and Read permission for conversation and meta data of chats with requester access (`chats--access:ro`)          |
 | `chats.conversation--my:rw`     | normal        | Read/write permission for conversation data of chats with requester presence and Read permission for conversation and meta data of the chats with requester presence (`chats--my:ro`) |
 | `chats--all:rw`                 | administrator | Read/write permission for conversation and meta data of all license chats                                                                                                             |
-| `chats--access:rw`              | administrator | Read/write permission for conversation and meta data of chats with requester access                                                                                                   |
+| `chats--access:rw`              | normal        | Read/write permission for conversation and meta data of chats with requester access                                                                                                   |
 | `chats--my:rw`                  | normal        | Read/write permission for conversation and meta data of chats with requester presence                                                                                                 |
 
 - chats conversation data applies to:

--- a/content/messaging/agent-chat-api/v3.2/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/index.mdx
@@ -107,14 +107,14 @@ The table shows scopes dependency of accessing chat parts:
 
 | Scope                           | role          | Description                                                                                                                                                                           |
 | ------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `chats--all:ro`                 | normal        | Read permission for conversation and meta data of all license chats                                                                                                                   |
+| `chats--all:ro`                 | administrator | Read permission for conversation and meta data of all license chats                                                                                                                   |
 | `chats--access:ro`              | normal        | Read permission for conversation and meta data of chats with requester access                                                                                                         |
 | `chats--my:ro`                  | normal        | Read permission for conversation and meta data of the chats with requester presence                                                                                                   |
-| `chats.conversation--all:rw`    | normal        | Write permission for conversation data of all license chats and Read permission for conversation and meta data of all license chats (`chats--all:ro`)                                 |
+| `chats.conversation--all:rw`    | administrator | Write permission for conversation data of all license chats and Read permission for conversation and meta data of all license chats (`chats--all:ro`)                                 |
 | `chats.conversation--access:rw` | normal        | Write permission for conversation data of chats with requester access and Read permission for conversation and meta data of chats with requester access (`chats--access:ro`)          |
 | `chats.conversation--my:rw`     | normal        | Read/write permission for conversation data of chats with requester presence and Read permission for conversation and meta data of the chats with requester presence (`chats--my:ro`) |
 | `chats--all:rw`                 | administrator | Read/write permission for conversation and meta data of all license chats                                                                                                             |
-| `chats--access:rw`              | administrator | Read/write permission for conversation and meta data of chats with requester access                                                                                                   |
+| `chats--access:rw`              | normal        | Read/write permission for conversation and meta data of chats with requester access                                                                                                   |
 | `chats--my:rw`                  | normal        | Read/write permission for conversation and meta data of chats with requester presence                                                                                                 |
 
 - chats conversation data applies to:
@@ -1536,8 +1536,11 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 | `filters.agent_ids`                                   | No       | `array`   | Array of agent IDs                                                                        |
 | `filters.thread_ids`                                  | No       | `array`   | Array of thread IDs. Cannot be used with other filters or pagination; max array size: 20. |
 | `filters.group_ids`                                   | No       | `array`   | Array of group IDs. Max array size: 200                                                   |
-| `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     |                                                                                           |
-| `<filter_type>`                                       | No       | `any`     | **\***                                                                                    |
+| `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     |  **\* described below**                                                                   |
+| `filters.tags.<filter_type>`                          | No       | `any`     |                                                                                           |
+| `filters.sales.<filter_type>`                         | No       | `any`     |                                                                                           |
+| `filters.goals.<filter_type>`                         | No       | `any`     |                                                                                           |
+| `filters.surveys.<survey>`                            | No       | `array`   | **\*\*** **described below**                                                              |                                                                             
 | `pagination`                                          | No       | `object`  |                                                                                           |
 | `pagination.page`                                     | No       | `number`  | Default: 1, min: 1, max: 1000                                                             |
 | `pagination.limit`                                    | No       | `number`  | Default: 25, min: 0, max: 100                                                             |
@@ -1550,6 +1553,12 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 - `exclude_values` (`type[]` - array with specific type for property: `string`, `int` or `bool`)
 
 There's only one value allowed for a single property.
+
+**\*\*)**
+`<survey>` contains the following fields:
+
+- `type` (`string`) - allowed values: `pre_chat`, `post_chat`
+- `answer_id` (`string`)
 
 </Text>
 <Code>

--- a/content/messaging/agent-chat-api/v3.2/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/index.mdx
@@ -181,30 +181,30 @@ The **File** event informs about an uploaded file.
 
 ### Request
  
-| Field                                                 | Required | Data type | Notes                                                               |
-| ----------------------------------------------------- | -------- | --------- | ------------------------------------------------------------------: |
-| `custom_id`                                           | no       | `string`  |                                                                     |
-| `type`                                                | yes      | `string`  | `file`                                                              |
-| `recipients`                                          | yes      | `string`  | Possible values: `all` (default), `agents`                          |
-| `properties`                                          | no       | `object`  | [Properties](#properties)                                           |
-| `url`                                                 | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file).|
+| Field        | Required | Data type |                                                                                                                                     Notes |
+| ------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
+| `custom_id`  | no       | `string`  |                                                                                                                                           |
+| `type`       | yes      | `string`  |                                                                                                                                    `file` |
+| `recipients` | yes      | `string`  |                                                                                                Possible values: `all` (default), `agents` |
+| `properties` | no       | `object`  |                                                                                                                 [Properties](#properties) |
+| `url`        | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file). |
 
 ### Response
 
-| Field                               | Returned        | Notes                                                               |
-| ----------------------------------- | :-------------- | ------------------------------------------------------------------: |
-| `id`                                | always          |                                                                     |
-| `custom_id`                         | optionally      |                                                                     |
-| `created_at`                        | always          | Date & time format with a resolution of microseconds, `UTC string`. |
-| `type`                              | always          |                                                                     |
-| `author_id`                         | always          |                                                                     |
-| `recipients`                        | always          |                                                                     |
-| `properties`                        | optionally      |                                                                     |
-| `name`                              | always          |                                                                     |
-| `url`                               | always          |                                                                     |
-| `thumbnail_url`, `thumbnail2x_url`  | only for images |                                                                     |
-| `content_type`                      | always          |                                                                     |
-| `size`, `width`, `height`           | only for images |                                                                     |
+| Field                              | Returned        |                                                               Notes |
+| ---------------------------------- | :-------------- | ------------------------------------------------------------------: |
+| `id`                               | always          |                                                                     |
+| `custom_id`                        | optionally      |                                                                     |
+| `created_at`                       | always          | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`                             | always          |                                                                     |
+| `author_id`                        | always          |                                                                     |
+| `recipients`                       | always          |                                                                     |
+| `properties`                       | optionally      |                                                                     |
+| `name`                             | always          |                                                                     |
+| `url`                              | always          |                                                                     |
+| `thumbnail_url`, `thumbnail2x_url` | only for images |                                                                     |
+| `content_type`                     | always          |                                                                     |
+| `size`, `width`, `height`          | only for images |                                                                     |
 
 </Text>
 <Code>
@@ -245,28 +245,28 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 
 ### Request
 
-| Field                   | Required | Data type  |  Notes                                                                    |
-| ------------------------| -------- | -----------| ------------------------------------------------------------------------- |
-| `custom_id`             | no       | `string`   |                                                                           |
-| `type`                  | yes      | `string`   | `filled_form`                                                             |
-| `recipients`            | yes      | `string`   | Possible values: `all` (default), `agents`                                |
-| `properties`            | no       | `object`   | [Properties](#properties)                                                 |
-| `form_id`               | yes      | `string`   |                                                                           |
-| `fields`                | yes      | `array`    | The fields a form contains. See [form fields](#form-fields) for details.  |
+| Field        | Required | Data type | Notes                                                                    |
+| ------------ | -------- | --------- | ------------------------------------------------------------------------ |
+| `custom_id`  | no       | `string`  |                                                                          |
+| `type`       | yes      | `string`  | `filled_form`                                                            |
+| `recipients` | yes      | `string`  | Possible values: `all` (default), `agents`                               |
+| `properties` | no       | `object`  | [Properties](#properties)                                                |
+| `form_id`    | yes      | `string`  |                                                                          |
+| `fields`     | yes      | `array`   | The fields a form contains. See [form fields](#form-fields) for details. |
 
 ### Response
 
-| Field                   | Returned    | Notes |
-| ------------------------| ----------- | ----- |
-| `id`                    | always      |       |
-| `custom_id`             | optionally  |       |
-| `created_at`            | always      | Date & time format with a resolution of microseconds, `UTC string`. |
-| `type`                  | always      |       |
-| `author_id`             | always      |       |
-| `recipients`            | always      |       |
-| `properties`            | optionally  |       |
-| `form_id`               | always      |       |
-| `fields`                | always      | An array of [form fields](#form-fields) |
+| Field        | Returned   | Notes                                                               |
+| ------------ | ---------- | ------------------------------------------------------------------- |
+| `id`         | always     |                                                                     |
+| `custom_id`  | optionally |                                                                     |
+| `created_at` | always     | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`       | always     |                                                                     |
+| `author_id`  | always     |                                                                     |
+| `recipients` | always     |                                                                     |
+| `properties` | optionally |                                                                     |
+| `form_id`    | always     |                                                                     |
+| `fields`     | always     | An array of [form fields](#form-fields)                             |
 
 </Text>
 
@@ -340,38 +340,38 @@ The **Message** event contains text message to other chat users.
 
 ### Request
 
-| Field                 | Required| Data type | Notes                                                               |
-| --------------------- | ------- | --------- | ------------------------------------------------------------------  |
-| `custom_id`           | no      | `string`  |                                                                     |
-| `text`                | yes     | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
-| `type`                | yes     | `string`  | `message`                                                           |
-| `recipients`          | yes     | `string`  | Possible values: `all` (default), `agents`                          |
-| `properties`          | no      | `object`  | [Properties](#properties)                                           |
-| `postback`            | no      | `object`  | Indicates that the message event was generated in response to a rich message event. |
-| `postback.id`         | yes     | `string`  | ID of the postback from the rich message event.                     |
-| `postback.thread_id`  | yes     | `string`  | ID of the thread with the rich message event.                       |
-| `postback.event_id`   | yes     | `string`  | ID of the rich message event.                                       |
-| `postback.type`       | no      | `string`  | Should be used together with `postback.value`.                      |
-| `postback.value`      | no      | `string`  | Should be used together with `postback.type`.                       |
+| Field                | Required | Data type | Notes                                                                                                                         |
+| -------------------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `custom_id`          | no       | `string`  |                                                                                                                               |
+| `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
+| `type`               | yes      | `string`  | `message`                                                                                                                     |
+| `recipients`         | yes      | `string`  | Possible values: `all` (default), `agents`                                                                                    |
+| `properties`         | no       | `object`  | [Properties](#properties)                                                                                                     |
+| `postback`           | no       | `object`  | Indicates that the message event was generated in response to a rich message event.                                           |
+| `postback.id`        | yes      | `string`  | ID of the postback from the rich message event.                                                                               |
+| `postback.thread_id` | yes      | `string`  | ID of the thread with the rich message event.                                                                                 |
+| `postback.event_id`  | yes      | `string`  | ID of the rich message event.                                                                                                 |
+| `postback.type`      | no       | `string`  | Should be used together with `postback.value`.                                                                                |
+| `postback.value`     | no       | `string`  | Should be used together with `postback.type`.                                                                                 |
 
 ### Response
 
-| Field                   | Returned    | Notes                                                                 |
-| ------------------------| ----------- | ----------------------------------------------------------------------|
-| `id`                    | always      |                                                                       |
-| `custom_id`             | optionally  |                                                                       |
-| `created_at`            | always      | Date & time format with a resolution of microseconds, `UTC string`.   |
-| `type`                  | always      | `message`                                                             |
-| `author_id`             | always      |                                                                       |
-| `recipients`            | always      |                                                                       |
-| `text`                  | always      |                                                                       |
-| `postback`              | optionally  | Appears in a message only when triggered by a rich message.           |
-| `postback.id`           | optionally  |                                                                       |
-| `postback.thread_id`    | optionally  |                                                                       |
-| `postback.event_id`     | optionally  |                                                                       |
-| `postback.type`         | optionally  | Appears only if `postback.value` is present.                          |
-| `postback.value`        | optionally  | Appears only if `postback.type` is present.                           |
-| `properties`            | optionally  | [Properties](#properties)                                             |
+| Field                | Returned   | Notes                                                               |
+| -------------------- | ---------- | ------------------------------------------------------------------- |
+| `id`                 | always     |                                                                     |
+| `custom_id`          | optionally |                                                                     |
+| `created_at`         | always     | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`               | always     | `message`                                                           |
+| `author_id`          | always     |                                                                     |
+| `recipients`         | always     |                                                                     |
+| `text`               | always     |                                                                     |
+| `postback`           | optionally | Appears in a message only when triggered by a rich message.         |
+| `postback.id`        | optionally |                                                                     |
+| `postback.thread_id` | optionally |                                                                     |
+| `postback.event_id`  | optionally |                                                                     |
+| `postback.type`      | optionally | Appears only if `postback.value` is present.                        |
+| `postback.value`     | optionally | Appears only if `postback.type` is present.                         |
+| `properties`         | optionally | [Properties](#properties)                                           |
 
 </Text>
 <Code>
@@ -539,13 +539,13 @@ Custom event is an event with customizable payload.
 
 System message event is native system event sent in specific situations.
 
-| Field                 | Req./Opt. |                                                                                          Notes |
-| --------------------- | :-------: | ---------------------------------------------------------------------------------------------: |
-| `created_at`          | required  |                           Date & time format with a resolution of microseconds, `UTC string`.  |
-| `type`                | required  | `system_message`                                                                               |
-| `system_message_type` | required  |                                                                                                |
-| `custom_id`           | optional  |                                                                                                |
-| `recipients`          | optional  | It can be specified when sending system messages via the [**Send Event**](#send-event) method. Possible values: `all`, `agents`.|
+| Field                 | Req./Opt. |                                                                                                                            Notes |
+| --------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------: |
+| `created_at`          | required  |                                                              Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`                | required  |                                                                                                                 `system_message` |
+| `system_message_type` | required  |                                                                                                                                  |
+| `custom_id`           | optional  |                                                                                                                                  |
+| `recipients`          | optional  | It can be specified when sending system messages via the [**Send Event**](#send-event) method. Possible values: `all`, `agents`. |
 
 Here's the list of all system messages you might come across:
 
@@ -673,14 +673,14 @@ Here's the list of all system messages you might come across:
 
 ### `routing.assigned_deleted`
 
-|                                     Content                                     |                                                                        Generated when |
-| :-----------------------------------------------------------------------------: | ------------------------------------------------------------------------------------: |
+|                                      Content                                      |                                                                        Generated when |
+| :-------------------------------------------------------------------------------: | ------------------------------------------------------------------------------------: |
 | _Chat assigned to %agent_added% because %agent_removed% account had been deleted_ | Chat was assigned to a new Agent after the previous one was removed from the license. |
 
 ### `routing.assigned_disconnected`
 
-|                                       Content                                       |                                                                        Generated when |
-| :---------------------------------------------------------------------------------: | ------------------------------------------------------------------------------------: |
+|                                        Content                                        |                                                                        Generated when |
+| :-----------------------------------------------------------------------------------: | ------------------------------------------------------------------------------------: |
 | _Chat assigned to %agent_added% because %agent_removed% had lost internet connection_ | Chat was assigned to a new Agent after the previous one unexpectedly lost connection. |
 
 ### `routing.assigned_inactive`
@@ -697,14 +697,14 @@ Here's the list of all system messages you might come across:
 
 ### `routing.assigned_remotely_signed_out`
 
-|                                       Content                                       |                                                          Generated when |
-| :---------------------------------------------------------------------------------: | ----------------------------------------------------------------------: |
+|                                        Content                                        |                                                          Generated when |
+| :-----------------------------------------------------------------------------------: | ----------------------------------------------------------------------: |
 | _Chat assigned to %agent_added% because %agent_removed% had been remotely signed out_ | Chat was assigned to a new Agent after the previous one was logged out. |
 
 ### `routing.assigned_signed_out`
 
-|                                Content                                |                                                      Generated when |
-| :-------------------------------------------------------------------: | ------------------------------------------------------------------: |
+|                                 Content                                 |                                                      Generated when |
+| :---------------------------------------------------------------------: | ------------------------------------------------------------------: |
 | _Chat assigned to %agent_added% because %agent_removed% had signed out_ | Chat was assigned to a new Agent after the previous one logged out. |
 
 ### `routing.idle`
@@ -900,7 +900,7 @@ Here's the list of all system messages you might come across:
 | `email`                          | optional  |                                           |
 | `fields`                         | optional  | Is not present when the chat is archived. |
 | `name`                           | optional  |                                           |
-| `events_seen_up_to`              | optional  | RFC 3339 datetime string                  |
+| `events_seen_up_to`              | optional  |                  RFC 3339 datetime string |
 | `last_visit`                     | optional  |                                           |
 | `present`                        | optional  |                                           |
 | `statistics`                     | optional  |                                           |
@@ -970,10 +970,10 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
 
 </CodeResponse>
 
-| Field        | Req./Opt. |     |
-| ------------ | :-------: | --: |
-| `properties` | optional  |     |
-| `access`     | optional  |     |
+| Field        | Req./Opt. |      |
+| ------------ | :-------: | ---: |
+| `properties` | optional  |      |
+| `access`     | optional  |      |
 
 ## Chat summaries
 
@@ -1035,60 +1035,60 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
 
 A component of the [Filled form](#filled-form) event.
 
-| Field                   | Required | Data type               |  Notes                                                                                                   |
-| ------------------------| -------- | ----------------------- | -------------------------------------------------------------------------------------------------------: |
-| `fields`                | yes      | `array of objects`      | The fields a form contains.                                                                              |
-| `type`                  | yes      | `string`                | Possible values: `checkbox`, `email`, `name`, `question`, `textarea`, `group_chooser`, `radio`, `select` |
-| `id`                    | yes      | `string`                | Field id, for all field types                                                                            |
-| `label`                 | yes      | `string`                | Field label; for all field types                                                                         |
-| `answer`                | yes      | `any`                   | For all field types                                                                                      |
-| `answer.id`             | yes      | `string`                | An identifier of each option a Customer can choose. For all field types.                           |
-| `answer.label`          | yes      | `string`                | Answer label; for all field types                                                                        |
-| `answer.group_id`       | yes      | `number`                | For `group_chooser`                                                                                      |
+| Field             | Required | Data type          |                                                                                                    Notes |
+| ----------------- | -------- | ------------------ | -------------------------------------------------------------------------------------------------------: |
+| `fields`          | yes      | `array of objects` |                                                                              The fields a form contains. |
+| `type`            | yes      | `string`           | Possible values: `checkbox`, `email`, `name`, `question`, `textarea`, `group_chooser`, `radio`, `select` |
+| `id`              | yes      | `string`           |                                                                            Field id, for all field types |
+| `label`           | yes      | `string`           |                                                                         Field label; for all field types |
+| `answer`          | yes      | `any`              |                                                                                      For all field types |
+| `answer.id`       | yes      | `string`           |                                 An identifier of each option a Customer can choose. For all field types. |
+| `answer.label`    | yes      | `string`           |                                                                        Answer label; for all field types |
+| `answer.group_id` | yes      | `number`           |                                                                                      For `group_chooser` |
 
 <CodeResponse>
 
 ```json
 {
-	"fields": [{
-		"type": "name",
-		"id": "154417206262603539",
-		"label": "Your name",
-		"answer": "John Doe"
-	}, {
-		"type": "email",
-		"id": "154417206262601584",
-		"label": "Your email",
-		"answer": "customer1@example.com"
-	}, {
-		"type": "radio",
-		"id": "154417206262602571",
-		"label": "Chat purpose",
-		"answer": {
-				"id": "0",
-				"label": "Support"
-		}
-	}, {
-		"type": "checkbox",
-		"id": "154417206262604640",
-		"label": "Company industry",
-		"answers": [{
-			"id": "0"
-			"label": "automotive"
-		}, {
-			"id": "1"
-			"label": "it"
-		}]
-	}, {
-		"type": "group_chooser",
-		"id": "154417206262605324",
-		"label": "Choose department",
-		"answer": {
-            "id": 2,
-            "group_id": 1,
-            "label": "Marketing"
-		    }
-	}]
+  "fields": [{
+    "type": "name",
+    "id": "154417206262603539",
+    "label": "Your name",
+    "answer": "John Doe"
+  }, {
+    "type": "email",
+    "id": "154417206262601584",
+    "label": "Your email",
+    "answer": "customer1@example.com"
+  }, {
+    "type": "radio",
+    "id": "154417206262602571",
+    "label": "Chat purpose",
+    "answer": {
+      "id": "0",
+      "label": "Support"
+    }
+  }, {
+    "type": "checkbox",
+    "id": "154417206262604640",
+    "label": "Company industry",
+    "answers": [{
+      "id": "0",
+      "label": "automotive"
+    }, {
+      "id": "1",
+      "label": "it"
+    }]
+  }, {
+    "type": "group_chooser",
+    "id": "154417206262605324",
+    "label": "Choose department",
+    "answer": {
+      "id": 2,
+      "group_id": 1,
+      "label": "Marketing"
+      }
+  }]
 }
 ```
 
@@ -1157,7 +1157,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | ----------- | -------------------------------------------------------- |
 | `POST`      | `https://api.livechatinc.com/v3.2/agent/action/<action>` |
 
-If you specify the API version in the URL, you don't have to include the optional `"X-API-Version: 3.1"` header.
+If you specify the API version in the URL, you don't have to include the optional `"X-API-Version: 3.2"` header.
 
 | Reqiured Header |                   Value                    |                                          Notes |
 | --------------- | :----------------------------------------: | ---------------------------------------------: |
@@ -1223,7 +1223,7 @@ It returns [summaries](#chat-summaries) of the chats an Agent has access to.
 | `filters.group_ids`                                   | No       | `array`  | Array of group IDs. Max array size: 200                                                     |
 | `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`    |                                                                                             |
 | `order`                                               | No       | `string` | Possible values: `asc` - oldest chats firstm `desc` - newest chats first (default)          |
-| `limit`                                               | No       | `number` | Default: 10, maximum: 100                                                                    |
+| `limit`                                               | No       | `number` | Default: 10, maximum: 100                                                                   |
 | `page_id`                                             | No       | `string` |                                                                                             |
 
 `filter_type` can take the following values:
@@ -1344,16 +1344,16 @@ curl -X POST \
 | --------- | -------- | --------- | -------------------------------------------------------------------------------------- |
 | `chat_id` | Yes      | `string`  |                                                                                        |
 | `order`   | No       | `string`  | Possible values: `asc` - oldest chats first and `desc` - newest chats first (default). |
-| `limit`   | No       | `number`  | Default: 10, maximum: 100                                                               |
+| `limit`   | No       | `number`  | Default: 10, maximum: 100                                                              |
 | `page_id` | No       | `string`  |                                                                                        |
 
 #### Response
 
-| Parameter       | Data type | Notes                       |
-| --------------- | --------- | --------------------------- |
-| `found_threads` | `number`  | Number of threads in a chat |
-| `next_page_id`    | `string`  | In relation to `page_id` specified in the request. |
-| `previous_page_id`| `string`  | In relation to `page_id` specified in the request. |
+| Parameter          | Data type | Notes                                              |
+| ------------------ | --------- | -------------------------------------------------- |
+| `found_threads`    | `number`  | Number of threads in a chat                        |
+| `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
+| `previous_page_id` | `string`  | In relation to `page_id` specified in the request. |
 
 </Text>
 <Code>
@@ -1536,11 +1536,11 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 | `filters.agent_ids`                                   | No       | `array`   | Array of agent IDs                                                                        |
 | `filters.thread_ids`                                  | No       | `array`   | Array of thread IDs. Cannot be used with other filters or pagination; max array size: 20. |
 | `filters.group_ids`                                   | No       | `array`   | Array of group IDs. Max array size: 200                                                   |
-| `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     |  **\* described below**                                                                   |
+| `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     | **\* described below**                                                                    |
 | `filters.tags.<filter_type>`                          | No       | `any`     |                                                                                           |
 | `filters.sales.<filter_type>`                         | No       | `any`     |                                                                                           |
 | `filters.goals.<filter_type>`                         | No       | `any`     |                                                                                           |
-| `filters.surveys.<survey>`                            | No       | `array`   | **\*\*** **described below**                                                              |                                                                             
+| `filters.surveys.<survey>`                            | No       | `array`   | **\*\*** **described below**                                                              |
 | `pagination`                                          | No       | `object`  |                                                                                           |
 | `pagination.page`                                     | No       | `number`  | Default: 1, min: 1, max: 1000                                                             |
 | `pagination.limit`                                    | No       | `number`  | Default: 25, min: 0, max: 100                                                             |
@@ -1676,18 +1676,18 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Request
 
-| Parameters               | Required | Data type | Notes                                                                       |
-| ------------------------ | -------- | --------- | --------------------------------------------------------------------------- |
-| `chat`                   | No       | `object`  |                                                                             |
-| `chat.properties`        | No       | `object`  |                                                                             |
-| `chat.access`            | No       | `object`  |                                                                             |
+| Parameters               | Required | Data type  | Notes                                                                                                    |
+| ------------------------ | -------- | ---------- | -------------------------------------------------------------------------------------------------------- |
+| `chat`                   | No       | `object`   |                                                                                                          |
+| `chat.properties`        | No       | `object`   |                                                                                                          |
+| `chat.access`            | No       | `object`   |                                                                                                          |
 | `chat.users`             | No       | `[]object` | The list of existing users. Up to 4 additional (other than the requester) agents and 1 customer allowed. |
-| `chat.users.id`          | Yes      | `string`  | User ID                                                                    |
-| `chat.users.type`        | Yes      | `string`  | `agent` or `customer`                                                       |
-| `chat.thread`            | No       | `object`  |                                                                             |
-| `chat.thread.events`     | No       | `array`   | The list of initial chat events.                                            |
-| `chat.thread.properties` | No       | `object`  |                                                                             |
-| `continuous`             | No       | `bool`    | Starts chat as continuous (online group is not required); default: `false`. |
+| `chat.users.id`          | Yes      | `string`   | User ID                                                                                                  |
+| `chat.users.type`        | Yes      | `string`   | `agent` or `customer`                                                                                    |
+| `chat.thread`            | No       | `object`   |                                                                                                          |
+| `chat.thread.events`     | No       | `array`    | The list of initial chat events.                                                                         |
+| `chat.thread.properties` | No       | `object`   |                                                                                                          |
+| `continuous`             | No       | `bool`     | Starts chat as continuous (online group is not required); default: `false`.                              |
 
 #### Response
 
@@ -1748,19 +1748,19 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Request
 
-| Parameter                | Required | Data type | Notes                                                                      |
-| ------------------------ | -------- | --------- | -------------------------------------------------------------------------- |
-| `chat`                   | Yes      | `object`  |                                                                            |
-| `chat.id`                | Yes      | `string`  | ID of the chat that will be activated.                                     |
-| `chat.access`            | No       | `object`  | Chat access to set, default: all agents.                                   |
-| `chat.properties`        | No       | `object`  | Initial chat properties                                                    |
-| `chat.users`             | No       | `[]object`| The list of existing users. Up to 4 additional (other than the requester) agents and 1 customer allowed. |
-| `chat.users.id`          | Yes      | `string`  | User ID                                                                   |
-| `chat.users.type`        | Yes      | `string`  | `agent` or `customer`                                                      |
-| `chat.thread`            | No       | `object`  |                                                                            |
-| `chat.thread.events`     | No       | `array`   | Initial chat events array                                                  |
-| `chat.thread.properties` | No       | `object`  | Initial chat thread properties                                             |
-| `continuous`             | No       | `bool`    | Sets a chat to the continuous mode. When unset, leaves the mode unchanged. |
+| Parameter                | Required | Data type  | Notes                                                                                                    |
+| ------------------------ | -------- | ---------- | -------------------------------------------------------------------------------------------------------- |
+| `chat`                   | Yes      | `object`   |                                                                                                          |
+| `chat.id`                | Yes      | `string`   | ID of the chat that will be activated.                                                                   |
+| `chat.access`            | No       | `object`   | Chat access to set, default: all agents.                                                                 |
+| `chat.properties`        | No       | `object`   | Initial chat properties                                                                                  |
+| `chat.users`             | No       | `[]object` | The list of existing users. Up to 4 additional (other than the requester) agents and 1 customer allowed. |
+| `chat.users.id`          | Yes      | `string`   | User ID                                                                                                  |
+| `chat.users.type`        | Yes      | `string`   | `agent` or `customer`                                                                                    |
+| `chat.thread`            | No       | `object`   |                                                                                                          |
+| `chat.thread.events`     | No       | `array`    | Initial chat events array                                                                                |
+| `chat.thread.properties` | No       | `object`   | Initial chat thread properties                                                                           |
+| `continuous`             | No       | `bool`     | Sets a chat to the continuous mode. When unset, leaves the mode unchanged.                               |
 
 #### Response
 
@@ -1851,12 +1851,12 @@ Marks a chat as followed. All changes to the chat will be sent to the requester 
 
 #### Specifics
 
-|                        |                                                              |
-| ---------------------- | -------------------------------------------------------------|
-| **Method URL**         | `https://api.livechatinc.com/v3.2/agent/action/follow_chat`  |
-| **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw`            |
-| **RTM API equivalent** | [`follow_chat`](rtm-reference/#follow-chat)                  |
-| **Webhook**            | -                                                            |
+|                        |                                                             |
+| ---------------------- | ----------------------------------------------------------- |
+| **Method URL**         | `https://api.livechatinc.com/v3.2/agent/action/follow_chat` |
+| **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw`           |
+| **RTM API equivalent** | [`follow_chat`](rtm-reference/#follow-chat)                 |
+| **Webhook**            | -                                                           |
 
 #### Request
 
@@ -2163,11 +2163,11 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 
 #### Request
 
-| Request object          | Required | Type     | Notes                                                                   |
-| ----------------------- | -------- | -------- | ----------------------------------------------------------------------- |
-| `chat_id`               | Yes      | `string` |                                                                         |
-| `user_id`               | Yes      | `string` |                                                                         |
-| `user_type`             | Yes      | `string` | Possible values: `agent` or `customer`                                  |
+| Request object          | Required | Type     | Notes                                                                                        |
+| ----------------------- | -------- | -------- | -------------------------------------------------------------------------------------------- |
+| `chat_id`               | Yes      | `string` |                                                                                              |
+| `user_id`               | Yes      | `string` |                                                                                              |
+| `user_type`             | Yes      | `string` | Possible values: `agent` or `customer`                                                       |
 | `require_active_thread` | No       | `bool`   | If `true`, it adds a user to a chat only if that chat has an active thread; default `false`. |
 
 #### Response
@@ -2256,12 +2256,12 @@ It's possible to write to a chat without joining it. The user sending an event w
 
 #### Specifics
 
-|                        |                                                                                          
-| ---------------------- | ---------------------------------------------------------------------------------------- 
-| **Method URL**         | `https://api.livechatinc.com/v3.2/agent/action/send_event`                               
-| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` 
-| **RTM API equivalent** | [`send_event`](rtm-reference/#send-event)                                                
-| **Webhook**            | [`incoming_event`](/management/configuration-api/#incoming_event)                        
+|                        |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| **Method URL**         | `https://api.livechatinc.com/v3.2/agent/action/send_event`                               |
+| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
+| **RTM API equivalent** | [`send_event`](rtm-reference/#send-event)                                                |
+| **Webhook**            | [`incoming_event`](/management/configuration-api/#incoming_event)                        |
 
 #### Request
 
@@ -3002,10 +3002,10 @@ Dates are represented in ISO 8601 format with microseconds resolution, e.g. `201
 
 #### Response
 
-| Parameter         | Data type | Notes                                              |
-| ----------------- | --------- | -------------------------------------------------- |
-| `next_page_id`    | `string`  | In relation to `page_id` specified in the request. |
-| `previous_page_id`| `string`  | In relation to `page_id` specified in the request. |
+| Parameter          | Data type | Notes                                              |
+| ------------------ | --------- | -------------------------------------------------- |
+| `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
+| `previous_page_id` | `string`  | In relation to `page_id` specified in the request. |
 
 </Text>
 <Code>
@@ -3205,19 +3205,19 @@ Changes the status of an Agent or a Bot Agent.
 
 #### Specifics
 
-|                        |                                                                           |
-| ---------------------- | ------------------------------------------------------------------------- |
-| **Method URL**         | `https://api.livechatinc.com/v3.2/agent/action/set_routing_status`        |
-| **Required scopes**    | for Agents: `agents--my:rw` `agents--all:rw`; for Bot Agents: `agents-bot--my:rw` `agents-bot--all:rw`|
-| **RTM API equivalent** | [`set_routing_status`](/messaging/agent-chat-api/v3.2/rtm-reference/#set-routing-status)                 |
-| **Webhook**            | [`routing_status_set`](/management/configuration-api/v3.2/#routing_status_set) |
+|                        |                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Method URL**         | `https://api.livechatinc.com/v3.2/agent/action/set_routing_status`                                     |
+| **Required scopes**    | for Agents: `agents--my:rw` `agents--all:rw`; for Bot Agents: `agents-bot--my:rw` `agents-bot--all:rw` |
+| **RTM API equivalent** | [`set_routing_status`](/messaging/agent-chat-api/v3.2/rtm-reference/#set-routing-status)               |
+| **Webhook**            | [`routing_status_set`](/management/configuration-api/v3.2/#routing_status_set)                         |
 
 #### Request
 
-| Parameter  | Required | Data type| Notes                                                            |
-| -----------| -------- | -------- | ---------------------------------------------------------------- |
-| `status`   |   Yes    | `string` | For Agents: `accepting_chats` or `not_accepting_chats`; for Bot Agents: `accepting_chats`, `not_accepting_chats`, or `offline` | 
-| `agent_id` |   No     | `string` | If not specified, the requester's status will be updated.        | 
+| Parameter  | Required | Data type | Notes                                                                                                                          |
+| ---------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `status`   | Yes      | `string`  | For Agents: `accepting_chats` or `not_accepting_chats`; for Bot Agents: `accepting_chats`, `not_accepting_chats`, or `offline` |
+| `agent_id` | No       | `string`  | If not specified, the requester's status will be updated.                                                                      |
 
 #### Response
 
@@ -3424,18 +3424,18 @@ It returns the Agents you can transfer a chat to. Agents are sorted ascendingly 
 
 #### Specifics
 
-|                        |                                                                        |
-| ---------------------- | ---------------------------------------------------------------------- |
-| **Method URL**         | `https://api.livechatinc.com/v3.2/agent/action/get_agents_for_transfer`|
-| **Required scopes**    | -                                                                      |
-| **RTM API equivalent** | [`get_agents_for_transfer`](rtm-reference/#get-agents-for-transfer)    |
-| **Webhook**            | -                                                                      |
+|                        |                                                                         |
+| ---------------------- | ----------------------------------------------------------------------- |
+| **Method URL**         | `https://api.livechatinc.com/v3.2/agent/action/get_agents_for_transfer` |
+| **Required scopes**    | -                                                                       |
+| **RTM API equivalent** | [`get_agents_for_transfer`](rtm-reference/#get-agents-for-transfer)     |
+| **Webhook**            | -                                                                       |
 
 #### Request
 
-| Parameter  | Required | Data type | Notes                                   |
-| ---------- | -------- | --------- | --------------------------------------- |
-| `chat_id`  | Yes      | `string`  | The ID of the chat you want to transfer |
+| Parameter | Required | Data type | Notes                                   |
+| --------- | -------- | --------- | --------------------------------------- |
+| `chat_id` | Yes      | `string`  | The ID of the chat you want to transfer |
 
 </Text>
 <Code>
@@ -3507,20 +3507,20 @@ You can create and manage webhooks via the [Configuration API](/management/confi
 
 #### Possible errors
 
-| Type                        | Default Message               | Notes                                                     
-| --------------------------- | ----------------------------- | --------------------------------------------------------- 
-| `authentication`            | Authentication error          | An invalid or expired access token.                       
-| `authorization`             | Authorization error           | User is not allowed to perform the action.                
-| `entity_too_large`          | Upload limit exceeded (10MB). | Client's request is too large.                            
-| `internal`                  | Internal server error         |                                                           
-| `license_expired`           | License expired               | The end of license trial or subcription.                  
-| `license_not_found`         | License not found             | License with the specified ID doesn't exist.              
-| `misdirected_request`**\*** | Wrong region                  | Client's request should be performed to another region.   
-| `request_timeout`           | Request timed out             | Timeout threshold is 15 seconds.                          
-| `unsupported_version`       | Unsupported version           | Unsupported protocol version.                             
-| `validation`                | Wrong format of request       |                                                           
-| `wrong_product_version`     | Wrong product version         | License is not LiveChat 3 (probably still LiveChat 2).    
-| `chat_inactive`             | No active chat thread         | An action that requires an active thread performed on a chat with no active threads. 
+| Type                        | Default Message               | Notes                                                                                |
+| --------------------------- | ----------------------------- | ------------------------------------------------------------------------------------ |
+| `authentication`            | Authentication error          | An invalid or expired access token.                                                  |
+| `authorization`             | Authorization error           | User is not allowed to perform the action.                                           |
+| `entity_too_large`          | Upload limit exceeded (10MB). | Client's request is too large.                                                       |
+| `internal`                  | Internal server error         |
+| `license_expired`           | License expired               | The end of license trial or subcription.                                             |
+| `license_not_found`         | License not found             | License with the specified ID doesn't exist.                                         |
+| `misdirected_request`**\*** | Wrong region                  | Client's request should be performed to another region.                              |
+| `request_timeout`           | Request timed out             | Timeout threshold is 15 seconds.                                                     |
+| `unsupported_version`       | Unsupported version           | Unsupported protocol version.                                                        |
+| `validation`                | Wrong format of request       |
+| `wrong_product_version`     | Wrong product version         | License is not LiveChat 3 (probably still LiveChat 2).                               |
+| `chat_inactive`             | No active chat thread         | An action that requires an active thread performed on a chat with no active threads. |
 
 \* `misdirected_request` error returns also correct `region` in optional `data` object.
 With this information client is able to figure out where he should be connected.

--- a/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
@@ -134,14 +134,14 @@ The table shows scopes dependency of accessing chat parts:
 
 | Scope                           | role          | Description                                                                                                                                                                           |
 | ------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `chats--all:ro`                 | normal        | Read permission for conversation and meta data of all license chats                                                                                                                   |
+| `chats--all:ro`                 | administrator | Read permission for conversation and meta data of all license chats                                                                                                                   |
 | `chats--access:ro`              | normal        | Read permission for conversation and meta data of chats with requester access                                                                                                         |
 | `chats--my:ro`                  | normal        | Read permission for conversation and meta data of the chats with requester presence                                                                                                   |
-| `chats.conversation--all:rw`    | normal        | Write permission for conversation data of all license chats and Read permission for conversation and meta data of all license chats (`chats--all:ro`)                                 |
+| `chats.conversation--all:rw`    | administrator | Write permission for conversation data of all license chats and Read permission for conversation and meta data of all license chats (`chats--all:ro`)                                 |
 | `chats.conversation--access:rw` | normal        | Write permission for conversation data of chats with requester access and Read permission for conversation and meta data of chats with requester access (`chats--access:ro`)          |
 | `chats.conversation--my:rw`     | normal        | Read/write permission for conversation data of chats with requester presence and Read permission for conversation and meta data of the chats with requester presence (`chats--my:ro`) |
 | `chats--all:rw`                 | administrator | Read/write permission for conversation and meta data of all license chats                                                                                                             |
-| `chats--access:rw`              | administrator | Read/write permission for conversation and meta data of chats with requester access                                                                                                   |
+| `chats--access:rw`              | normal        | Read/write permission for conversation and meta data of chats with requester access                                                                                                   |
 | `chats--my:rw`                  | normal        | Read/write permission for conversation and meta data of chats with requester presence                                                                                                 |
 
 - chats conversation data applies to:
@@ -1569,8 +1569,11 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 | `filters.agent_ids`                                   | No       | `array`   | Array of agent IDs                                                                        |
 | `filters.thread_ids`                                  | No       | `array`   | Array of thread IDs. Cannot be used with other filters or pagination; max array size: 20. |
 | `filters.group_ids`                                   | No       | `array`   | Array of group IDs. Max array size: 200                                                   |
-| `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     |                                                                                           |
-| `<filter_type>`                                       | No       | `any`     | **\***                                                                                    |
+| `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     | **\* described below**                                                                    |
+| `filters.tags.<filter_type>`                          | No       | `any`     |                                                                                           |
+| `filters.sales.<filter_type>`                         | No       | `any`     |                                                                                           |
+| `filters.goals.<filter_type>`                         | No       | `any`     |                                                                                           |
+| `filters.surveys.<survey>`                            | No       | `array`   | **\*\*** **described below**                                                              |   
 | `pagination`                                          | No       | `object`  |                                                                                           |
 | `pagination.page`                                     | No       | `number`  | Default: 1, min: 1, max: 1000                                                             |
 | `pagination.limit`                                    | No       | `number`  | Default: 25, min: 0, max: 100                                                             |
@@ -1583,6 +1586,12 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 - `exclude_values` (`type[]` - array with specific type for property: `string`, `int` or `bool`)
 
 There's only one value allowed for a single property.
+
+**\*\*)**
+`<survey>` contains the following fields:
+
+- `type` (`string`) - allowed values: `pre_chat`, `post_chat`
+- `answer_id` (`string`)
 
 </Text>
 <Code>

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -6,7 +6,8 @@ import { SCROLL_OFFSET } from "./src/constant";
 window.docsearch = docsearch;
 
 if (typeof window !== "undefined") {
-  require("smooth-scroll")('a[href*="#"]', {
+  // use #open-chat when adding openChatWindow to links, otherwise it'll scroll up upon click
+  require("smooth-scroll")('a[href*="#"]:not([href="#open-chat"])', {
     speed: 160,
     speedAsDuration: true,
     offset: SCROLL_OFFSET

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -32,7 +32,7 @@ export const setupDocsearch = () => {
     indexName: "livechatinc",
     inputSelector: "#search",
     debug: false,
-    handleSelected: function(input, event, suggestion, datasetNumber, context) {
+    handleSelected: function (input, event, suggestion, datasetNumber, context) {
       if (
         context.selectionMethod === "click" ||
         context.selectionMethod === "enterKey"
@@ -59,4 +59,10 @@ export const getVersionColor = (version, groupVersions) => {
   const isLegacy = version === groupVersions.LEGACY_VERSION;
 
   return isStable ? "67, 132, 245" : isLegacy ? "209, 52, 91" : "239, 168, 67";
+};
+
+export const openChatWindow = (e) => {
+  e.preventDefault()
+  const LC_API = window.LC_API || {}
+  LC_API.open_chat_window()
 };


### PR DESCRIPTION
- Fix in scopes (incorrect roles)
- Fix in Get Archives (`filters` param)
- Added opening of the chat widget when clicking a link in **Getting started > Installing LiveChat > LiveChat for iOS > Getting help**