### PR TITLE
Created_at in Thread data structure

### DIFF
--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -17,7 +17,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - There's a new method **Get Customer** ([Web](/messaging/agent-chat-api/v3.2/#get-customer) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#get-customer)) that returns info about a given Customer.
 - There's a new push [`chat_unfollowed`](/messaging/agent-chat-api/v3.2/rtm-reference/#chat_unfollowed) complementary to the **Unfollow Chat** method.
 - There's a new `include_chats_without_threads` filter in the  **List Chats** ([Web](/messaging/agent-chat-api/v3.2/#list-chats) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#list-chats)) method.
-- There's a new `agents` filter in the  **List Archives** ([Web](/messaging/agent-chat-api/v3.2/#list-archives) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#list-archives)) method. It replaces the `agents_ids` filter. 
+- There's a new `agents` filter in the  **List Archives** ([Web](/messaging/agent-chat-api/v3.2/#list-archives) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#list-archives)) method. It replaces the `agents_ids` filter.
 
 ### Changed
 
@@ -44,6 +44,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - `order` has been renamed to `sort_order` in **List Chats**, **Get Chat Threads Summary** and **List Customers**.
 - `scopes` in **Multicast** has been renamed to `recipients`.
 - There're new fields `previous_thread_id` and `next_thread_id` in the [**Thread**](/messaging/agent-chat-api/v3.2/#threads) data structure.
+- Fields `order` and `timestamp` in the [**Thread**](/messaging/agent-chat-api/v3.2/#threads) data structure were replaced with the new field, `created_at` (date & time in microseconds in UTC).
 
 ### Removed
 

--- a/content/messaging/agent-chat-api/v3.2/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/index.mdx
@@ -1209,15 +1209,16 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 
 </CodeResponse>
 
-| Field                | Req./Opt. | Note                                                                                 |
-| -------------------- | --------- | ------------------------------------------------------------------------------------ |
-| `access`             | optional  |                                                                                      |
-| `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active) |
-| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                     |
-| `properties`         | optional  |                                                                                      |
-| `restricted_access`  | optional  |                                                                                      |
-| `previous_thread_id` | optional  | Present only if there is a preceding thread.                                         |
-| `next_thread_id`     | optional  | Present only if there is a following thread.                                         |
+| Field                | Req./Opt. | Note                                                                                       |
+| -------------------- | --------- | ------------------------------------------------------------------------------------------ |
+| `access`             | optional  |                                                                                            |
+| `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active)       |
+| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
+| `properties`         | optional  |                                                                                            |
+| `restricted_access`  | optional  |                                                                                            |
+| `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
+| `next_thread_id`     | optional  | Present only if there is a following thread.                                               |
+| `created_at`         | required  | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
 
 <Section>
 <Text>

--- a/content/messaging/agent-chat-api/v3.2/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/index.mdx
@@ -1060,7 +1060,7 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
     // last event of each type in chat
     "message": {
       "thread_id": "K600PKZON8",
-      "thread_order": 3,
+      "thread_created_at": "2020-05-07T07:11:28.288340Z",
       "event": {
         // "restricted_access": true
         // or
@@ -1069,7 +1069,7 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
     },
     "system_message": {
       "thread_id": "K600PKZON6",
-      "thread_order": 1,
+      "thread_created_at": "2020-05-07T07:11:28.288340Z",
       "event": {
         // "restricted_access": true
         // or
@@ -1080,13 +1080,12 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
   },
   "last_thread_summary": {
     "id": "K600PKZON8",
-    "order": 3,
-    "timestamp": 1473433500,
     "user_ids": ["smith@example.com"],
     "properites": {
       // "Properites" object
     },
-    "tags": ["bug_report"]
+    "tags": ["bug_report"],
+    "created_at": "2020-05-07T07:11:28.288340Z"
   },
   "properites": {
     // "Properites" object
@@ -1190,14 +1189,12 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 ```json
 {
   "id": "K600PKZON8",
-  "timestamp": 1473433500,
   "active": true,
   "user_ids": ["smith@example.com"],
   "restricted_access": true,
   "events": [
     // array of "Event" objects
   ],
-  "order": 112057129857,
   "properties": {
     // "Properties" object
   },
@@ -1205,7 +1202,8 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
     // "Access" object
   },
   "previous_thread_id": "K600PKZOM8",
-  "next_thread_id": "K600PKZOO8"
+  "next_thread_id": "K600PKZOO8",
+  "created_at": "2020-05-07T07:11:28.288340Z"
 }
 ```
 
@@ -1362,19 +1360,18 @@ curl -X POST \
     }],
     "last_thread_summary": {
       "id": "K600PKZON8",
-      "timestamp": 1575892853,
       "user_ids": [
         "b7eff798-f8df-4364-8059-649c35c9ed0c",
         "smith@example.com"
       ],
-      "order": 1,
       "properties": {
         // "Properties" object
       },
       "active": true,
       "access": {
         "group_ids": [0]
-      }
+      },
+      "created_at": "2020-05-07T07:11:28.288340Z"
     },
     "properties": {
       // "Properties" object
@@ -1531,7 +1528,6 @@ curl -X POST \
     }],
     "threads": [{
       "id": "K600PKZON8",
-      "timestamp": 1576569422,
       "active": true,
       "user_ids": [
         "b7eff798-f8df-4364-8059-649c35c9ed0c",
@@ -1545,7 +1541,6 @@ curl -X POST \
         "text": "Hello",
         "author_id": "smith@example.com"
       }, ],
-      "order": 1,
       "properties": {
         // "Property" object
       },
@@ -1553,7 +1548,8 @@ curl -X POST \
         "group_ids": [0]
       },
       "previous_thread_id": "K600PKZOM8",
-      "next_thread_id": "K600PKZOO8"
+      "next_thread_id": "K600PKZOO8",
+      "created_at": "2020-05-07T07:11:28.288340Z"
     }],
     "properties": {
       // "Property" object
@@ -1663,7 +1659,6 @@ curl -X POST \
       }],
       "thread": {
         "id": "K600PKZON8",
-        "timestamp": 1575402961,
         "active": false,
         "user_ids": [
           "smith@example.com",
@@ -1679,7 +1674,6 @@ curl -X POST \
           }
           // "events": ...
         ],
-        "order": 1,
         "properties": {
           "0805e283233042b37f460ed8fbf22160": {
             "string_property": "string value"
@@ -1689,7 +1683,8 @@ curl -X POST \
           "group_ids": [0]
         },
         "previous_thread_id": "K600PKZOM8",
-        "next_thread_id": "K600PKZOO8"
+        "next_thread_id": "K600PKZOO8",
+        "created_at": "2020-05-07T07:11:28.288340Z"
       },
       "properties": {
         // "Properties" object

--- a/content/messaging/agent-chat-api/v3.2/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/index.mdx
@@ -1017,16 +1017,6 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
     // optional
     // "Thread" object
   ],
-  "threads_summary": [
-    {
-      "thread_id": "K600PKZON8",
-      "order": 129846129847
-    },
-    {
-      "thread_id": "K600PKZON8",
-      "order": 129846129848
-    }
-  ],
   "properites": {
     // "Properites" object
   },
@@ -1336,7 +1326,7 @@ curl -X POST \
     "last_event_per_type": {
       "message": {
         "thread_id": "K600PKZON8",
-        "thread_order": 1,
+        "thread_created_at": "2020-05-07T07:11:28.288340Z",
         "event": {
           "id": "Q298LUVPRH_1",
           "created_at": "2019-12-09T12:01:18.909000Z",
@@ -1348,7 +1338,7 @@ curl -X POST \
       },
       "system_message": {
         "thread_id": "K600PKZON8",
-        "thread_order": 1,
+        "thread_created_at": "2020-05-07T07:11:28.288340Z",
         "event": {
           // "System message" event
         }

--- a/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
@@ -1036,16 +1036,6 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
     // optional
     // "Thread" object
   ],
-  "threads_summary": [
-    {
-      "thread_id": "K600PKZON8",
-      "order": 129846129847
-    },
-    {
-      "thread_id": "K600PKZON8",
-      "order": 129846129848
-    }
-  ],
   "properites": {
     // "Properites" object
   },

--- a/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
@@ -1228,16 +1228,16 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 
 </CodeResponse>
 
-| Field                | Req./Opt. | Note                                                                                 |
-| -------------------- | --------- | ------------------------------------------------------------------------------------ |
-| `access`             | optional  |                                                                                      |
-| `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active) |
-| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                     |
-| `properties`         | optional  |                                                                                      |
-| `restricted_access`  | optional  |                                                                                      |
-| `previous_thread_id` | optional  | Present only if there is a preceding thread.                                         |
-| `next_thread_id`     | optional  | Present only if there is a following thread.                                         |
-| `created_at`         | required  |                                                                                      |
+| Field                | Req./Opt. | Note                                                                                       |
+| -------------------- | --------- | ------------------------------------------------------------------------------------------ |
+| `access`             | optional  |                                                                                            |
+| `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active)       |
+| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
+| `properties`         | optional  |                                                                                            |
+| `restricted_access`  | optional  |                                                                                            |
+| `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
+| `next_thread_id`     | optional  | Present only if there is a following thread.                                               |
+| `created_at`         | required  | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
 
 # Methods
 

--- a/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
@@ -1079,7 +1079,7 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
     // last event of each type in chat
     "message": {
       "thread_id": "K600PKZON8",
-      "thread_order": 3,
+      "thread_created_at": "2020-05-07T07:11:28.288340Z",
       "event": {
         // "restricted_access": true
         // or
@@ -1088,7 +1088,7 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
     },
     "system_message": {
       "thread_id": "K600PKZON6",
-      "thread_order": 1,
+      "thread_created_at": "2020-05-07T07:11:28.288340Z",
       "event": {
         // "restricted_access": true
         // or
@@ -1099,13 +1099,12 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
   },
   "last_thread_summary": {
     "id": "K600PKZON8",
-    "order": 3,
-    "timestamp": 1473433500,
     "user_ids": ["smith@example.com"],
     "properites": {
       // "Properites" object
     },
-    "tags": ["bug_report"]
+    "tags": ["bug_report"],
+    "created_at": "2020-05-07T07:11:28.288340Z"
   },
   "properites": {
     // "Properites" object
@@ -1209,14 +1208,12 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 ```json
 {
   "id": "K600PKZON8",
-  "timestamp": 1473433500,
   "active": true,
   "user_ids": ["smith@example.com"],
   "restricted_access": true,
   "events": [
     // array of "Event" objects
   ],
-  "order": 112057129857,
   "properties": {
     // "Properties" object
   },
@@ -1224,7 +1221,8 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
     // "Access" object
   },
   "previous_thread_id": "K600PKZOM8",
-  "next_thread_id": "K600PKZOO8"
+  "next_thread_id": "K600PKZOO8",
+  "created_at": "2020-05-07T07:11:28.288340Z"
 }
 ```
 
@@ -1239,6 +1237,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | `restricted_access`  | optional  |                                                                                      |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                         |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                         |
+| `created_at`         | required  |                                                                                      |
 
 # Methods
 
@@ -1371,7 +1370,7 @@ There's only one value allowed for a single property.
       "last_event_per_type": {
         "message": {
           "thread_id": "K600PKZON8",
-          "thread_order": 1,
+          "thread_created_at": "2020-05-07T07:11:28.288340Z",
           "event": {
             "id": "Q298LUVPRH_1",
             "created_at": "2019-12-09T12:01:18.909000Z",
@@ -1383,7 +1382,7 @@ There's only one value allowed for a single property.
         },
         "system_message": {
           "thread_id": "K600PKZON8",
-          "thread_order": 1,
+          "thread_created_at": "2020-05-07T07:11:28.288340Z",
           "event": {
             // "System message" event
           }
@@ -1396,19 +1395,18 @@ There's only one value allowed for a single property.
       }],
       "last_thread_summary": {
         "id": "K600PKZON8",
-        "timestamp": 1575892853,
         "user_ids": [
           "b7eff798-f8df-4364-8059-649c35c9ed0c",
           "smith@example.com"
         ],
-        "order": 1,
         "properties": {
           // "Properties" object
         },
         "active": true,
         "access": {
           "group_ids": [0]
-        }
+        },
+        "created_at": "2020-05-07T07:11:28.288340Z"
       },
       "properties": {
         // "Properties" object
@@ -1571,7 +1569,6 @@ It returns threads that the current Agent has access to in a given chat.
           "text": "Hello",
           "author_id": "smith@example.com"
         }],
-        "order": 1,
         "properties": {
           // "Property" object
         },
@@ -1579,7 +1576,8 @@ It returns threads that the current Agent has access to in a given chat.
           "group_ids": [0]
         },
         "previous_thread_id": "K600PKZOM8",
-        "next_thread_id": "K600PKZOO8"
+        "next_thread_id": "K600PKZOO8",
+        "created_at": "2020-05-07T07:11:28.288340Z"
       }],
       "users": [{
         "id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
@@ -1704,7 +1702,6 @@ There's only one value allowed for a single property.
         }],
         "thread": {
           "id": "Q1GZ3FNAU9",
-          "timestamp": 1575452961,
           "active": false,
           "user_ids": [
             "smith@example.com",
@@ -1720,7 +1717,6 @@ There's only one value allowed for a single property.
             },
             // "events": ...
           ],
-          "order": 1,
           "properties": {
             "0805e283233042b37f460ed8fbf22160": {
               "string_property": "string value"
@@ -1730,7 +1726,8 @@ There's only one value allowed for a single property.
             "group_ids": [0]
           },
           "previous_thread_id": "K600PKZOM8",
-          "next_thread_id": "K600PKZOO8"
+          "next_thread_id": "K600PKZOO8",
+          "created_at": "2020-05-07T07:11:28.288340Z"
         },
         "properties": {
           // "Properties" object
@@ -3674,7 +3671,7 @@ as `away`. [Read more...](#set-away-status)
         // the last event of each type in chat
         "message": {
           "thread_id": "K600PKZON8",
-          "thread_order": 343544565,
+          "thread_created_at": "2020-05-07T07:11:28.288340Z",
           "event": {
             // "restricted_access": true
             // or
@@ -3683,7 +3680,7 @@ as `away`. [Read more...](#set-away-status)
         },
         "system_message": {
           "thread_id": "K600PKZON8",
-          "thread_order": 343544565,
+          "thread_created_at": "2020-05-07T07:11:28.288340Z",
           "event": {
             // "restricted_access": true
             // or
@@ -3694,16 +3691,15 @@ as `away`. [Read more...](#set-away-status)
       },
       "last_thread_summary": {
         "id": "K600PKZON8",
-        "timestamp": 1473433500,
         "user_ids": ["smith@example.com"],
-        "order": 12417249812721,
         "properties": {
           "routing": {
             "idle": false,
             "unassigned": false
           }
           // ...
-        }
+        },
+        "created_at": "2020-05-07T07:11:28.288340Z"
       },
       "properties": {
         "routing": {
@@ -4259,7 +4255,7 @@ Here's what you need to know about **pushes**:
 ## Chats
 
 ### `incoming_chat`
-Informs about a chat coming with a new thread. The push payload contains the whole chat data structure. If the chat was started with some initial events, the thread object contains them.  
+Informs about a chat coming with a new thread. The push payload contains the whole chat data structure. If the chat was started with some initial events, the thread object contains them.
 
 <CodeResponse title={'Sample push payload'}>
 

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -34,6 +34,7 @@ This document is the record of all the changes in the **Customer Chat API**, Web
   - method: **Close Thread** -> **Deactivate Chat** and push: **Thread Closed** -> **Chat Deactivated**
   - push: **Incoming Chat Thread** -> **Incoming Chat**
 - There're new fields `previous_thread_id` and `next_thread_id` in the [**Thread**](/messaging/customer-chat-api/v3.2/#threads) data structure.
+- Fields `order` and `timestamp` in the [**Thread**](/messaging/customer-chat-api/v3.2/#threads) data structure were replaced with the new field, `created_at` (date & time in microseconds in UTC).
 
 ## [v3.1] - 2019-09-17
 

--- a/content/messaging/customer-chat-api/v3.2/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/index.mdx
@@ -811,23 +811,12 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
     // optional
     // "Thread" object
   ],
-  "threads_summary": [
-    {
-      "thread_id": "K600PKZON8",
-      "order": 129846129847
-    },
-    {
-      "thread_id": "K600PKZON8",
-      "order": 129846129848
-    }
-  ],
   "properites": {
     // "Properites" object
   },
   "access": {
     // "Access" object
-  },
-  "is_followed": true
+  }
 }
 ```
 
@@ -1124,7 +1113,7 @@ curl -X POST \
       "last_event_per_type": {
         "message": {
           "thread_id": "K600PKZON9",
-          "thread_order": 1,
+          "thread_created_at": "2020-05-07T07:11:28.288340Z",
           "event": {
             "id": "Q298LUVPRH_1",
             "created_at": "2019-12-09T12:01:18.909000Z",

--- a/content/messaging/customer-chat-api/v3.2/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/index.mdx
@@ -1004,16 +1004,16 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 
 </CodeResponse>
 
-| Field                | Req./Opt. | Note                                                                                  |
-| -------------------- | --------- | ------------------------------------------------------------------------------------- |
-| `access`             | optional  |                                                                                       |
-| `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active). |
-| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                      |
-| `properties`         | optional  |                                                                                       |
-| `restricted_access`  | optional  |                                                                                       |
-| `previous_thread_id` | optional  | Present only if there is a preceding thread.                                          |
-| `next_thread_id`     | optional  | Present only if there is a following thread.                                          |
-| `created_at`         | required  |                                                                                       |
+| Field                | Req./Opt. | Note                                                                                       |
+| -------------------- | --------- | ------------------------------------------------------------------------------------------ |
+| `access`             | optional  |                                                                                            |
+| `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active).      |
+| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
+| `properties`         | optional  |                                                                                            |
+| `restricted_access`  | optional  |                                                                                            |
+| `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
+| `next_thread_id`     | optional  | Present only if there is a following thread.                                               |
+| `created_at`         | required  | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
 
 # Methods
 

--- a/content/messaging/customer-chat-api/v3.2/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/index.mdx
@@ -61,7 +61,7 @@ These are the available **event types**:
 File event informs about a file being uploaded.
 
 ### Request
- 
+
 | Field        | Required | Data type |                                                                                                                                     Notes |
 | ------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`  | no       | `string`  |                                                                                                                                           |
@@ -436,7 +436,7 @@ Custom event is an event with customizable payload.
 
 ```json
 {
-  "id": "0affb00a-82d6-4e07-ae61-56ba5c36f743", 
+  "id": "0affb00a-82d6-4e07-ae61-56ba5c36f743",
   "custom_id": "31-0C-1C-07-DB-16",
   "type": "custom",
   "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
@@ -854,7 +854,7 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
     // last event of each type in chat
     "message": {
       "thread_id": "K600PKZON8",
-      "thread_order": 3,
+      "thread_created_at": "2020-05-07T07:11:28.288340Z"
       "event": {
         // "restricted_access": true
         // or
@@ -863,7 +863,7 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
     },
     "system_message": {
       "thread_id": "K600PKZON6",
-      "thread_order": 1,
+      "thread_created_at": "2020-05-07T07:11:28.288340Z"
       "event": {
         // "restricted_access": true
         // or
@@ -874,8 +874,7 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
   },
   "last_thread_summary": {
     "id": "K600PKZON8",
-    "order": 3,
-    "timestamp": 1473433500,
+    "created_at": "2020-05-07T07:11:28.288340Z"
     "user_ids": ["b5657aff34dd32e198160d54666df9d8"],
     "properites": {
       // "Properites" object
@@ -985,14 +984,12 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 ```json
 {
   "id": "K600PKZON8",
-  "timestamp": 1473433500,
   "active": true,
   "user_ids": ["b5657aff34dd32e198160d54666df9d8"],
   "restricted_access": true,
   "events": [
     // array of "Event" objects
   ],
-  "order": 112057129857,
   "properties": {
     // "Properties" object
   },
@@ -1000,7 +997,8 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
     // "Access" object
   },
   "previous_thread_id": "K600PKZOM8",
-  "next_thread_id": "K600PKZOO8"
+  "next_thread_id": "K600PKZOO8",
+  "created_at": "2020-05-07T07:11:28.288340Z"
 }
 ```
 
@@ -1015,6 +1013,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | `restricted_access`  | optional  |                                                                                       |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                          |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                          |
+| `created_at`         | required  |                                                                                       |
 
 # Methods
 
@@ -1260,7 +1259,7 @@ curl -X POST \
 
 <Code>
 
-<CodeSample path={'REQUEST'}>	  
+<CodeSample path={'REQUEST'}>
 
 ```shell
 curl -X POST \
@@ -1296,7 +1295,6 @@ curl -X POST \
         "text": "Hello",
         "author_id": "b5657aff34dd32e198160d54666df9d8"
       }],
-      "order": 1,
       "properties": {
         // "Property" object
       },
@@ -1304,7 +1302,8 @@ curl -X POST \
         "group_ids": [0]
       },
       "previous_thread_id": "K600PKZOM8",
-      "next_thread_id": "K600PKZOO8"
+      "next_thread_id": "K600PKZOO8",
+      "created_at": "2020-05-07T07:11:28.288340Z"
     }],
     "users": [{
       "id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
@@ -1527,7 +1526,7 @@ curl -X POST \
 
 ### Send Event
 
-Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request. 
+Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request.
 
 #### Specifics
 
@@ -2785,7 +2784,7 @@ Marks an incoming greeting as seen.
 
 **How it's implemented in LiveChat:**
 
-The Chat Widget uses this method to inform that a Customer has seen a greeting. Based on that, the Reports section displays the greetings 
+The Chat Widget uses this method to inform that a Customer has seen a greeting. Based on that, the Reports section displays the greetings
 that were actually seen by Customers, not all the sent greetings. If a Customer started a chat from a greeting, but the **Accept Method** wasn't executed,
 the greeting is still counted as seen in Reports.
 
@@ -2934,7 +2933,7 @@ You can create and manage webhooks via the [Configuration API](/management/confi
 | `request_timeout`       | Request timed out             | Timeout threshold is 15 seconds.                                                                                           |
 | `unsupported_version`   | Unsupported version           | Unsupported protocol version.                                                                                              |
 | `wrong_product_version` | Wrong product version         | License is not LiveChat 3 (probably still LiveChat 2).                                                                     |
-          
+
 </Text>
 
 </Section>
@@ -2943,5 +2942,3 @@ You can create and manage webhooks via the [Configuration API](/management/confi
 
 If you found a bug or a typo, you can let us know directly on GitHub.
 In case of any questions or feedback, don't hesitate to contact us at [developers@livechatinc.com](mailto:developers@livechatinc.com). We'll be happy to hear from you!
-
-

--- a/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
@@ -841,23 +841,12 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
     // optional
     // "Thread" object
   ],
-  "threads_summary": [
-    {
-      "thread_id": "K600PKZON8",
-      "order": 129846129847
-    },
-    {
-      "thread_id": "K600PKZON8",
-      "order": 129846129848
-    }
-  ],
   "properites": {
     // "Properites" object
   },
   "access": {
     // "Access" object
-  },
-  "is_followed": true
+  }
 }
 ```
 
@@ -1166,7 +1155,7 @@ It returns [summaries](#chat-summaries) of the chats a Customer participated in.
       "last_event_per_type": {
         "message": {
           "thread_id": "K600PKZON9",
-          "thread_order": 1,
+          "thread_created_at": "2020-05-07T07:11:28.288340Z",
           "event": {
             "id": "Q298LUVPRH_1",
             "created_at": "2019-12-09T12:01:18.909000Z",

--- a/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
@@ -32,7 +32,7 @@ Also, the RTM API will be a better choice if you want to avoid time delays or pr
 
 ## Access
 
-The basics on authorization and server pinging in the Customer Chat RTM API. 
+The basics on authorization and server pinging in the Customer Chat RTM API.
 
 ### Authorization
 
@@ -54,7 +54,7 @@ For web applications and backend integrations (e.g. in Python, Go). Send the fol
 }
 ```
 
-After pinging the server, the client will receive a response with the `ping` action. Thanks to that, the client can make sure the connection is still alive. 
+After pinging the server, the client will receive a response with the `ping` action. Thanks to that, the client can make sure the connection is still alive.
 
 - **The control frame ping in the websocket protocol**
 
@@ -65,7 +65,7 @@ For backend integrations; unavailable in web browsers. Read more about the [cont
 LiveChat system operates in two data centers: `dal` (USA) and `fra` (Europe). The default data center is `dal`.
 
 For backend applications, you can specify the region in the request header. The mechanism is the same as in [Customer Chat Web API reference](../#data-centers). It doesn't work for frontend applications, though.
-Instead, frontend apps connect to a region different than the default one by specifying the region suffix in the URL. 
+Instead, frontend apps connect to a region different than the default one by specifying the region suffix in the URL.
 
 **`fra`:** `wss://api-fra.livechatinc.com/v3.2/customer/rtm/ws`
 
@@ -94,7 +94,7 @@ These are the available **event types**:
 The **File** event informs about an uploaded file.
 
 ### Request
- 
+
 | Field        | Required | Data type |                                                                                                                                     Notes |
 | ------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`  | no       | `string`  |                                                                                                                                           |
@@ -465,7 +465,7 @@ Custom event is an event with customizable payload.
 
 ```json
 {
-  "id": "0affb00a-82d6-4e07-ae61-56ba5c36f743", 
+  "id": "0affb00a-82d6-4e07-ae61-56ba5c36f743",
   "custom_id": "31-0C-1C-07-DB-16",
   "type": "custom",
   "author_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
@@ -884,7 +884,7 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
     // last event of each type in chat
     "message": {
       "thread_id": "K600PKZON8",
-      "thread_order": 3,
+      "thread_created_at": "2020-05-07T07:11:28.288340Z",
       "event": {
         // "restricted_access": true
         // or
@@ -893,7 +893,7 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
     },
     "system_message": {
       "thread_id": "K600PKZON6",
-      "thread_order": 1,
+      "thread_created_at": "2020-05-07T07:11:28.288340Z",
       "event": {
         // "restricted_access": true
         // or
@@ -904,8 +904,7 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
   },
   "last_thread_summary": {
     "id": "K600PKZON8",
-    "order": 3,
-    "timestamp": 1473433500,
+    "created_at": "2020-05-07T07:11:28.288340Z",
     "user_ids": ["b5657aff34dd32e198160d54666df9d8"],
     "properites": {
       // "Properites" object
@@ -1014,14 +1013,12 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 ```json
 {
   "id": "K600PKZON8",
-  "timestamp": 1473433500,
   "active": true,
   "user_ids": ["b5657aff34dd32e198160d54666df9d8"],
   "restricted_access": true,
   "events": [
     // array of "Event" objects
   ],
-  "order": 112057129857,
   "properties": {
     // "Properties" object
   },
@@ -1029,7 +1026,8 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
     // "Access" object
   },
   "previous_thread_id": "K600PKZOM8",
-  "next_thread_id": "K600PKZOO8"
+  "next_thread_id": "K600PKZOO8",
+  "created_at": "2020-05-07T07:11:28.288340Z"
 }
 ```
 
@@ -1044,6 +1042,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | `restricted_access`  | optional  |                                                                                       |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                          |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                          |
+| `created_at`         | required  |                                                                                       |
 
 # Methods
 
@@ -1346,7 +1345,6 @@ It returns [summaries](#chat-summaries) of the chats a Customer participated in.
           "text": "Hello",
           "author_id": "b5657aff34dd32e198160d54666df9d8"
         }],
-        "order": 1,
         "properties": {
           // "Property" object
         },
@@ -1354,7 +1352,8 @@ It returns [summaries](#chat-summaries) of the chats a Customer participated in.
           "group_ids": [0]
         },
         "previous_thread_id": "K600PKZOM8",
-        "next_thread_id": "K600PKZOO8"
+        "next_thread_id": "K600PKZOO8",
+        "created_at": "2020-05-07T07:11:28.288340Z"
       }],
       "users": [{
         "id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
@@ -1691,7 +1690,7 @@ Deactivates a chat by closing the currently open thread. Sending messages to thi
 
 ### Send Event
 
-Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request. 
+Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request.
 
 #### Specifics
 
@@ -3086,7 +3085,7 @@ Marks an incoming greeting as seen.
 
 **How it's implemented in LiveChat:**
 
-The Chat Widget uses this method to inform that a Customer has seen a greeting. Based on that, the Reports section displays the greetings 
+The Chat Widget uses this method to inform that a Customer has seen a greeting. Based on that, the Reports section displays the greetings
 that were actually seen by Customers, not all the sent greetings. If a Customer started a chat from a greeting, but the **Accept Method** wasn't executed,
 the greeting is still counted as seen in Reports.
 
@@ -3209,10 +3208,10 @@ Cancels a greeting (an invitation to the chat). For example, Customers could can
 Here's what you need to know about **pushes**:
 
 - They are generated primarily by RTM API actions, but also by Web API actions.
-- They notify you when specific events occur. 
-- Can be **delivered** only in the websocket transport. 
-- You don't need to register pushes to receive them. 
-- Their equivalents in Web API are [webhooks](/management/configuration-api/#webhooks). 
+- They notify you when specific events occur.
+- Can be **delivered** only in the websocket transport.
+- You don't need to register pushes to receive them.
+- Their equivalents in Web API are [webhooks](/management/configuration-api/#webhooks).
 - Pushes and webhooks have similar payloads.
 
 |                 |                                                                                                                                                                                                                                                                                                                                                                     |
@@ -3253,7 +3252,7 @@ Here's what you need to know about **pushes**:
 ## Chats
 
 ### `incoming_chat`
-Informs about a chat coming with a new thread. The push payload contains the whole chat data structure. If the chat was started with some initial events, the thread object contains them.  
+Informs about a chat coming with a new thread. The push payload contains the whole chat data structure. If the chat was started with some initial events, the thread object contains them.
 
 <CodeResponse title={'Sample push payload'}>
 
@@ -3383,9 +3382,9 @@ Informs that a chat was transferred to a different group or to an Agent.
 ## Chat users
 
 ### `chat_user_added`
-Informs that a user (Customer or Agent) was added to a chat. 
+Informs that a user (Customer or Agent) was added to a chat.
 
-This push can be emitted with `user.present` set to `false` when a user writes to a chat without joining it. You can achieve that via the [Send Event](/messaging/agent-chat-api/v3.2/rtm-reference/#send-event) method.  
+This push can be emitted with `user.present` set to `false` when a user writes to a chat without joining it. You can achieve that via the [Send Event](/messaging/agent-chat-api/v3.2/rtm-reference/#send-event) method.
 
 <CodeResponse title={'Sample push payload'}>
 
@@ -3608,7 +3607,7 @@ Informs about those thread properties that were updated.
   "thread_id": "Q1GZ3FNAU9",
   "properties": {
     "0805e283233042b37f460ed8fbf22160": {
-      "string_property": "Thread property value updated by Customer" 
+      "string_property": "Thread property value updated by Customer"
         },
     // ...
     }
@@ -3773,7 +3772,7 @@ Informs that a Customer changed the website - moved to another page of the websi
 | **Webhook equivalent** | -                       |
 
 ### `customer_side_storage_updated`
-Informs that a Customer updated the data stored on their side. 
+Informs that a Customer updated the data stored on their side.
 
 <CodeResponse title={'Sample push payload'}>
 
@@ -3867,7 +3866,7 @@ Informs that one of the chat users is currently typing a message. The message ha
 {
   "chat_id": "PJ0MRSHTDG",
   "thread_id": "K600PKZON8",
-  "typing_indicator": {   
+  "typing_indicator": {
     "author_id": "d17cd570-11a9-45c0-45c0-1b020b7586dc",
     "recipients": "all",
     "timestamp": 1574245378,
@@ -3886,7 +3885,7 @@ Informs that one of the chat users is currently typing a message. The message ha
 | **Webhook equivalent** | -                           |
 
 ### `incoming_multicast`
-Informs about messages sent via the `multicast` method or by the system. 
+Informs about messages sent via the `multicast` method or by the system.
 
 <CodeResponse title={'Sample push payload'}>
 
@@ -4028,7 +4027,7 @@ Informs about a greeting rejected by the Customer. Also, the push is sent when a
     "type": "push",
     "payload": {
       "unique_id": "Q10O0N5B5D"
-    } 
+    }
 }
 ```
 

--- a/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
@@ -1033,16 +1033,16 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 
 </CodeResponse>
 
-| Field                | Req./Opt. | Note                                                                                  |
-| -------------------- | --------- | ------------------------------------------------------------------------------------- |
-| `access`             | optional  |                                                                                       |
-| `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active). |
-| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                      |
-| `properties`         | optional  |                                                                                       |
-| `restricted_access`  | optional  |                                                                                       |
-| `previous_thread_id` | optional  | Present only if there is a preceding thread.                                          |
-| `next_thread_id`     | optional  | Present only if there is a following thread.                                          |
-| `created_at`         | required  |                                                                                       |
+| Field                | Req./Opt. | Note                                                                                       |
+| -------------------- | --------- | ------------------------------------------------------------------------------------------ |
+| `access`             | optional  |                                                                                            |
+| `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active).      |
+| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
+| `properties`         | optional  |                                                                                            |
+| `restricted_access`  | optional  |                                                                                            |
+| `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
+| `next_thread_id`     | optional  | Present only if there is a following thread.                                               |
+| `created_at`         | required  | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
 
 # Methods
 


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-5735-thread-created_at)
- [Jira](https://livechatinc.atlassian.net/browse/API-5735)

## 📓 Description
Replace `order` + `timestamp` with `created_at` in Thread data structure
