### PR TITLE
Rename `groups` parameter in `list_group_statuses` to `group_ids`

### DIFF
--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -35,7 +35,7 @@ This document is the record of all the changes in the **Customer Chat API**, Web
   - push: **Incoming Chat Thread** -> **Incoming Chat**
 - There're new fields `previous_thread_id` and `next_thread_id` in the [**Thread**](/messaging/customer-chat-api/v3.2/#threads) data structure.
 - Fields `order` and `timestamp` in the [**Thread**](/messaging/customer-chat-api/v3.2/#threads) data structure were replaced with the new field, `created_at` (date & time in microseconds in UTC).
-- From now on `list_group_statuses` accepts `group_ids` instead of `groups` parameter.
+- From now on `list_group_statuses` accepts `group_ids` instead of the `groups` parameter.
 
 ## [v3.1] - 2019-09-17
 

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -35,6 +35,7 @@ This document is the record of all the changes in the **Customer Chat API**, Web
   - push: **Incoming Chat Thread** -> **Incoming Chat**
 - There're new fields `previous_thread_id` and `next_thread_id` in the [**Thread**](/messaging/customer-chat-api/v3.2/#threads) data structure.
 - Fields `order` and `timestamp` in the [**Thread**](/messaging/customer-chat-api/v3.2/#threads) data structure were replaced with the new field, `created_at` (date & time in microseconds in UTC).
+- From now on `list_group_statuses` accepts `group_ids` instead of `groups` parameter.
 
 ## [v3.1] - 2019-09-17
 

--- a/content/messaging/customer-chat-api/v3.2/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/index.mdx
@@ -2375,10 +2375,10 @@ curl -X POST \
 
 #### Request
 
-| Parameter | Required | Data type | Notes                                                      |
-| --------- | -------- | --------- | ---------------------------------------------------------- |
-| `all`     | No       | `bool`    | If set to `true`, you will get statuses of all the groups. |
-| `groups`  | No       | `array`   | A table of groups' IDs                                     |
+| Parameter   | Required | Data type | Notes                                                      |
+| ----------- | -------- | --------- | ---------------------------------------------------------- |
+| `all`       | No       | `bool`    | If set to `true`, you will get statuses of all the groups. |
+| `group_ids` | No       | `array`   | A table of groups' IDs                                     |
 
 One of the optional parameters needs to be included in the request.
 

--- a/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
@@ -2722,10 +2722,10 @@ It returns the initial state of the current Customer.
 
 #### Request
 
-| Parameter | Required | Data type | Notes                                                      |
-| --------- | -------- | --------- | ---------------------------------------------------------- |
-| `all`     | No       | `bool`    | If set to `true`, you will get statuses of all the groups. |
-| `groups`  | No       | `array`   | A table of a groups' IDs                                   |
+| Parameter   | Required | Data type | Notes                                                      |
+| ----------- | -------- | --------- | ---------------------------------------------------------- |
+| `all`       | No       | `bool`    | If set to `true`, you will get statuses of all the groups. |
+| `group_ids` | No       | `array`   | A table of a groups' IDs                                   |
 
 One of the optional parameters needs to be included in the request payload.
 


### PR DESCRIPTION
## 📓 Description

API has adjusted this parameter to match the existing naming scheme used in other methods.

## 👷 Type of change

### Content

- New content
  