### PR TITLE
remove get-chat-threads-summary from both apis

### DIFF
--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -51,7 +51,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 
 ### Removed
 
-- Methods: **Update Agent** and **Get Chat Threads Summary** were removed.
+- The **Update Agent** and **Get Chat Threads Summary** methods were removed.
 - The **Agent Updated** push was removed.
 
 ## [v3.1] - 2019-09-17

--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -51,8 +51,8 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 
 ### Removed
 
-- The **Update Agent** method was removed.
-- The `agent_updated` push was removed.
+- Methods: **Update Agent** and **Get Chat Threads Summary** were removed.
+- The **Agent Updated** push was removed.
 
 ## [v3.1] - 2019-09-17
 

--- a/content/messaging/agent-chat-api/v3.2/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/index.mdx
@@ -708,7 +708,7 @@ curl -X POST \
 
 |                 |                                                                                                                                                                                                                                                                                                                                                         |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat_threads_summary`](#get-chat-threads-summary) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                 |
+| **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                 |
 | **Chat access** | [`grant_chat_access`](#grant-chat-access) [`revoke_chat_access`](#revoke-chat-access) [`set_chat_access`](#set-chat-access) [`transfer_chat`](#transfer-chat)                                                                                                                                                                                           |
 | **Chat users**  | [`add_user_to_chat`](#add-user-to-chat) [`remove_user_from_chat`](#remove-user-from-chat)                                                                                                                                                                                                                                                               |
 | **Events**      | [`send_event`](#send-event) [`upload_file`](#upload-file) [`send_rich_message_postback`](#send-rich-message-postback)                                                                                                                                                                                                                                   |
@@ -920,78 +920,6 @@ curl -X POST \
 
 </CodeResponse>
 
-</Code>
-</Section>
-
-<Section>
-<Text>
-
-### Get Chat Threads Summary
-
-#### Specifics
-
-|                        |                                                                          |
-| ---------------------- | ------------------------------------------------------------------------ |
-| **Method URL**         | `https://api.livechatinc.com/v3.2/agent/action/get_chat_threads_summary` |
-| **Required scopes**    | `chats--all:ro` `chats--access:ro` `chats--my:ro`                        |
-| **RTM API equivalent** | [`get_chat_threads_summary`](rtm-reference/#get-chat-threads-summary)    |
-| **Webhook**            | -                                                                        |
-
-#### Request
-
-| Parameter    | Required | Data type | Notes                                                                                  |
-|--------------|----------|-----------|----------------------------------------------------------------------------------------|
-| `chat_id`    | Yes      | `string`  |                                                                                        |
-| `sort_order` | No       | `string`  | Possible values: `asc` - oldest chats first and `desc` - newest chats first (default). |
-| `limit`      | No       | `number`  | Default: 10, maximum: 100                                                              |
-| `page_id`    | No       | `string`  |                                                                                        |
-
-#### Response
-
-| Parameter          | Data type | Notes                                              |
-| ------------------ | --------- | -------------------------------------------------- |
-| `found_threads`    | `number`  | Number of threads in a chat                        |
-| `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
-| `previous_page_id` | `string`  | In relation to `page_id` specified in the request. |
-
-</Text>
-<Code>
-<CodeSample path={'REQUEST'}>
-
-```shell
-curl -X POST \
-https://api.livechatinc.com/v3.2/agent/action/get_chat_threads_summary \
- -H 'Authorization: Bearer <your_access_token>' \
--H 'Content-Type: application/json' \
--d '{
-  "chat_id": "PWJ8Y4THAV"
-	}'
-```
-
-</CodeSample>
-<CodeResponse>
-
-```json
-{
-  "threads_summary": [
-	{
-	  "id": "PT039ES4OG",
-	  "order": 2,
-	  "events_count": 2
-	},
-	{
-	  "id": "PT039DS6IP",
-	  "order": 1,
-	  "events_count": 17
-	}
-  ],
-  "found_threads": 7,
-  "next_page_id": "MTUxNzM5ODEzMTQ5Ng==", // optional
-  "previous_page_id": "MTUxNzM5ODEzMTQ5Nw==" // optional
-}
-```
-
-</CodeResponse>
 </Code>
 </Section>
 

--- a/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
@@ -708,7 +708,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 
 |                 |                                                                                                                                                                                                                                                                                                                                                         |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat_threads_summary`](#get-chat-threads-summary) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                 |
+| **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                 |
 | **Chat access** | [`grant_chat_access`](#grant-chat-access) [`revoke_chat_access`](#revoke-chat-access) [`set_chat_access`](#set-chat-access) [`transfer_chat`](#transfer-chat)                                                                                                                                                                                           |
 | **Chat users**  | [`add_user_to_chat`](#add-user-to-chat) [`remove_user_from_chat`](#remove-user-from-chat)                                                                                                                                                                                                                                                               |
 | **Events**      | [`send_event`](#send-event) [`send_rich_message_postback`](#send-rich-message-postback)                                                                                                                                                                                                                                                                 |
@@ -972,84 +972,6 @@ You cannot use both `limit` and `min_events_count` at the same time.
 </Code>
 </Section>
 
-
-<Section>
-<Text>
-
-### Get Chat Threads Summary
-
-#### Specifics
-
-|                        |                                                            |
-| ---------------------- | ---------------------------------------------------------- |
-| **Action**             | `get_chat_threads_summary`                                 |
-| **Required scopes**    | `chats--all:ro` `chats--access:ro` `chats--my:ro`          |
-| **Web API equivalent** | [`get_chat_threads_summary`](../#get-chat-threads-summary) |
-| **Push message**       | -                                                          |
-
-#### Request
-
-| Parameter    | Required | Data type | Notes                                                                              |
-|--------------|----------|-----------|------------------------------------------------------------------------------------|
-| `chat_id`    | Yes      | `string`  |                                                                                    |
-| `sort_order` | No       | `string`  | Possible values: `asc` - oldest chats first, `desc` - newest chats first (default) |
-| `limit`      | No       | `number`  | Defaul: 10, maximum: 100                                                           |
-| `page_id`    | No       | `string`  |                                                                                    |
-
-#### Response
-
-| Parameter       | Data type | Notes                           |
-| --------------- | --------- | ------------------------------- |
-| `found_threads` | `number`  | The number of threads in a chat |
-| `next_page_id`    | `string`  | In relation to `page_id` specified in the request. |
-| `previous_page_id`| `string`  | In relation to `page_id` specified in the request. |
-
-</Text>
-<Code>
-<CodeSample path={'REQUEST'}>
-
-```json
-{
-  "action": "get_chat_threads_summary",
-  "payload": {
-	"chat_id": "PJ0MRSHTDG"
-  }
-}
-```
-
-</CodeSample>
-
-<CodeResponse>
-
-```json
-{
-  "request_id": "<request_id>", // optional
-  "action": "get_chat_threads_summary",
-  "type": "response",
-  "success": true,
-  "payload": {
-	"threads_summary": [
-	  {
-		"id": "PT039ES4OG",
-		"order": 2,
-		"events_count": 2
-	  },
-	  {
-		"id": "PT039DS6IP",
-		"order": 1,
-		"events_count": 17
-	  }
-	],
-	"found_threads": 7,
-	"next_page_id": "MTUxNzM5ODEzMTQ5Ng==", // optional
-	"previous_page_id": "MTUxNzM5ODEzMTQ5Nw==" // optional
-  }
-}
-```
-
-</CodeResponse>
-</Code>
-</Section>
 
 <Section>
 <Text>

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -40,6 +40,10 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 - The [Login](/messaging/customer-chat-api/v3.2/rtm-reference/#login) method was extended with the application info.
 - The **Get Chat Threads** method evolved into **Get Chat** ([Web](/messaging/customer-chat-api/v3.2/#get-chat) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#get-chat)). It now allows to retrieve a chat containing a particular thread. It also changed its shape; it no longer contains the `order` field and the `chat` key.
 
+### Removed
+
+- The **Get Chat Threads Summary** method was removed.
+
 ## [v3.1] - 2019-09-17
 
 ### Added

--- a/content/messaging/customer-chat-api/v3.2/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/index.mdx
@@ -680,7 +680,7 @@ curl -X POST \
 
 |                |                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**      | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat_threads_summary`](#get-chat-threads-summary) [`get_chat`](#get-chat) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat)                                                                                                                                                                                                                     |
+| **Chats**      | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat)                                                                                                                                                                                                                     |
 | **Events**     | [`send_event`](#send-event) [`upload_file`](#upload-file) [`send_rich_message_postback`](#send-rich-message-postback) [`send_sneak_peek`](#send-sneak-peek)                                                                                                                                                                                                                                                                                                 |
 | **Properties** | [`update_chat_properties`](#update-chat-properties) [`delete_chat_properties`](#delete-chat-properties) [`update_thread_properties`](#update-thread-properties) [`delete_thread_properties`](#delete-thread-properties) [`update_event_properties`](#update-event-properties) [`delete_event_properties`](#delete-event-properties) [`list_license_properties`](#list-license-properties) [`list_group_properties`](#list-group-properties) |
 | **Customers**  | [`update_customer`](#update-customer) [`set_customer_session_fields`](#set-customer-session-fields) [`get_customer`](#get-customer)                                                                                                                                                                                                                                                                                                                         |
@@ -873,74 +873,6 @@ curl -X POST \
 </CodeResponse>
 
 </Code>
-</Section>
-
-<Section>
-
-<Text>
-
-### Get Chat Threads Summary
-
-#### Specifics
-
-|                        |                                                                             |
-| ---------------------- | --------------------------------------------------------------------------- |
-| **Method URL**         | `https://api.livechatinc.com/v3.2/customer/action/get_chat_threads_summary` |
-| **RTM API equivalent** | [`get_chat_threads_summary`](rtm-reference/#get-chat-threads-summary)       |
-| **Webhook**            | -                                                                           |
-
-#### Request
-
-| Parameter | Required | Data type | Notes                     |
-| --------- | -------- | --------- | ------------------------- |
-| `chat_id` | Yes      | `string`  |                           |
-| `offset`  | No       | `number`  | Default: 0                |
-| `limit`   | No       | `number`  | Default: 25, maximum: 100 |
-
-#### Response
-
-| Parameter         | Notes                           |     |
-| ----------------- | ------------------------------- | --- |
-| `threads_summary` | Sorted descendingly by `order`. |     |
-
-</Text>
-
-<Code>
-
-<CodeSample path={'REQUEST'}>
-
-```shell
-curl -X POST \
-  https://api.livechatinc.com/v3.2/customer/action/get_chat_threads_summary?license_id=<license_id> \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <customer_access_token>' \
-  -d '{
-		  "chat_id": "PJ0MRSHTDG"
-	  }'
-```
-
-</CodeSample>
-
-<CodeResponse>
-
-```json
-{
-  "threads_summary": [
-	{
-	  "id": "Q298LUVPRH",
-	  "order": 1,
-	  "total_events": 1,
-	  "active": true
-	}
-  ],
-  "total_threads": 1
-}
-```
-
-</CodeResponse>
-
-</Code>
-
 </Section>
 
 <Section>

--- a/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
@@ -682,7 +682,7 @@ When connecting to the Customer Chat RTM API, clients have to send over the requ
 
 |                |                                                                                                                                                                                                                                                                                                                                                         |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**      | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat_threads_summary`](#get-chat-threads-summary) [`get_chat`](#get-chat) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat)                                                                                                                 |
+| **Chats**      | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat)                                                                                                                 |
 | **Events**     | [`send_event`](#send-event) [`send_rich_message_postback`](#send-rich-message-postback) [`send_sneak_peek`](#send-sneak-peek)                                                                                                                                                                                                                           |
 | **Properties** | [`update_chat_properties`](#update-chat-properties) [`delete_chat_properties`](#delete-chat-properties) [`update_thread_properties`](#update-thread-properties) [`delete_thread_properties`](#delete-thread-properties) [`update_event_properties`](#update-event-properties) [`delete_event_properties`](#delete-event-properties) |
 | **Customers**  | [`update_customer`](#update-customer) [`update_customer_page`](#update-customer-page) [`set_customer_session_fields`](#set-customer-session-fields) [`get_customer`](#get-customer)                                                                                                                                                                     |
@@ -916,79 +916,6 @@ You cannot use both `limit` and `min_events_count` at the same time.
 </CodeResponse>
 
 </Code>
-</Section>
-
-<Section>
-
-<Text>
-
-### Get Chat Threads Summary
-
-#### Specifics
-
-|                        |                                                            |
-| ---------------------- | ---------------------------------------------------------- |
-| **Action**             | `get_chat_threads_summary`                                 |
-| **Web API equivalent** | [`get_chat_threads_summary`](../#get-chat-threads-summary) |
-| **Push message**       | -                                                          |
-
-#### Request
-
-| Parameter | Required | Data type | Notes                      |
-| --------- | -------- | --------- | -------------------------- |
-| `chat_id` | Yes      | `string`  |                            |
-| `offset`  | No       | `number`  | Default: 0.                |
-| `limit`   | No       | `number`  | Default: 25; maximum: 100. |
-
-#### Response
-
-| Parameter         | Notes                           |     |
-| ----------------- | ------------------------------- | --- |
-| `threads_summary` | Sorted descendingly by `order`. |     |
-
-</Text>
-
-<Code>
-
-<CodeSample path={'REQUEST'}>
-
-```json
-{
-  "action": "get_chat_threads_summary",
-  "payload": {
-	"chat_id": "PJ0MRSHTDG"
-  }
-}
-```
-
-</CodeSample>
-
-<CodeResponse>
-
-```json
-{
-  "request_id": "<request_id>", // optional
-  "action": "get_chat_threads_summary",
-  "type": "response",
-  "success": true,
-  "payload": {
-	"threads_summary": [
-		{
-			"id": "Q298LUVPRH",
-			"order": 1,
-			"total_events": 1,
-			"active": true
-		}
-	],
-	"total_threads": 1
-  }
-}
-```
-
-</CodeResponse>
-
-</Code>
-
 </Section>
 
 <Section>


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-5739-remove-get-chat-threads-summary)
- [Jira](https://livechatinc.atlassian.net/browse/XXX-XXX)

## 📓 Description

Remove get chat threads summary from v3.2
