### PR TITLE
deprecate chat order field

### DIFF
--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -49,6 +49,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - There're new fields `previous_thread_id` and `next_thread_id` in the [**Thread**](/messaging/agent-chat-api/v3.2/#threads) data structure.
 - Fields `order` and `timestamp` in the [**Thread**](/messaging/agent-chat-api/v3.2/#threads) data structure were replaced with the new field, `created_at` (date & time in microseconds in UTC).
 - The **Get Chat Threads** method evolved into **Get Chat** ([Web](/messaging/agent-chat-api/v3.2/#get-chat) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#get-chat)). It now allows to retrieve a chat containing a particular thread. It also changed its shape; it no longer contains the `order` field and the `chat` key.
+- `order` in `chat` object has been removed from the responses of **Login** and **List Chats** methods
 
 ### Removed
 

--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -49,7 +49,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - There're new fields `previous_thread_id` and `next_thread_id` in the [**Thread**](/messaging/agent-chat-api/v3.2/#threads) data structure.
 - Fields `order` and `timestamp` in the [**Thread**](/messaging/agent-chat-api/v3.2/#threads) data structure were replaced with the new field, `created_at` (date & time in microseconds in UTC).
 - The **Get Chat Threads** method evolved into **Get Chat** ([Web](/messaging/agent-chat-api/v3.2/#get-chat) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#get-chat)). It now allows to retrieve a chat containing a particular thread. It also changed its shape; it no longer contains the `order` field and the `chat` key.
-- `order` in `chat` object has been removed from the responses of **Login** and **List Chats** methods
+- The `order` field in the `chat` object was removed from the responses of the **Login** and **List Chats** methods.
 
 ### Removed
 

--- a/content/messaging/agent-chat-api/v3.2/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/index.mdx
@@ -828,7 +828,6 @@ curl -X POST \
 	"access": {
 	  "group_ids": [0]
 	},
-	"order": 1575892853242000,
 	"is_followed": true
   }],
   "found_chats": 4
@@ -1127,7 +1126,6 @@ curl -X POST \
       ],
       "thread": {
         "id": "K600PKZON8",
-        "timestamp": 1590666298,
         "active": false,
         "user_ids": [
           "smith@example.com"
@@ -1147,7 +1145,6 @@ curl -X POST \
             "author_id": "smith@example.com"
           }
         ],
-        "order": 1,
         "properties": {
           "0805e283233042b37f460ed8fbf22160": {
             "thread_property": "property_value"

--- a/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
@@ -871,7 +871,6 @@ There's only one value allowed for a single property.
 	  "access": {
 		"group_ids": [0]
 	  },
-	  "order": 1575892853242000,
 	  "is_followed": true
 	}],
 	"found_chats": 4
@@ -1178,7 +1177,6 @@ There's only one value allowed for a single property.
         ],
         "thread": {
           "id": "K600PKZON8",
-          "timestamp": 1590666298,
           "active": false,
           "user_ids": [
             "smith@example.com"
@@ -1198,7 +1196,6 @@ There's only one value allowed for a single property.
               "author_id": "smith@example.com"
             }
           ],
-          "order": 1,
           "properties": {
             "0805e283233042b37f460ed8fbf22160": {
               "thread_property": "property_value"

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -39,6 +39,7 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 - Method **List Chats** ([Web](/messaging/customer-chat-api/v3.2/#list-chats) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#list-chats)) is paginated with `page_id` now.
 - The [Login](/messaging/customer-chat-api/v3.2/rtm-reference/#login) method was extended with the application info.
 - The **Get Chat Threads** method evolved into **Get Chat** ([Web](/messaging/customer-chat-api/v3.2/#get-chat) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#get-chat)). It now allows to retrieve a chat containing a particular thread. It also changed its shape; it no longer contains the `order` field and the `chat` key.
+- `order` in `chat` object has been removed from the payload of **Incoming Chat** push. Also, this field has been replaced with `last_thread_created_at` in the response of **List Chats** method.
 
 ### Removed
 

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -39,7 +39,7 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 - Method **List Chats** ([Web](/messaging/customer-chat-api/v3.2/#list-chats) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#list-chats)) is paginated with `page_id` now.
 - The [Login](/messaging/customer-chat-api/v3.2/rtm-reference/#login) method was extended with the application info.
 - The **Get Chat Threads** method evolved into **Get Chat** ([Web](/messaging/customer-chat-api/v3.2/#get-chat) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#get-chat)). It now allows to retrieve a chat containing a particular thread. It also changed its shape; it no longer contains the `order` field and the `chat` key.
-- `order` in `chat` object has been removed from the payload of **Incoming Chat** push. Also, this field has been replaced with `last_thread_created_at` in the response of **List Chats** method.
+- The `order` field in the `chat` object was removed from the payload of the **incoming_chat** push. Also, this field was replaced with `last_thread_created_at` in the response of the **List Chats** method.
 
 ### Removed
 

--- a/content/messaging/customer-chat-api/v3.2/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/index.mdx
@@ -745,8 +745,8 @@ curl -X POST \
   "next_page_id": "MTUxNzM5ODEzMTQ5Ng==",
   "chats_summary": [{
 	  "id": "PJ0MRSHTDG",
-	  "order": 1575892853242000,
 	  "last_thread_id": "K600PKZON8",
+	  "last_thread_created_at": "2020-05-08T08:22:21.128420Z",
 	  "last_event_per_type": {
 		"message": {
 		  "thread_id": "K600PKZON9",

--- a/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
@@ -790,8 +790,8 @@ It returns [summaries](#chat-summaries) of the chats a Customer participated in.
     "next_page_id": "MTUxNzM5ODEzMTQ5Ng==",
     "chats_summary": [{
       "id": "PJ0MRSHTDG",
-      "order": 1575892853242000,
       "last_thread_id": "K600PKZON8",
+	  "last_thread_created_at": "2020-05-08T08:22:21.128420Z",
       "last_event_per_type": {
         "message": {
           "thread_id": "K600PKZON9",
@@ -1218,7 +1218,6 @@ Used to restart an archived chat.
 	"payload": {
 	"chat": {
 		"id": "PJ0MRSHTDG",
-		"order": 343544565,
 		"access": {
 			"group_ids": [1]
 		},
@@ -2892,7 +2891,6 @@ Informs about a chat coming with a new thread. The push payload contains the who
 {
   "chat": {
 	"id": "PJ0MRSHTDG",
-	"order": 343544565,
 	"users": [
 	  // array of "User" objects
 	],


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/chat-order)
- [Jira](https://livechatinc.atlassian.net/browse/XXX-XXX)

## 📓 Description
Deprecate `order` in `chat` object - more details in the comments of https://livechatinc.atlassian.net/browse/API-6333 
