### PR TITLE
Fix mark_events_as_seen rtm reference

### DIFF
--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -3464,12 +3464,11 @@ Logs the Agent out.
 
 ```json
 {
-  "request_id": "<request_id>", // optional
+  "request_id": "<request_id>",
   "action": "mark_events_as_seen",
   "type": "response",
   "success": true,
   "payload": {
-	//no response payload
   }
 }
 ```

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -3444,10 +3444,6 @@ Logs the Agent out.
 | `chat_id`    | Yes      | `string`    |       |
 | `seen_up_to` | Yes      | `string`    | RFC 3339 date-time format |
 
-#### Response
-
-No response payload (`200 OK`).
-
 </Text>
 <Code>
 <CodeSample path={'REQUEST'}>
@@ -3463,6 +3459,22 @@ No response payload (`200 OK`).
 ```
 
 </CodeSample>
+
+<CodeResponse>
+
+```json
+{
+  "request_id": "<request_id>", // optional
+  "action": "mark_events_as_seen",
+  "type": "response",
+  "success": true,
+  "payload": {
+	//no response payload
+  }
+}
+```
+
+</CodeResponse>
 
 </Code>
 </Section>

--- a/content/messaging/agent-chat-api/v3.1/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.1/rtm-reference/index.mdx
@@ -4040,10 +4040,6 @@ Logs the Agent out.
 | `chat_id`    | Yes      | `string`    |       |
 | `seen_up_to` | Yes      | `string`    | RFC 3339 date-time format |
 
-#### Response
-
-No response payload (`200 OK`).
-
 </Text>
 <Code>
 <CodeSample path={'REQUEST'}>


### PR DESCRIPTION
## 🚀 Links

- [Feature branch] n/a
- [Jira] n/a

## 📓 Description
There was a web-api reference in rtm-api `mark_events_as_seen` method description


## ✅ Checklist (for API docs)

- Changelog
Updated `mark_events_as_seen` description for rtm by removing Web-api information about status_code
- API versions v3.1, v3.2
- RTM

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)

### Content

- Proofreading/content fixes
