### PR TITLE
Restore API-6209: update queue and transfers.

### DIFF
--- a/content/management/changelog/index.mdx
+++ b/content/management/changelog/index.mdx
@@ -45,7 +45,7 @@ Since the migration is still ongoing, different parts will be successively moved
 - The [**Create Bot**](/management/configuration-api/v3.2/#create-bot) method no longer accepts the `status` parameter. The initial value is now `__offline__`.
 - The [**Update Bot**](/management/configuration-api/v3.2/#update-bot) method no longer accepts the `status` parameter. To change the Bot's status, use [**Set Routing Status**](/messaging/agent-chat-api/v3.2/rtm-reference/#set-routing-status) from **the Agent Chat API**.
 - You can now update other Bot within the same license. To do that, call the [**Update Bot**](/management/configuration-api/v3.2/#update-bot) method with the `agents-bot--all:rw` scope.
-- The [**Chat access**](/management/configuration-api/v3.2/#chat-access) webhooks, `access_set`, `access_revoked`, and `access_granted` were renamed to `chat_access_set`, `chat_access_revoked`, and `chat_access_granted`, respectively. These webhooks no longer include the `resource` parameter.
+- The [**Chat access**](/management/configuration-api/v3.2/#chat-access) webhooks, `access_revoked`, and `access_granted` were renamed to `chat_access_revoked`, and `chat_access_granted`, respectively. These webhooks no longer include the `resource` parameter.
 - Many methods and webhooks have been renamed:
   - method: **Get Property Configs** -> **List Registered Properties**
   - method: **Create Properties** -> **Register Properties**
@@ -55,16 +55,19 @@ Since the migration is still ongoing, different parts will be successively moved
   - method: **Update Bot Agent** -> **Update Bot**
   - method: **Create Bot Agent** -> **Create Bot**
   - method: **Remove Bot Agent** -> **Delete Bot**
-  - webhook: **Chat Thread Properties Updated** -> **Thread Properties Updated**
-  - webhook: **Chat Thread Properties Deleted** -> **Thread Properties Deleted**
-  - webhook: **Thread Closed** -> **Chat Deactivated**
-  - webhook: **Incoming Chat Thread** -> **Incoming Chat**
-  - webhook: **Chat Thread Tagged** -> **Thread Tagged**
-  - webhook: **Chat Thread Untagged** -> **Thread Untagged**
+  - webhook: **chat_thread_properties_updated** -> **thread_properties_updated**
+  - webhook: **chat_thread_properties_deleted** -> **thread_properties_deleted**
+  - webhook: **thread_closed** -> **chat_deactivated**
+  - webhook: **incoming_chat_thread** -> **incoming_chat**
+  - webhook: **chat_thread_tagged** -> **thread_tagged**
+  - webhook: **chat_thread_untagged** -> **thread_untagged**
+  - webhook: **chat_user_added** -> **user_added_to_chat**
+  - webhook: **chat_user_removed** -> **user_removed_from_chat**
 
 ### Removed
 
 - The `agent_status_changed` webhook was removed.
+- The `access_set` webhook was removed.
 
 ## [v3.1] - 2019-09-17
 

--- a/content/management/configuration-api/index.mdx
+++ b/content/management/configuration-api/index.mdx
@@ -1835,7 +1835,7 @@ Here's what you need to know about **webhooks**:
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                                           |
 | **Chat access** | [`chat_access_granted`](#chat_access_granted) [`chat_access_revoked`](#chat_access_revoked) [`chat_access_set`](#chat_access_set)                                                                                                                                                                                                                                   |
-| **Chat users**  | [`chat_user_added`](#chat_user_added) [`chat_user_removed`](#chat_user_removed)                                                                                                                                                                                                                                                                                     |
+| **Chat users**  | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                                     |
 | **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated) [`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                           |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_deleted`](#thread_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
 | **Thread tags** | [`thread_tagged`](#thread_tagged) [`thread_untagged`](#thread_untagged)                                                                                                                                                                                                                                                                         |
@@ -2153,7 +2153,7 @@ Informs that new, single access to a chat was set. The existing access is overwr
 
 <Text>
 
-### `chat_user_added`
+### `user_added_to_chat`
 
 Informs that a user (Customer or Agent) was added to a chat.
 
@@ -2161,8 +2161,8 @@ Informs that a user (Customer or Agent) was added to a chat.
 
 |                     |                                                           |
 | ------------------- | --------------------------------------------------------- |
-| **Action**          | `chat_user_added`                                          |
-| **Push equivalent in** | [`Agent Chat API`](/messaging/agent-chat-api/v3.2/rtm-reference/#chat_user_added) [`Customer Chat API`](/messaging/customer-chat-api/v3.2/rtm-reference/#chat_user_added)|
+| **Action**          | `user_added_to_chat`                                          |
+| **Push equivalent in** | [`Agent Chat API`](/messaging/agent-chat-api/v3.2/rtm-reference/#user_added_to_chat) [`Customer Chat API`](/messaging/customer-chat-api/v3.2/rtm-reference/#user_added_to_chat)|
 
 #### Webhook payload
 
@@ -2180,19 +2180,20 @@ Informs that a user (Customer or Agent) was added to a chat.
 {
   "webhook_id": "<webhook_id>",
   "secret_key": "<secret_key>",
-  "action": "chat_user_added",
+  "action": "user_added_to_chat",
   "license_id": 104130623,
   "payload": {
     "chat_id": "PJ0MRSHTDG",
     "thread_id": "K600PKZON8",
     "user": {
       // "User > Customer" or "User > Agent" object
-        },
-    "user_type": "agent"
     },
+    "reason": "manual",
+    "requester_id": "smith@example.com"
+  },
   "additional_data": {
     "chat_properties": { //optional
-        // chat properties
+      // chat properties
     }
   }
 }
@@ -2208,7 +2209,7 @@ Informs that a user (Customer or Agent) was added to a chat.
 
 <Text>
 
-### `chat_user_removed`
+### `user_removed_from_chat`
 
 Informs that a user (Customer or Agent) was removed from a chat.
 
@@ -2216,8 +2217,8 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 |                     |                                                           |
 | ------------------- | --------------------------------------------------------- |
-| **Action**          | `chat_user_removed`                                          |
-| **Push equivalent in** | [`Agent Chat API`](/messaging/agent-chat-api/v3.2/rtm-reference/#chat_user_removed) [`Customer Chat API`](/messaging/customer-chat-api/v3.2/rtm-reference/#chat_user_removed)|
+| **Action**          | `user_removed_from_chat`                                          |
+| **Push equivalent in** | [`Agent Chat API`](/messaging/agent-chat-api/v3.2/rtm-reference/#user_removed_from_chat) [`Customer Chat API`](/messaging/customer-chat-api/v3.2/rtm-reference/#user_removed_from_chat)|
 
 #### Webhook payload
 
@@ -2235,17 +2236,18 @@ Informs that a user (Customer or Agent) was removed from a chat.
 {
   "webhook_id": "<webhook_id>",
   "secret_key": "<secret_key>",
-  "action": "chat_user_removed",
+  "action": "user_removed_from_chat",
   "license_id": 104130623,
   "payload": {
     "chat_id": "PJ0MRSHTDG",
     "thread_id": "K600PKZON8",
-    "user_id": "agent1@example.com",
-    "user_type": "agent"
+    "user_id": "agent@example.com",
+    "reason": "manual",
+    "requester_id": "smith@example.com"
   },
   "additional_data": {
     "chat_properties": { //optional
-        // chat properties
+      // chat properties
     }
   }
 }
@@ -3079,8 +3081,8 @@ __*__ The table below presents the possible values for the `action` parameter.
 | [`chat_access_granted`](#chat_access_granted)                       | `chat_member_ids`, `only_my_chats`                |
 | [`chat_access_revoked`](#chat_access_revoked)                       | `chat_member_ids`, `only_my_chats`                |
 | [`chat_access_set`](#chat_access_set)                               | `chat_member_ids`, `only_my_chats`                |
-| [`chat_user_added`](#chat_user_added)                               | `chat_member_ids`, `only_my_chats`                |
-| [`chat_user_removed`](#chat_user_removed)                           | `chat_member_ids`, `only_my_chats`                |
+| [`user_added_to_chat`](#user_added_to_chat)                         | `chat_member_ids`, `only_my_chats`                |
+| [`user_removed_from_chat`](#user_removed_from_chat)                 | `chat_member_ids`, `only_my_chats`                |
 | [`incoming_event`](#incoming_event)                                 | `chat_member_ids`, `author_type`, `only_my_chats` |
 | [`event_updated`](#event_updated)                                   | `chat_member_ids`, `author_type`, `only_my_chats` |
 | [`incoming_rich_message_postback`](#incoming_rich_message_postback) | `chat_member_ids`, `only_my_chats`                |

--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -22,6 +22,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - The **List Archives** ([Web](/messaging/agent-chat-api/v3.2/#list-archives) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#list-archives)) method has new pagination with hashed page IDs replacing the old pagination format. Pagination is now uniform across the whole Agent Chat API.
 - There's a new method **List Threads** ([Web](/messaging/agent-chat-api/v3.2/#list-threads) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#list-threads)).
 - There's a new `highlights` parameter in the **List Archives** ([Web](/messaging/agent-chat-api/v3.2/#list-archives) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#list-archives)) method. It allows you to highlight the match of `filters.query` with an HTML tag.
+- There's a new push [`queue_positions_updated`](/messaging/agent-chat-api/v3.2/rtm-reference/#queue_positions_updated) with updated positions and wait times for queued chats.
 
 ### Changed
 
@@ -34,7 +35,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - The **Add User to Chat** method ([Web](/messaging/agent-chat-api/v3.2/#add-user-to-chat) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#add-user-to-chat)) accepts an optional parameter `require_active_thread`.
 - There's a new parameter `away` in the [Login](/messaging/agent-chat-api/v3.2/rtm-reference/#login) method. It was introduced to prevent chat assignments after unexpected reconnects.
 - Each method, response, and push that deals with a variation of customer `fields` had this field renamed to `session_fields` and its format changed. It's now an array that respects the item order.
-- The **Chat access** ([Web](/messaging/agent-chat-api/v3.2/#chat-access) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#chat-access)) methods, `grant_access`, `revoke_access`, and `set_access` were renamed, respectively, to `grant_chat_access`, `revoke_chat_access`, and `set_chat_access` along with the corresponding [pushes](/messaging/agent-chat-api/v3.2/rtm-reference/#chat-access-1). These methods no longer accept the `resource` parameter.
+- The **Chat access** ([Web](/messaging/agent-chat-api/v3.2/#chat-access) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#chat-access)) methods, `grant_access` and `revoke_access` were renamed, respectively, to `grant_chat_access` and `revoke_chat_access` along with the corresponding [pushes](/messaging/agent-chat-api/v3.2/rtm-reference/#chat-access-1). These methods no longer accept the `resource` parameter.
 - Many methods and pushes have been renamed:
   - method: **Get Customers** -> **List Customers**
   - method: **Get Archives** -> **List Archives**
@@ -44,18 +45,30 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
   - method: **Tag Chat Thread** -> **Tag Thread** and push: **Chat Thread Tagged** -> **Thread Tagged**
   - method: **Untag Chat Thread** -> **Untag Thread** and push: **Chat Thread Untagged** -> **Thread Untagged**
   - method: **Close Thread** -> **Deactivate Chat** and push: **Thread Closed** -> **Chat Deactivated**
-  - push: **Incoming Chat Thread** -> **Incoming Chat**
-- `order` has been renamed to `sort_order` in **List Chats**, **Get Chat Threads Summary** and **List Customers**.
-- `scopes` in **Multicast** has been renamed to `recipients`.
-- There're new fields `previous_thread_id` and `next_thread_id` in the [**Thread**](/messaging/agent-chat-api/v3.2/#threads) data structure.
-- Fields `order` and `timestamp` in the [**Thread**](/messaging/agent-chat-api/v3.2/#threads) data structure were replaced with the new field, `created_at` (date & time in microseconds in UTC).
+  - push: **incoming_chat_thread** -> **incoming_chat**
+- The `order` field has been renamed to `sort_order` in **List Chats**, **Get Chat Threads Summary**, and **List Customers**.
+- The `scopes` field in **Multicast** has been renamed to `recipients`.
+- There are new fields, `previous_thread_id`, `next_thread_id`, `queue` and `queues_duration` in the [**Thread**](/messaging/agent-chat-api/v3.2/#threads) data structure.
+- There's a new field `queue` in [**Chat summary**](/messaging/agent-chat-api/v3.2/#chat-summaries), nested in `last_thread_summary`.
+- The `order` and `timestamp` fields in the [**Thread**](/messaging/agent-chat-api/v3.2/#threads) data structure were replaced with the new field, `created_at` (date & time in microseconds in UTC).
 - The **Get Chat Threads** method evolved into **Get Chat** ([Web](/messaging/agent-chat-api/v3.2/#get-chat) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#get-chat)). It now allows to retrieve a chat containing a particular thread. It also changed its shape; it no longer contains the `order` field and the `chat` key.
 - The `order` field in the `chat` object was removed from the responses of the **Login** and **List Chats** methods.
+- **Transfer Chat** ([Web](/messaging/agent-chat-api/v3.2/#transfer-chat) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#transfer-chat)) can now be used with inactive chats.
+- There are new fields, `requester_id` and `transferred_from` in [`incoming_chat`](/messaging/agent-chat-api/v3.2/rtm-reference/#incoming_chat).
+- The [`chat_transferred`](/messaging/agent-chat-api/v3.2/rtm-reference/#chat_transferred-1) push is no longer tied directly to **Transfer Chat**. Now, it can be generated when the transfer is implicit, for example, agents are reassigned due to their inactivity.
+- There are new fields, `requester_id`, `thread_id`, `reason`, `queue` and `transferred_to` in `chat_transferred`.
+- The `chat_user_added` push was renamed to [`user_added_to_chat`](/messaging/agent-chat-api/v3.2/rtm-reference/#user_added_to_chat). It has new fields: `reason` and `requester_id`.
+- The `chat_user_removed` push was renamed to [`user_removed_from_chat`](/messaging/agent-chat-api/v3.2/rtm-reference/#user_removed_from_chat). It has new fields: `reason` and `requester_id`.
 
 ### Removed
 
 - The **Update Agent** and **Get Chat Threads Summary** methods were removed.
-- The **Agent Updated** push was removed.
+- The `agent_updated` push was removed.
+- The **Set Chat Access** method was removed. Its use cases are now covered by the **Transfer Chat**.
+- The `chat_access_set` push was removed.
+- The `type` and `ids` fields were removed from the `chat_transferred` push.
+- The `user_type` field was removed from the `user_added_to_chat` push.
+- The `user_type` field was removed from the `user_removed_from_chat` push.
 
 ## [v3.1] - 2019-09-17
 

--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -664,6 +664,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
 | `properties`         | optional  |                                                                                            |
 | `restricted_access`  | optional  |                                                                                            |
+| `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                               |
 | `created_at`         | required  | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
@@ -1682,7 +1683,7 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 | **Method URL**         | `https://api.livechatinc.com/v3.2/agent/action/add_user_to_chat`    |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw`                   |
 | **RTM API equivalent** | [`add_user_to_chat`](rtm-reference/#add-user-to-chat)               |
-| **Webhook**            | [`chat_user_added`](/management/configuration-api/#chat_user_added) |
+| **Webhook**            | [`user_added_to_chat`](/management/configuration-api/#user_added_to_chat) |
 
 #### Request
 
@@ -1732,7 +1733,7 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 | **Method URL**         | `https://api.livechatinc.com/v3.2/agent/action/remove_user_from_chat`   |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw`                       |
 | **RTM API equivalent** | [`remove_user_from_chat`](rtm-reference/#remove-user-from-chat)         |
-| **Webhook**            | [`chat_user_removed`](/management/configuration-api/#chat_user_removed) |
+| **Webhook**            | [`user_removed_from_chat`](/management/configuration-api/#user_removed_from_chat) |
 
 **Request payload**
 
@@ -1775,7 +1776,7 @@ https://api.livechatinc.com/v3.2/agent/action/remove_user_from_chat \
 
 Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request.
 
-It's possible to write to a chat without joining it. The user sending an event will be automatically added to the chat with the `present` parameter set to `false` (see [`chat_user_added`](/messaging/agent-chat-api/v3.2/rtm-reference/#chat_user_added)). **Sample use case:** a Bot Agent that sends messages visible to all chat participants without actually joining the chat.
+It's possible to write to a chat without joining it. The user sending an event will be automatically added to the chat with the `present` parameter set to `false` (see [`user_added_to_chat`](/messaging/agent-chat-api/rtm-reference/#user_added_to_chat)). **Sample use case:** a Bot Agent that sends messages visible to all chat participants without actually joining the chat.
 
 #### Specifics
 

--- a/content/messaging/agent-chat-api/payloads/other-structures/aa_chatSummary.json
+++ b/content/messaging/agent-chat-api/payloads/other-structures/aa_chatSummary.json
@@ -86,6 +86,11 @@
       "group_ids": [
         0
       ]
+    },
+    "queue": {
+      "position": 42,
+      "wait_time": 1337,
+      "queued_at": "2020-05-12T11:42:47.383000Z"
     }
   },
   "properites": {

--- a/content/messaging/agent-chat-api/payloads/other-structures/aa_thread.json
+++ b/content/messaging/agent-chat-api/payloads/other-structures/aa_thread.json
@@ -36,6 +36,12 @@
       2
     ]
   },
+  "queue": {
+    "position": 42,
+    "wait_time": 1337,
+    "queued_at": "2020-05-07T07:11:28.288340Z"
+  },
+  "queues_duration": 1337,
   "previous_thread_id": "K600PKZOM8",
   "next_thread_id": "K600PKZOO8",
   "created_at": "2020-05-07T07:11:28.288340Z"

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -692,6 +692,8 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
 | `properties`         | optional  |                                                                                            |
 | `restricted_access`  | optional  |                                                                                            |
+| `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
+| `queues_duration`    | optional  | Present only in the [List Archives](#list-archives) responses if the chat was queued.      |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                               |
 | `created_at`         | required  | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
@@ -709,7 +711,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 |                 |                                                                                                                                                                                                                                                                                                                                                         |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                 |
-| **Chat access** | [`grant_chat_access`](#grant-chat-access) [`revoke_chat_access`](#revoke-chat-access) [`set_chat_access`](#set-chat-access) [`transfer_chat`](#transfer-chat)                                                                                                                                                                                           |
+| **Chat access** | [`grant_chat_access`](#grant-chat-access) [`revoke_chat_access`](#revoke-chat-access) [`transfer_chat`](#transfer-chat)                                                                                                                                                                                                                           |
 | **Chat users**  | [`add_user_to_chat`](#add-user-to-chat) [`remove_user_from_chat`](#remove-user-from-chat)                                                                                                                                                                                                                                                               |
 | **Events**      | [`send_event`](#send-event) [`send_rich_message_postback`](#send-rich-message-postback)                                                                                                                                                                                                                                                                 |
 | **Properties**  | [`update_chat_properties`](#update-chat-properties) [`delete_chat_properties`](#delete-chat-properties) [`update_thread_properties`](#update-thread-properties) [`delete_thread_properties`](#delete-thread-properties) [`update_event_properties`](#update-event-properties) [`delete_event_properties`](#delete-event-properties) |
@@ -1781,68 +1783,6 @@ Grants access to a new chat without overwriting the existing ones.
 <Section>
 <Text>
 
-### Set Chat Access
-
-Grants access to a new chat overwriting the existing ones.
-
-#### Specifics
-
-|                        |                                                   |
-| ---------------------- | ------------------------------------------------- |
-| **Action**             | `set_chat_access`                                 |
-| **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw` |
-| **Web API equivalent** | [`set_chat_access`](../#set-chat-access)          |
-| **Push message**       | [`chat_access_set`](#chat_access_set)             |
-
-#### Request
-
-| Request object | Required | Type     | Notes                |
-| -------------- | -------- | -------- | -------------------- |
-| `id`           | Yes      | `string` | Chat Id              |
-| `access`       | Yes      | `object` |                      |
-| `access.type`  | Yes      | `string` | `group` or `agent`   |
-| `access.id`    | Yes      | `number` |                      |
-
-</Text>
-<Code>
-<CodeSample path={'REQUEST'}>
-
-```json
-{
-  "action": "set_chat_access",
-  "payload": {
-  "id": "PW94SJTGW6",
-  "access": {
-    "type": "group",
-    "id": 19
-  }
-  }
-}
-```
-
-</CodeSample>
-
-<CodeResponse>
-
-```json
-{
-  "request_id": "<request_id>", // optional
-  "action": "set_chat_access",
-  "type": "response",
-  "success": true,
-  "payload": {
-  // no response optional
-  }
-}
-```
-
-</CodeResponse>
-</Code>
-</Section>
-
-<Section>
-<Text>
-
 ### Transfer Chat
 
 Transfers a chat to an Agent or a group.
@@ -1919,7 +1859,7 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 | **Action**             | `add_user_to_chat`                                |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw` |
 | **Web API equivalent** | [`add_user_to_chat`](../#add-user-to-chat)        |
-| **Push message**       | [`chat_user_added`](#chat_user_added)             |
+| **Push message**       | [`user_added_to_chat`](#user_added_to_chat)       |
 
 #### Request
 
@@ -1980,7 +1920,7 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 | **Action**             | `remove_user_from_chat`                              |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw`    |
 | **Web API equivalent** | [`remove_user_from_chat`](../#remove-user-from-chat) |
-| **Push message**       | [`chat_user_added`](#chat_user_added)                |
+| **Push message**       | [`user_removed_from_chat`](#user_removed_from_chat)  |
 
 **Request payload**
 
@@ -2034,7 +1974,7 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 
 Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request.
 
-It's possible to write to a chat without joining it. The user sending an event will be automatically added to the chat with the `present` parameter set to `false` (see [`chat_user_added`](#chat_user_added)). **Sample use case:** a Bot Agent that sends messages visible to all chat participants without actually joining the chat.
+It's possible to write to a chat without joining it. The user sending an event will be automatically added to the chat with the `present` parameter set to `false` (see [`user_added_to_chat`](#user_added_to_chat)). **Sample use case:** a Bot Agent that sends messages visible to all chat participants without actually joining the chat.
 
 #### Specifics
 
@@ -3707,14 +3647,14 @@ Here's what you need to know about **pushes**:
 |                 |                                                                                                                                                                                                                                                                                                                                                                     |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                                   |
-| **Chat access** | [`chat_access_granted`](#chat_access_granted) [`chat_access_revoked`](#chat_access_revoked) [`chat_access_set`](#chat_access_set) [`chat_transferred`](#chat_transferred-1)                                                                                                                                                                                         |
-| **Chat users**  | [`chat_user_added`](#chat_user_added) [`chat_user_removed`](#chat_user_removed)                                                                                                                                                                                                                                                                                     |
+| **Chat access** | [`chat_access_granted`](#chat_access_granted) [`chat_access_revoked`](#chat_access_revoked) [`chat_transferred`](#chat_transferred-1)                                                                                                                                                                                                           |
+| **Chat users**  | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                 |
 | **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                            |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
 | **Thread tags** | [`thread_tagged`](#thread_tagged) [`thread_untagged`](#thread_untagged)                                                                                                                                                                                                                                                                         |
 | **Customers**   | [`customer_visit_started`](#customer_visit_started) [`customer_created`](#customer_created) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_banned`](#customer_banned) [`customer_visit_ended`](#customer_visit_ended)                                                                                         |
 | **Status**      | [`routing_status_set`](#routing_status_set) [`agent_disconnected`](#agent_disconnected)                                                                                                                                                                                                                                                                             |
-| **Other**       | [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_sneak_peek`](#incoming_sneak_peek) [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`chat_unfollowed`](#chat_unfollowed)                                                                                                                         |
+| **Other**       | [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_sneak_peek`](#incoming_sneak_peek) [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`chat_unfollowed`](#chat_unfollowed) [`queue_positions_updated`](#queue_positions_updated)                                               |
 
 </Text>
 
@@ -3748,20 +3688,25 @@ Informs about a chat coming with a new thread. The push payload contains the who
 
 ```json
 {
+  "requester_id": "smith@example.com",
   "chat": {
-  "id": "PJ0MRSHTDG",
-  "users": [
-    // array of "User" objects
-  ],
-  "properties": {
-    "0805e283233042b37f460ed8fbf22160": {
-    "string_property": "string value"
+    "id": "PJ0MRSHTDG",
+    "users": [
+      // array of "User" objects
+    ],
+    "properties": {
+      "0805e283233042b37f460ed8fbf22160": {
+      "string_property": "string value"
+      }
+      // ...
+    },
+    "thread": {
+      // "Thread" object
+    },
+    "transferred_from": {
+      "group_ids": [ 1 ],
+      "agent_ids": [ "agent@example.com" ]
     }
-    // ...
-  },
-  "thread": {
-    // "Thread" object
-  }
   }
 }
 ```
@@ -3863,35 +3808,6 @@ Informs that access to a certain chat was revoked.
 | ---------- | ------------- |
 | `id`       | Chat Id   |
 
-### `chat_access_set`
-Informs that new, single access to a chat was set. The existing access is overwritten.
-
-<CodeResponse title={'Sample push payload'}>
-
-```json
-{
-  "id": "PJ0MRSHTDG",
-  "access": {
-  "group_ids": [1]
-  }
-}
-```
-
-</CodeResponse>
-
-#### Specifics
-
-|                        |                                                                     |
-| ---------------------- | ------------------------------------------------------------------- |
-| **Action**             | `chat_access_set`                                                   |
-| **Webhook equivalent** | [`chat_access_set`](/management/configuration-api/v3.2/#chat_access_set) |
-
-#### Push payload
-
-| Object     | Notes         |
-| ---------- | ------------- |
-| `id`       | Chat Id   |
-
 ### `chat_transferred`
 Informs that a chat was transferred to a different group or to an Agent.
 
@@ -3900,9 +3816,17 @@ Informs that a chat was transferred to a different group or to an Agent.
 ```json
 {
   "chat_id": "PJ0MRSHTDG",
+  "thread_id": "K600PKZON8",
   "requester_id": "cb531744-e6a4-4ded-b3eb-b3eb4ded4ded",
-  "type": "agent",
-  "ids": ["smith@example.com"]
+  "transferred_to": {
+    "group_ids": [ 1 ],
+    "agent_ids": ["smith@example.com"],
+  },
+  "queue": {
+    "position": 42,
+    "wait_time": 1337,
+    "queued_at": "2019-12-09T12:01:18.909000Z"
+  }
 }
 ```
 
@@ -3919,12 +3843,14 @@ Informs that a chat was transferred to a different group or to an Agent.
 
 | Object | Notes                        |
 | ------ | ---------------------------- |
-| `type` | `agent` or `group`           |
-| `ids`  | `group` or `agent` IDs array |
+| `thread_id`      | present if the chat is active                        |
+| `transferred_to` | IDs of groups and Agents the chat is now assigned to |
+| `queue`          | present if the chat is queued after the transfer     |
 
 ## Chat users
 
-### `chat_user_added`
+### `user_added_to_chat`
+
 Informs that a user (Customer or Agent) was added to a chat.
 
 This push can be emitted with `user.present` set to `false` when a user writes to a chat without joining it. You can achieve that via the [Send Event](#send-event) method.
@@ -3938,7 +3864,8 @@ This push can be emitted with `user.present` set to `false` when a user writes t
   "user": {
   // "User > Customer" or "User > Agent" object
   },
-  "user_type": "agent"
+  "reason": "manual",
+  "requester_id": "smith@example.com"
 }
 ```
 
@@ -3948,17 +3875,19 @@ This push can be emitted with `user.present` set to `false` when a user writes t
 
 |                        |                                                             |
 | ---------------------- | ----------------------------------------------------------- |
-| **Action**             | `chat_user_added`                                           |
-| **Webhook equivalent** | [`chat_user_added`](/management/configuration-api/#chat_user_added) |
+| **Action**             | `user_added_to_chat`                                                      |
+| **Webhook equivalent** | [`user_added_to_chat`](/management/configuration-api/#user_added_to_chat) |
 
 #### Push payload
 
 | Object      | Notes                                |
 | ----------- | ------------------------------------ |
-| `user_type` | Possible values: `agent`, `customer` |
-| `thread_id` | Present when a user was added to an active chat. |
+| `thread_id`    | Present when a user was added to an active chat. |
+| `reason`       | Why the user was added.                          |
+| `requester_id` | Present if the user was added by an agent.       |
 
-### `chat_user_removed`
+### `user_removed_from_chat`
+
 Informs that a user (Customer or Agent) was removed from a chat.
 
 <CodeResponse title={'Sample push payload'}>
@@ -3967,8 +3896,9 @@ Informs that a user (Customer or Agent) was removed from a chat.
 {
   "chat_id": "PJ0MRSHTDG",
   "thread_id": "K600PKZON8",
-  "user_id": "smith@example.com",
-  "user_type": "agent"
+  "user_id": "agent@example.com",
+  "reason": "manual",
+  "requester_id": "smith@example.com"
 }
 ```
 
@@ -3978,15 +3908,16 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 |                        |                                                                 |
 | ---------------------- | --------------------------------------------------------------- |
-| **Action**             | `chat_user_removed`                                             |
-| **Webhook equivalent** | [`chat_user_removed`](/management/configuration-api/#chat_user_removed) |
+| **Action**             | `user_removed_from_chat`                                                          |
+| **Webhook equivalent** | [`user_removed_from_chat`](/management/configuration-api/#user_removed_from_chat) |
 
 #### Push payload
 
 | Object      | Notes                                |
 | ----------- | ------------------------------------ |
-| `user_type` | Possible values: `agent`, `customer` |
-| `thread_id` | Present when a user was removed from an active chat. |
+| `thread_id`    | Present when a user was removed from an active chat. |
+| `reason`       | Why the user was removed.                            |
+| `requester_id` | Present if the user was removed by an agent.         |
 
 ## Events
 
@@ -4689,6 +4620,39 @@ Informs that a chat has been unfollowed. Useful in multiple connection scenarios
 | ---------------------- | ----------------- |
 | **Action**             | `chat_unfollowed` |
 | **Webhook equivalent** | -                 |
+
+### `queue_positions_updated`
+
+New positions and wait times for queued chats.
+
+<CodeResponse title={'Sample push payload'}>
+
+```json
+[{
+  "chat_id": "PJ0MRSHTDG",
+  "thread_id": "K600PKZON8",
+  "queue": {
+    "position": 42,
+    "wait_time": 1337
+  }
+}, {
+  "chat_id": "PJ0VRSATDS",
+  "thread_id": "K60QPKSON9",
+  "queue": {
+    "position": 43,
+    "wait_time": 1373
+  }
+}]
+```
+
+</CodeResponse>
+
+#### Specifics
+
+|                        |                           |
+|------------------------|---------------------------|
+| **Action**             | `queue_positions_updated` |
+| **Webhook equivalent** | -                         |
 
 # Errors
 

--- a/content/messaging/agent-chat-api/v3.1/index.mdx
+++ b/content/messaging/agent-chat-api/v3.1/index.mdx
@@ -2025,7 +2025,7 @@ https://api.livechatinc.com/v3.1/agent/action/remove_user_from_chat \
 
 Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request. 
 
-It's possible to write to a chat without joining it. The user sending an event will be automatically added to the chat with the `present` parameter set to `false` (see [`chat_user_added`](/messaging/agent-chat-api/rtm-reference/#chat_user_added)). **Sample use case:** a Bot Agent that sends messages visible to all chat participants without actually joining the chat.
+It's possible to write to a chat without joining it. The user sending an event will be automatically added to the chat with the `present` parameter set to `false` (see [`chat_user_added`](/messaging/agent-chat-api/v3.1/rtm-reference/#chat_user_added)). **Sample use case:** a Bot Agent that sends messages visible to all chat participants without actually joining the chat.
 
 #### Specifics
 

--- a/content/messaging/agent-chat-api/v3.1/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.1/rtm-reference/index.mdx
@@ -2400,7 +2400,7 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 | **Action**             | `remove_user_from_chat`                              |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw`    |
 | **Web API equivalent** | [`remove_user_from_chat`](../#remove-user-from-chat) |
-| **Push message**       | [`chat_user_added`](#chat_user_added)                |
+| **Push message**       | [`chat_user_removed`](#chat_user_removed)            |
 
 **Request payload**
 

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -15,6 +15,7 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 
 - There are new methods: **Get Customer** ([Web](/messaging/customer-chat-api/v3.2/#get-customer) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#get-customer)), **Accept Greeting** ([Web](/messaging/customer-chat-api/v3.2/#accept-greeting) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#accept-greeting)), **Cancel Greeting** ([Web](/messaging/customer-chat-api/v3.2/#cancel-greeting) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#cancel-greeting)), **List License Properties** ([Web](/messaging/customer-chat-api/v3.2/#list-license-properties)), **List Group Properties** ([Web](/messaging/customer-chat-api/v3.2/#list-group-properties)), **List Threads** ([Web](/messaging/customer-chat-api/v3.2/#list-threads) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#list-threads)).
 - There are new pushes: [`incoming_greeting`](/messaging/customer-chat-api/v3.2/rtm-reference/#incoming_greeting), [`greeting_accepted`](/messaging/customer-chat-api/v3.2/rtm-reference/#greeting_accepted), and [`greeting_canceled`](/messaging/customer-chat-api/v3.2/rtm-reference/#greeting_canceled).
+- There's a new push [`queue_position_updated`](/messaging/customer-chat-api/v3.2/rtm-reference/#queue_position_updated) with an updated queue position and wait time.
 
 ### Changed
 
@@ -40,10 +41,21 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 - The [Login](/messaging/customer-chat-api/v3.2/rtm-reference/#login) method was extended with the application info.
 - The **Get Chat Threads** method evolved into **Get Chat** ([Web](/messaging/customer-chat-api/v3.2/#get-chat) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#get-chat)). It now allows to retrieve a chat containing a particular thread. It also changed its shape; it no longer contains the `order` field and the `chat` key.
 - The `order` field in the `chat` object was removed from the payload of the **incoming_chat** push. Also, this field was replaced with `last_thread_created_at` in the response of the **List Chats** method.
+- There's a new field `queue` in the [**Thread**](/messaging/customer-chat-api/v3.2/#threads) data structure.
+- There's a new field `requester_id` in [`incoming_chat`](/messaging/customer-chat-api/v3.2/rtm-reference/#incoming_chat).
+- The [`chat_transferred`](/messaging/customer-chat-api/v3.2/rtm-reference/#chat_transferred-1) push is no longer tied directly to **Transfer Chat** ([Web](/messaging/agent-chat-api/v3.2/#transfer-chat) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#transfer-chat)). Now, it can be generated when the transfer is implicit, for example, agents are reassigned due to their inactivity.
+- There're new fields, `thread_id`, `reason`, `queue` and `transferred_to` in `chat_transferred`.
+- The `requester_id` field in the `chat_transferred` push is now optional and will be present only when `reason` is `manual`.
+- The `chat_user_added` push was renamed to [`user_added_to_chat`](/messaging/customer-chat-api/v3.2/rtm-reference/#user_added_to_chat). It has new fields: `reason` and `requester_id`.
+- The `chat_user_removed` push was renamed to [`user_removed_from_chat`](/messaging/customer-chat-api/v3.2/rtm-reference/#user_removed_from_chat). It has new fields: `reason` and `requester_id`.
 
 ### Removed
 
 - The **Get Chat Threads Summary** method was removed.
+- The `chat_access_set` push was removed.
+- The `type` and `ids` fields were removed from the `chat_transferred` push.
+- The `user_type` field was removed from the `user_added_to_chat` push.
+- The `user_type` field was removed from the `user_removed_from_chat` push.
 
 ## [v3.1] - 2019-09-17
 

--- a/content/messaging/customer-chat-api/index.mdx
+++ b/content/messaging/customer-chat-api/index.mdx
@@ -626,6 +626,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
 | `properties`         | optional  |                                                                                            |
 | `restricted_access`  | optional  |                                                                                            |
+| `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                               |
 | `created_at`         | required  | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |

--- a/content/messaging/customer-chat-api/payloads/other-structures/ca_thread.json
+++ b/content/messaging/customer-chat-api/payloads/other-structures/ca_thread.json
@@ -30,6 +30,11 @@
       0
     ]
   },
+  "queue": {
+    "position": 42,
+    "wait_time": 1337,
+    "queued_at": "2020-05-07T07:11:28.288340Z"
+  },
   "previous_thread_id": "K600PKZOM8",
   "next_thread_id": "K600PKZOO8",
   "created_at": "2020-05-07T07:11:28.288340Z"

--- a/content/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -658,6 +658,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
 | `properties`         | optional  |                                                                                            |
 | `restricted_access`  | optional  |                                                                                            |
+| `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                               |
 | `created_at`         | required  | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
@@ -2854,13 +2855,13 @@ Here's what you need to know about **pushes**:
 |                 |                                                                                                                                                                                                                                                                                                                                                                     |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                                   |
-| **Chat access** | [`access_set`](#access_set) [`chat_transferred`](#chat_transferred-1)                                                                                                                                                                                                                                                                                               |
-| **Chat users**  | [`chat_user_added`](#chat_user_added) [`chat_user_removed`](#chat_user_removed)                                                                                                                                                                                                                                                                                     |
+| **Chat access** | [`chat_transferred`](#chat_transferred-1)                                                                                                                                                                                                                                                                                                       |
+| **Chat users**  | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                 |
 | **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                            |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
 | **Customers**   | [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                                         |
 | **Status**      | [`customer_disconnected`](#customer_disconnected)                                                                                                                                                                                                                                                                                                                   |
-| **Other**       | [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_greeting`](#incoming_greeting) [`greeting_accepted`](#greeting_accepted) [`greeting_canceled`](#greeting_canceled)                                                                               |
+| **Other**       | [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_greeting`](#incoming_greeting) [`greeting_accepted`](#greeting_accepted) [`greeting_canceled`](#greeting_canceled) [`queue_position_updated`](#queue_position_updated)       |
 
 
 </Text>
@@ -2895,20 +2896,25 @@ Informs about a chat coming with a new thread. The push payload contains the who
 
 ```json
 {
+  "requester_id": "b5657aff34dd32e198160d54666df9d8",
   "chat": {
-  "id": "PJ0MRSHTDG",
-  "users": [
-    // array of "User" objects
-  ],
-  "properties": {
-    // "Properties" object
-  },
-  "access": {
-    // "Access" object
-  },
-  "thread": {
-    // "Thread" object
-  }
+    "id": "PJ0MRSHTDG",
+    "users": [
+      // array of "User" objects
+    ],
+    "properties": {
+      // "Properties" object
+    },
+    "access": {
+      // "Access" object
+    },
+    "thread": {
+      // "Thread" object
+    },
+    "transferred_from": {
+      "group_ids": [ 1 ],
+      "agent_ids": [ "bbb67d600796e9f277e360e842418833" ]
+    }
   }
 }
 ```
@@ -2952,38 +2958,6 @@ Informs that a chat was deactivated by closing the currently open thread.
 
 ## Chat access
 
-### `access_set`
-
-Informs that new, single access to a resource was set. The existing access is overwritten.
-
-<CodeResponse title={'Sample push payload'}>
-
-```json
-{
-  "resource": "chat",
-  "id": "PJ0MRSHTDG",
-  "access": {
-  "group_ids": [1]
-  }
-}
-```
-
-</CodeResponse>
-
-#### Specifics
-
-|                        |                                                           |
-| ---------------------- | --------------------------------------------------------- |
-| **Action**             | `access_set`                                              |
-| **Webhook equivalent** | [`access_set`](/management/configuration-api/#access_set) |
-
-#### Push payload
-
-| Object     | Notes         |
-| ---------- | ------------- |
-| `resource` | Resource type |
-| `id`       | Resource id   |
-
 ### `chat_transferred`
 Informs that a chat was transferred to a different group or to an Agent.
 
@@ -2993,9 +2967,16 @@ Informs that a chat was transferred to a different group or to an Agent.
 {
   "chat_id": "PJ0MRSHTDG",
   "thread_id": "K600PKZON8",
-  "requester_id": "cb531744-e6a4-4ded-b3eb-b3eb4ded4ded",
-  "type": "agent",
-  "ids": ["b7eff798-f8df-4364-8059-649c35c9ed0c"]
+  "requester_id": "b5657aff34dd32e198160d54666df9d8",
+  "transferred_to": {
+    "group_ids": [ 1 ],
+    "agent_ids": ["b5657aff34dd32e198160d54666df9d8"],
+  },
+  "queue": {
+    "position": 42,
+    "wait_time": 1337,
+    "queued_at": "2019-12-09T12:01:18.909000Z"
+  }
 }
 ```
 
@@ -3012,12 +2993,13 @@ Informs that a chat was transferred to a different group or to an Agent.
 
 | Object | Notes                                  |
 | ------ | -------------------------------------- |
-| `type` | `agent` or `group`                     |
-| `ids`  | An array of the `group` or `agent` IDs |
+| `thread_id`      | Present if the chat is active                          |
+| `transferred_to` | IDs of groups and Agents the chat has been assigned to |
+| `queue`          | Present if the chat is queued after the transfer       |
 
 ## Chat users
 
-### `chat_user_added`
+### `user_added_to_chat`
 Informs that a user (Customer or Agent) was added to a chat.
 
 This push can be emitted with `user.present` set to `false` when a user writes to a chat without joining it. You can achieve that via the [Send Event](/messaging/agent-chat-api/v3.2/rtm-reference/#send-event) method.
@@ -3031,7 +3013,8 @@ This push can be emitted with `user.present` set to `false` when a user writes t
   "user": {
   // "User > Customer" or "User > Agent" object
   },
-  "user_type": "customer"
+  "reason": "manual",
+  "requester_id": "b5657aff34dd32e198160d54666df9d8"
 }
 ```
 
@@ -3041,17 +3024,18 @@ This push can be emitted with `user.present` set to `false` when a user writes t
 
 |                        |                                                                     |
 | ---------------------- | ------------------------------------------------------------------- |
-| **Action**             | `chat_user_added`                                                   |
-| **Webhook equivalent** | [`chat_user_added`](/management/configuration-api/#chat_user_added) |
+| **Action**             | `user_added_to_chat`                                                   |
+| **Webhook equivalent** | [`user_added_to_chat`](/management/configuration-api/#user_added_to_chat) |
 
 #### Push payload
 
 | Object      | Notes                                            |
 | ----------- | ------------------------------------------------ |
-| `user_type` | Possible values: `agent`, `customer`             |
-| `thread_id` | Present when a user was added to an active chat. |
+| `thread_id`    | Present when a user was added to an active chat. |
+| `reason`       | Why the user was added.                          |
+| `requester_id` | Present if the user was added by an agent.       |
 
-### `chat_user_removed`
+### `user_removed_from_chat`
 Informs that a user (Customer or Agent) was removed from a chat.
 
 <CodeResponse title={'Sample push payload'}>
@@ -3060,8 +3044,9 @@ Informs that a user (Customer or Agent) was removed from a chat.
 {
   "chat_id": "PJ0MRSHTDG",
   "thread_id": "K600PKZON8",
-  "user_id": "user@example.com",
-  "user_type": "customer"
+  "user_id": "bbb67d600796e9f277e360e842418833",
+  "reason": "manual",
+  "requester_id": "b5657aff34dd32e198160d54666df9d8"
 }
 ```
 
@@ -3071,15 +3056,16 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 |                        |                                                                         |
 | ---------------------- | ----------------------------------------------------------------------- |
-| **Action**             | `chat_user_removed`                                                     |
-| **Webhook equivalent** | [`chat_user_removed`](/management/configuration-api/#chat_user_removed) |
+| **Action**             | `user_removed_from_chat`                                                     |
+| **Webhook equivalent** | [`user_removed_from_chat`](/management/configuration-api/#user_removed_from_chat) |
 
 #### Push payload
 
 | Object      | Notes                                                |
 | ----------- | ---------------------------------------------------- |
-| `user_type` | Possible values: `agent`, `customer`                 |
-| `thread_id` | Present when a user was removed from an active chat. |
+| `thread_id`    | Present when a user was removed from an active chat. |
+| `reason`       | Why the user was removed.                            |
+| `requester_id` | Present if the user was removed by an agent.         |
 
 ## Events
 
@@ -3683,6 +3669,36 @@ Informs about a greeting rejected by the Customer. Also, the push is sent when a
 | Object      | Notes                                                      |
 | ----------- | ---------------------------------------------------------- |
 | `unique_id` | ID of the greeting that was generated, sent, and rejected. |
+
+### `queue_position_updated`
+
+Informs about an updated position in the queue and about the wait time.
+
+<CodeResponse title={'Sample push payload'}>
+
+```json
+{
+  "action": "queue_position_updated",
+  "type": "push",
+  "payload": {
+    "chat_id": "PJ0MRSHTDG",
+    "thread_id": "K600PKZON8",
+    "queue": {
+      "position": 42,
+      "wait_time": 1337
+    }
+  }
+}
+```
+
+</CodeResponse>
+
+#### Specifics
+
+|                        |                          |
+| ---------------------- | ------------------------ |
+| **Action**             | `queue_position_updated` |
+| **Webhook equivalent** | -                        |
 
 # Errors
 


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-6209-queue-transfers-restore)
- [Jira](https://livechatinc.atlassian.net/browse/API-6209)

## 📓 Description


## ✅ Checklist (for API docs)

- Changelog
- API versions
- Web & RTM
- **Table:** Available methods/webhooks/pushes
- **Table:** Specifics

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)

### Content

- New content
- Proofreading/content fixes
