### PR TITLE
Fixes in List Chats and List Archives

### DIFF
--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -1061,8 +1061,8 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 | ----------------------------------------------------- | -------- | --------- | ----------------------------------------------------------------------------------------- |
 | `filters`                                             | No       | `object`  |                                                                                           |
 | `filters.query`                                       | No       | `string`  |                                                                                           |
-| `filters.date_from`                                   | No       | `string`  | `YYYY-MM-DD` format                                                                       |
-| `filters.date_to`                                     | No       | `string`  | `YYYY-MM-DD` format                                                                       |
+| `filters.from`                                        | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.000000+HH:MM` |
+| `filters.to`                                          | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.000000+HH:MM` |
 | `filters.thread_ids`                                  | No       | `array`   | Array of thread IDs. Cannot be used with other filters or pagination; max array size: 20. |
 | `filters.group_ids`                                   | No       | `array`   | Array of group IDs. Max array size: 200                                                   |
 | `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     | **\* described below**                                                                    |

--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -1064,8 +1064,8 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 | ----------------------------------------------------- | -------- | --------- | ----------------------------------------------------------------------------------------- |
 | `filters`                                             | No       | `object`  |                                                                                           |
 | `filters.query`                                       | No       | `string`  |                                                                                           |
-| `filters.from`                                        | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.000000+HH:MM` |
-| `filters.to`                                          | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.000000+HH:MM` |
+| `filters.from`                                        | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.ssssssZHH:MM` |
+| `filters.to`                                          | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.ssssssZHH:MM` |
 | `filters.thread_ids`                                  | No       | `array`   | Array of thread IDs. Cannot be used with other filters or pagination; max array size: 20. |
 | `filters.group_ids`                                   | No       | `array`   | Array of group IDs. Max array size: 200                                                   |
 | `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     | **\* described below**                                                                    |

--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -766,9 +766,12 @@ There's only one value allowed for a single property.
 
 #### Response
 
-| Parameter     | Data type | Notes                                                                    |
-| ------------- | --------- | ------------------------------------------------------------------------ |
-| `found_chats` | `number`  | An estimated number. The real number of found chats can slightly differ. |
+| Parameter          | Data type   | Notes                                                                    |
+| ------------------ | ----------- | ------------------------------------------------------------------------ |
+| `chats_summary`    | `array`     | An array of [Chat summary](#chat-summaries) data structures |
+| `next_page_id`     | `string`    | In relation to `page_id` specified in the request. Appears in the response only when there's a next page. |
+| `previous_page_id` | `string`    | In relation to `page_id` specified in the request Appears in the response only when there's a previous page.|
+| `found_chats`      | `number`    | An estimated number. The real number of found chats can slightly differ. |
 
 </Text>
 <Code>

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -1108,8 +1108,8 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 | ----------------------------------------------------- | -------- | --------- | ----------------------------------------------------------------------------------------- |
 | `filters`                                             | No       | `object`  |                                                                                           |
 | `filters.query`                                       | No       | `string`  |                                                                                           |
-| `filters.date_from`                                   | No       | `string`  | `YYYY-MM-DD` format                                                                       |
-| `filters.date_to`                                     | No       | `string`  | `YYYY-MM-DD` format                                                                       |
+| `filters.from`                                        | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.000000+HH:MM` |
+| `filters.to`                                           | No       | `string` | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.000000+HH:MM` |
 | `filters.group_ids`                                   | No       | `array`   | Array of group IDs. Max array size: 200                                                   |
 | `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     | **\* described below**                                                                    |
 | `filters.agents.<filter_type>`                        | No       | `any`     |  `exists` see to `false` will return unassigned chats; `true` will return the assigned ones.|

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -795,11 +795,12 @@ There's only one value allowed for a single property.
 
 #### Response
 
-| Parameter     | Data type | Notes                                                                     |
-| ------------- | --------- | ------------------------------------------------------------------------- |
-| `found_chats` | `number`  | An estimated number. The real number of found chats can slightly differ. |
-| `next_page_id`    | `string`  | In relation to `page_id` specified in the request. |
-| `previous_page_id`| `string`  | In relation to `page_id` specified in the request. |
+| Parameter          | Data type   | Notes                                                                     |
+| ------------------ | ----------- | ------------------------------------------------------------------------- |
+| `chats_summary`    | `array`     | An array of [Chat summary](#chat-summaries) data structures |
+| `next_page_id`     | `string`    | In relation to `page_id` specified in the request. Appears in the response only when there's a next page. |
+| `previous_page_id` | `string`    | In relation to `page_id` specified in the request Appears in the response only when there's a previous page.|
+| `found_chats`      | `number`    | An estimated number. The real number of found chats can slightly differ. |
 
 </Text>
 <Code>

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -1109,8 +1109,8 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 | ----------------------------------------------------- | -------- | --------- | ----------------------------------------------------------------------------------------- |
 | `filters`                                             | No       | `object`  |                                                                                           |
 | `filters.query`                                       | No       | `string`  |                                                                                           |
-| `filters.from`                                        | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.000000+HH:MM` |
-| `filters.to`                                           | No       | `string` | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.000000+HH:MM` |
+| `filters.from`                                        | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.ssssssZHH:MM` |
+| `filters.to`                                           | No       | `string` | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.ssssssZHH:MM` |
 | `filters.group_ids`                                   | No       | `array`   | Array of group IDs. Max array size: 200                                                   |
 | `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     | **\* described below**                                                                    |
 | `filters.agents.<filter_type>`                        | No       | `any`     |  `exists` see to `false` will return unassigned chats; `true` will return the assigned ones.|


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/fix-list-chats-and-list-archives)

## 📓 Description
- describe `next_page_id`, `chat-summaries`, and `previous_page_id` in List Chats (Agent APi)
- change `filters.date_from` and `filters.date_to` in List Archives

## 👷 Type of change (remove not needed)

### Content

- Proofreading/content fixes

