### PR TITLE
API-6512 documented new param for images in rich messages in v3.3 of …

### DIFF
--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -9,6 +9,12 @@ desc: "Changelog of the Agent Chat API"
 
 This document is the record of all the changes in the **Agent Chat API**, Web and RTM references, starting from **version 3.0**.
 
+## [v3.3] - Developer preview
+
+### Events
+
+- The **Rich Message** ([Web](/messaging/agent-chat-api/v3.3/#rich-message) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#rich-message)) images have a new parameter, `alternative_text`.
+
 ## [v3.2] - 2020-06-18
 
 ### Chats

--- a/content/messaging/agent-chat-api/v3.3/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/index.mdx
@@ -224,7 +224,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 | `elements`                       | no       | `array`   | Can contain up to 10 `element` objects.                                                           |
 | `elements.title`                 | yes      | `string`  | Displays formatted text on RMs.                                                                   |
 | `elements.subtitle`              | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.image`                 | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`.|
+| `elements.image`                 | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`, `alternative_text`.|
 | `elements.buttons`               | no       | `array`   | Displays buttons. Can contain up to 13 `button` objects.                                          |
 | `elements.buttons.text`          | yes      | `string`  | Text displayed on a button.                                                                       |
 | `elements.buttons.type`          | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value`. Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)  |

--- a/content/messaging/agent-chat-api/v3.3/payloads/events/aa_richMessage_v3_3.json
+++ b/content/messaging/agent-chat-api/v3.3/payloads/events/aa_richMessage_v3_3.json
@@ -21,7 +21,8 @@
         "content_type": "image/png",
         "size": 123444,
         "width": 640,
-        "height": 480
+        "height": 480,
+        "alternative_text": "A picture of lorem ipsum"
       },
       "buttons": [
         {

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -252,7 +252,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 | `elements`                       | no       | `array`   | Can contain up to 10 `element` objects.                                                           |
 | `elements.title`                 | yes      | `string`  | Displays formatted text on RMs.                                                                   |
 | `elements.subtitle`              | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.image`                 | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`.|
+| `elements.image`                 | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`, `alternative_text`.|
 | `elements.buttons`               | no       | `array`   | Displays buttons. Can contain up to 13 `button` objects.                                          |
 | `elements.buttons.text`          | yes      | `string`  | Text displayed on a button.                                                                       |
 | `elements.buttons.type`          | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value` (when  one of them is present, the other is required). Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)  |

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -9,6 +9,12 @@ desc: "Changelog of the Customer Chat API"
 
 This document is the record of all the changes in the **Customer Chat API**, Web and RTM, starting from **version 3.0**.
 
+## [v3.3] - Developer preview
+
+### Events
+
+- The **Rich Message** ([Web](/messaging/customer-chat-api/v3.3/#rich-message) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#rich-message)) images have a new parameter, `alternative_text`.
+
 ## [v3.2] - 2020-06-18
 
 ### Chats

--- a/content/messaging/customer-chat-api/v3.3/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/index.mdx
@@ -221,7 +221,7 @@ Rich message event contains rich message data structure. [Read more](/extending-
 | `elements`                       | no       | `array`   | Can contain up to 10 `element` objects.                                                           |
 | `elements.title`                 | yes      | `string`  | Displays formatted text on RMs.                                                                   |
 | `elements.subtitle`              | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.image`                 | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`.|
+| `elements.image`                 | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`, `alternative_text`.|
 | `elements.buttons`               | no       | `array`   | Displays buttons. Can contain up to 13 `button` objects.                                          |
 | `elements.buttons.text`          | yes      | `string`  | Text displayed on a button.                                                                       |
 | `elements.buttons.type`          | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value`. Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)  |

--- a/content/messaging/customer-chat-api/v3.3/payloads/events/ca_richMessage_v3_3.json
+++ b/content/messaging/customer-chat-api/v3.3/payloads/events/ca_richMessage_v3_3.json
@@ -20,7 +20,8 @@
         "content_type": "image/png",
         "size": 123444,
         "width": 640,
-        "height": 480
+        "height": 480,
+        "alternative_text": "A picture of lorem ipsum"
       },
       "buttons": [
         {

--- a/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
@@ -252,7 +252,7 @@ Rich message event contains rich message data structure. [Read more](/extending-
 | `elements`                       | no       | `array`   | Can contain up to 10 `element` objects.                                                           |
 | `elements.title`                 | yes      | `string`  | Displays formatted text on RMs.                                                                   |
 | `elements.subtitle`              | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.image`                 | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`.|
+| `elements.image`                 | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`, `alternative_text`.|
 | `elements.buttons`               | no       | `array`   | Displays buttons. Can contain up to 13 `button` objects.                                          |
 | `elements.buttons.text`          | yes      | `string`  | Text displayed on a button.                                                                       |
 | `elements.buttons.type`          | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value`. Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)  |


### PR DESCRIPTION
…agent-api and customer-api

## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-6512)
- [Jira](https://livechatinc.atlassian.net/browse/API-6512)

## 📓 Description

Images in Rich Messages have a new optional param: `alternative_text`. Only in v3.3 of agent-api and customer-api.

## ✅ Checklist (for API docs)

- Changelog
- API versions
- Web & RTM
- **Table:** Available methods/webhooks/pushes
- **Table:** Specifics

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)

New param for Rich Messages

### Content

- New content
- Proofreading/content fixes
 