### PR TITLE
API-6521 documented alternative_text for images in file event

### DIFF
--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -9,6 +9,12 @@ desc: "Changelog of the Agent Chat API"
 
 This document is the record of all the changes in the **Agent Chat API**, Web and RTM references, starting from **version 3.0**.
 
+## [v3.3] - Developer preview
+
+### Events
+
+- The **File** ([Web](/messaging/agent-chat-api/v3.3/#file) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#file)) event has a new parameter for images, `alternative_text`.
+
 ## [v3.2] - 2020-06-18
 
 ### Chats

--- a/content/messaging/agent-chat-api/v3.3/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/index.mdx
@@ -87,13 +87,14 @@ The **File** event informs about an uploaded file.
 
 ### Request
 
-| Field        | Required | Data type |                                                                                                                                     Notes |
-| ------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
-| `custom_id`  | no       | `string`  |                                                                                                                                           |
-| `type`       | yes      | `string`  |                                                                                                                                    `file` |
-| `recipients` | yes      | `string`  |                                                                                                Possible values: `all` (default), `agents` |
-| `properties` | no       | `object`  |                                                                                                                 [Properties](#properties) |
-| `url`        | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file). |
+| Field              | Required | Data type |                                                                                                                                     Notes |
+| ------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
+| `custom_id`        | no       | `string`  |                                                                                                                                           |
+| `type`             | yes      | `string`  |                                                                                                                                    `file` |
+| `recipients`       | yes      | `string`  |                                                                                                Possible values: `all` (default), `agents` |
+| `properties`       | no       | `object`  |                                                                                                                 [Properties](#properties) |
+| `url`              | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file). |
+| `alternative_text` | no       | `string`  | Only applicable to images                                                                                                                 |
 
 ### Response
 
@@ -111,6 +112,7 @@ The **File** event informs about an uploaded file.
 | `thumbnail_url`, `thumbnail2x_url` | only for images |                                                                     |
 | `content_type`                     | always          |                                                                     |
 | `size`, `width`, `height`          | only for images |                                                                     |
+| `alternative_text`                 | only for images |                                                                     |
 
 </Text>
 <Code>

--- a/content/messaging/agent-chat-api/v3.3/payloads/events/aa_file_v3_3.json
+++ b/content/messaging/agent-chat-api/v3.3/payloads/events/aa_file_v3_3.json
@@ -17,5 +17,6 @@
   "content_type": "image/png",
   "size": 123444,
   "width": 640,
-  "height": 480
+  "height": 480,
+  "alternative_text": "A sample image"
 }

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -115,13 +115,14 @@ The **File** event informs about an uploaded file.
 
 ### Request
 
-| Field                                                 | Required | Data type | Notes                                                               |
-| ----------------------------------------------------- | -------- | --------- | ------------------------------------------------------------------: |
-| `custom_id`                                           | no       | `string`  |                                                                     |
-| `type`                                                | yes      | `string`  | `file`                                                              |
-| `recipients`                                          | yes      | `string`  | Possible values: `all` (default), `agents`                          |
-| `properties`                                          | no       | `object`  | [Properties](#properties)                                           |
-| `url`                                                 | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file).|
+| Field              | Required | Data type | Notes                                                                                                                                     |
+| ------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
+| `custom_id`        | no       | `string`  |                                                                                                                                           |
+| `type`             | yes      | `string`  | `file`                                                                                                                                    |
+| `recipients`       | yes      | `string`  | Possible values: `all` (default), `agents`                                                                                                |
+| `properties`       | no       | `object`  | [Properties](#properties)                                                                                                                 |
+| `url`              | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file). |
+| `alternative_text` | no       | `string`  | Only applicable to images                                                                                                                 |
 
 ### Response
 
@@ -139,6 +140,7 @@ The **File** event informs about an uploaded file.
 | `thumbnail_url`, `thumbnail2x_url`  | only for images |                                                                     |
 | `content_type`                      | always          |                                                                     |
 | `size`, `width`, `height`           | only for images |                                                                     |
+| `alternative_text`                  | only for images |                                                                     |
 
 </Text>
 <Code>

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -9,6 +9,12 @@ desc: "Changelog of the Customer Chat API"
 
 This document is the record of all the changes in the **Customer Chat API**, Web and RTM, starting from **version 3.0**.
 
+## [v3.3] - Developer preview
+
+### Events
+
+- The **File** ([Web](/messaging/customer-chat-api/v3.3/#file) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#file)) event has a new parameter for images, `alternative_text`.
+
 ## [v3.2] - 2020-06-18
 
 ### Chats

--- a/content/messaging/customer-chat-api/v3.3/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/index.mdx
@@ -79,12 +79,13 @@ File event informs about a file being uploaded.
 
 ### Request
 
-| Field        | Required | Data type |                                                                                                                                     Notes |
-| ------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
-| `custom_id`  | no       | `string`  |                                                                                                                                           |
-| `type`       | yes      | `string`  |                                                                                                                                    `file` |
-| `properties` | no       | `object`  |                                                                                                                 [Properties](#properties) |
-| `url`        | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file). |
+| Field              | Required | Data type |                                                                                                                                     Notes |
+| ------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
+| `custom_id`        | no       | `string`  |                                                                                                                                           |
+| `type`             | yes      | `string`  |                                                                                                                                    `file` |
+| `properties`       | no       | `object`  |                                                                                                                 [Properties](#properties) |
+| `url`              | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file). |
+| `alternative_text` | no       | `string`  | Only applicable to images                                                                                                                 |
 
 ### Response
 
@@ -101,6 +102,7 @@ File event informs about a file being uploaded.
 | `thumbnail_url`, `thumbnail2x_url` | only for images |                                                                     |
 | `content_type`                     | always          |                                                                     |
 | `size`, `width`, `height`          | only for images |                                                                     |
+| `alternative_text`                 | only for images |                                                                     |
 
 </Text>
 

--- a/content/messaging/customer-chat-api/v3.3/payloads/events/ca_file_v3_3.json
+++ b/content/messaging/customer-chat-api/v3.3/payloads/events/ca_file_v3_3.json
@@ -16,5 +16,6 @@
   "content_type": "image/png",
   "size": 123444,
   "width": 640,
-  "height": 480
+  "height": 480,
+  "alternative_text": "A sample image"
 }

--- a/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
@@ -112,12 +112,13 @@ The **File** event informs about an uploaded file.
 
 ### Request
 
-| Field        | Required | Data type |                                                                                                                                     Notes |
-| ------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
-| `custom_id`  | no       | `string`  |                                                                                                                                           |
-| `type`       | yes      | `string`  |                                                                                                                                    `file` |
-| `properties` | no       | `object`  |                                                                                                                 [Properties](#properties) |
-| `url`        | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file). |
+| Field              | Required | Data type |                                                                                                                                     Notes |
+| ------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
+| `custom_id`        | no       | `string`  |                                                                                                                                           |
+| `type`             | yes      | `string`  |                                                                                                                                    `file` |
+| `properties`       | no       | `object`  |                                                                                                                 [Properties](#properties) |
+| `url`              | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file). |
+| `alternative_text` | no       | `string`  | Only applicable to images                                                                                                                 |
 
 ### Response
 
@@ -134,6 +135,7 @@ The **File** event informs about an uploaded file.
 | `thumbnail_url`, `thumbnail2x_url` | only for images |                                                                     |
 | `content_type`                     | always          |                                                                     |
 | `size`, `width`, `height`          | only for images |                                                                     |
+| `alternative_text`                 | only for images |                                                                     |
 
 </Text>
 


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-6521)
- [Jira](https://livechatinc.atlassian.net/browse/API-6521)

## 📓 Description

Support for `alternative_text` for images within File Events. Only available in v3.3 of agent-api and customer-api.

## ✅ Checklist (for API docs)

- Changelog
- API versions
- Web & RTM
- **Table:** Available methods/webhooks/pushes
- **Table:** Specifics

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)

New param in File Event

### Content

- New content
- Proofreading/content fixes
  
