### PR TITLE
API-6698: document auto access

### DIFF
--- a/content/management/changelog/index.mdx
+++ b/content/management/changelog/index.mdx
@@ -25,9 +25,9 @@ Since the migration is still ongoing, different parts will be successively moved
 ### Groups
 
 - There are new methods for managing auto access:
-  - [**Add Auto Access**](/management/configuration-api/v3.2/#add-auto-access)
-  - [**List Auto Accesses**](/management/configuration-api/v3.2/#list-auto-accesses)
-  - [**Delete Auto Access**](/management/configuration-api/v3.2/#delete-auto-access)
+  - [**Add Auto Access**](/management/configuration-api/v3.3/#add-auto-access)
+  - [**List Auto Accesses**](/management/configuration-api/v3.3/#list-auto-accesses)
+  - [**Delete Auto Access**](/management/configuration-api/v3.3/#delete-auto-access)
 
 ### Properties
 

--- a/content/management/changelog/index.mdx
+++ b/content/management/changelog/index.mdx
@@ -28,6 +28,7 @@ Since the migration is still ongoing, different parts will be successively moved
   - [**Add Auto Access**](/management/configuration-api/v3.3/#add-auto-access)
   - [**List Auto Accesses**](/management/configuration-api/v3.3/#list-auto-accesses)
   - [**Delete Auto Access**](/management/configuration-api/v3.3/#delete-auto-access)
+  - [**Reorder Auto Access**](/management/configuration-api/v3.3/#reorder-auto-access)
 
 ### Properties
 

--- a/content/management/changelog/index.mdx
+++ b/content/management/changelog/index.mdx
@@ -22,6 +22,12 @@ Since the migration is still ongoing, different parts will be successively moved
 - The [**Create Bot**](/management/configuration-api/v3.3/#create-bot) method has a new parameter, `timezone`. It's required when used with `work_scheduler`; otherwise optional.
 - The [**Update Bot**](/management/configuration-api/v3.3/#update-bot) method has a new parameter, `timezone`. It's required when used with `work_scheduler`; otherwise optional.
 
+### Groups
+
+- There are new methods for managing auto access:
+  - [**Add Auto Access**](/management/configuration-api/v3.2/#add-auto-access)
+  - [**List Auto Accesses**](/management/configuration-api/v3.2/#list-auto-accesses)
+  - [**Delete Auto Access**](/management/configuration-api/v3.2/#delete-auto-access)
 
 ### Properties
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -693,6 +693,9 @@ If a customer starts a chat via [**Start Chat**](/messaging/customer-chat-api/v3
 [**Activate Chat**](/messaging/customer-chat-api/v3.3/rtm-reference/#activate-chat) with the `chat.access` parameter,
 `chat.access` overrides the auto access assigned to the thread.
 
+Auto access rules are ordered using a linked list. Each of them points to the next element by keeping its `id` in the `next_id` field.
+For the last element of the list, the `next_id` is empty.
+
 ## Methods
 
 <Section>
@@ -711,34 +714,35 @@ Creates an `auto access` data structure, which is a set of conditions for the tr
 | Required scopes| `access_rules:rw`                                                             |
 
 
-| Parameter       | Required     | Data type | Notes                         |
-| --------------- | ------------ | --------- | ----------------------------- |
-| `access`        | Yes          | `object`  | Destination access            |
-| `access.groups` | Yes          | `[]int`   | Destination groups            |
-| `conditions`__**__   | Yes          | `object`  | Conditions to check                |
-| `conditions.customer_url` | No      | `object`  | The condition that matches on `customer_page.url` from **Login** or `url` from **Update Customer Page** |
-| `conditions.customer_domain` | No   | `object`  | The condition that matches on the domain of the `customer_url` |
-| `conditions.customer_*.values` | No | `[]match_object`_*_ | Positive match, may not be used together with `exclude_values` |
-| `conditions.customer_*.exclude_values` | No | `[]match_object` | Negative match |
-| `conditions.geolocation` | No   | `object`  | The condition that matches on the customer's geolocation |
-| `conditions.geolocation.values` | Yes | `[]geolocation_object`__**__ | An array of objects; matches when at least one subcondition matches. |
-| `description`   | No           | `string`  | Description of the auto access  |
+| Parameter                              | Required     | Data type                    | Notes                                                                                                   |
+| -------------------------------------- | ------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `access`                               | Yes          | `object`                     | Destination access                                                                                      |
+| `access.groups`                        | Yes          | `[]int`                      | Destination groups                                                                                      |
+| `conditions`__**__                     | Yes          | `object`                     | Conditions to check                                                                                     |
+| `conditions.customer_url`              | No           | `object`                     | The condition that matches on `customer_page.url` from **Login** or `url` from **Update Customer Page** |
+| `conditions.customer_domain`           | No           | `object`                     | The condition that matches on the domain of the `customer_url`                                          |
+| `conditions.customer_*.values`         | No           | `[]match_object`_*_          | Positive match, may not be used together with `exclude_values`                                          |
+| `conditions.customer_*.exclude_values` | No           | `[]match_object`             | Negative match                                                                                          |
+| `conditions.geolocation`               | No           | `object`                     | The condition that matches on the customer's geolocation                                                |
+| `conditions.geolocation.values`        | Yes          | `[]geolocation_object`__**__ | An array of objects; matches when at least one subcondition matches.                                    |
+| `description`                          | No           | `string`                     | Description of the auto access                                                                          |
+| `next_id`                              | No           | `string`                     | ID of an existing auto access. Leave empty if the new auto access should be the last.                   |
 
 __*__ `<match_object>` structure:
 
-| Parameter   | Required | Data type | Notes |
-| ----------- | -------- | --------- | ----- |
-| `value`     | Yes      | `string`  | A value to match |
-| `exact_match` | No     | `bool`    | If set to `false`, a `match_object.value` will be matched as a substring of the customer URL or domain. |
+| Parameter     | Required | Data type | Notes                                                                                                   |
+| ------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------- |
+| `value`       | Yes      | `string`  | A value to match                                                                                        |
+| `exact_match` | No       | `bool`    | If set to `false`, a `match_object.value` will be matched as a substring of the customer URL or domain. |
 
 __**__ the `geolocation_object` structure.  The condition is fulfilled only when all of the specified fields match:
 
-| Parameter   | Required | Data type | Example |
-| ----------- | -------- | --------- | ----- |
-| `country`   | No | `string` | "United States |
-| `country_code` | No | `string` | "US" |
-| `region` | No | `string` | "California" |
-| `city` | No | `string` | "Mountain View" |
+| Parameter      | Required | Data type | Example         |
+| -------------- | -------- | --------- | --------------- |
+| `country`      | No       | `string`  | "United States  |
+| `country_code` | No       | `string`  | "US"            |
+| `region`       | No       | `string`  | "California"    |
+| `city`         | No       | `string`  | "Mountain View" |
 
 
 </Text>
@@ -774,7 +778,8 @@ curl -X POST \
               }
             ]
           }
-        }
+        },
+        "next_id": "1faad6f5f1d6e8fdf27e8af9839783b7"
       }'
 ```
 
@@ -854,7 +859,8 @@ curl -X POST \
           }
         ]
       }
-    }
+    },
+    "next_id": "pqi8oasdjahuakndw9nsad9na"
   }
 ]
 ```
@@ -883,7 +889,7 @@ Deletes an existing `auto access` data structure specified by its ID.
 
 | Parameter              | Required     | Data type | Notes                         |
 | ---------------------- | ------------ | --------- | ----------------------------- |
-| `id`                   | Yes          | `string`  | auto access ID          |
+| `id`                   | Yes          | `string`  | Auto access ID                |
 
 #### Response
 
@@ -898,6 +904,54 @@ No response payload (`200 OK`).
 ```shell
 curl -X POST \
   https://api.livechatinc.com/v3.3/configuration/action/delete_auto_access \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <your_access_token>' \
+  -d '{
+    "id": "pqi8oasdjahuakndw9nsad9na"
+  }'
+```
+
+</CodeSample>
+
+</Code>
+
+</Section>
+
+<Section>
+
+<Text>
+
+### Reorder Auto Access
+
+Moves an existing `auto access` data structure, specified by `id`, in front of another, specified by `next_id`. 
+If `next_id` is empty, then the auto access will be placed at the end.
+
+#### Specifics
+
+|                |                                                                                  |
+| -------------- | -------------------------------------------------------------------------------- |
+| Method URL     | `https://api.livechatinc.com/v3.3/configuration/action/reorder_auto_access`      |
+| Required scopes| `access_rules:rw`                                                                |
+
+
+| Parameter              | Required     | Data type | Notes                                                                                                                     |
+| ---------------------- | ------------ | --------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | Yes          | `string`  | ID of the auto access to move                                                                                             |
+| `next_id`              | No           | `string`  | ID of the auto access which should follow the moved auto access. Leave empty if the moved auto access should be the last. |
+
+#### Response
+
+No response payload (`200 OK`).
+
+</Text>
+
+<Code>
+
+<CodeSample path={'REQUEST'}>
+
+```shell
+curl -X POST \
+  https://api.livechatinc.com/v3.3/configuration/action/reorder_auto_access \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <your_access_token>' \
   -d '{

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -924,7 +924,7 @@ curl -X POST \
 ### Reorder Auto Access
 
 Moves an existing `auto access` data structure, specified by `id`, before another one, specified by `next_id`. 
-If `next_id` is empty, then the auto access will be placed at the end.
+If `next_id` is empty, then the auto access will be placed at the end of the list.
 
 #### Specifics
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -937,7 +937,7 @@ If `next_id` is empty, then the auto access will be placed at the end.
 | Parameter              | Required     | Data type | Notes                                                                                                                     |
 | ---------------------- | ------------ | --------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `id`                   | Yes          | `string`  | ID of the auto access to move                                                                                             |
-| `next_id`              | No           | `string`  | ID of the auto access which should follow the moved auto access. Leave empty if the moved auto access should be the last. |
+| `next_id`              | No           | `string`  | ID of the auto access that should follow the moved auto access. Leave empty if the moved auto access should be the last. |
 
 #### Response
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -923,7 +923,7 @@ curl -X POST \
 
 ### Reorder Auto Access
 
-Moves an existing `auto access` data structure, specified by `id`, in front of another, specified by `next_id`. 
+Moves an existing `auto access` data structure, specified by `id`, before another one, specified by `next_id`. 
 If `next_id` is empty, then the auto access will be placed at the end.
 
 #### Specifics

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -955,7 +955,8 @@ curl -X POST \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <your_access_token>' \
   -d '{
-    "id": "pqi8oasdjahuakndw9nsad9na"
+    "id": "pqi8oasdjahuakndw9nsad9na",
+    "next_id": "1faad6f5f1d6e8fdf27e8af9839783b7"
   }'
 ```
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -726,7 +726,7 @@ Creates an `auto access` data structure, which is a set of conditions for the tr
 | `conditions.geolocation`               | No           | `object`                     | The condition that matches on the customer's geolocation                                                |
 | `conditions.geolocation.values`        | Yes          | `[]geolocation_object`__**__ | An array of objects; matches when at least one subcondition matches.                                    |
 | `description`                          | No           | `string`                     | Description of the auto access                                                                          |
-| `next_id`                              | No           | `string`                     | ID of an existing auto access. Leave empty if the new auto access should be the last.                   |
+| `next_id`                              | No           | `string`                     | ID of an existing auto access. Leave empty if the new auto access should be the last one on the list.   |
 
 __*__ `<match_object>` structure:
 
@@ -934,10 +934,10 @@ If `next_id` is empty, then the auto access will be placed at the end of the lis
 | Required scopes| `access_rules:rw`                                                                |
 
 
-| Parameter              | Required     | Data type | Notes                                                                                                                     |
-| ---------------------- | ------------ | --------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `id`                   | Yes          | `string`  | ID of the auto access to move                                                                                             |
-| `next_id`              | No           | `string`  | ID of the auto access that should follow the moved auto access. Leave empty if the moved auto access should be the last. |
+| Parameter              | Required     | Data type | Notes                                                                                                                                    |
+| ---------------------- | ------------ | --------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | Yes          | `string`  | ID of the auto access to move                                                                                                            |
+| `next_id`              | No           | `string`  | ID of the auto access that should follow the moved auto access. Leave empty if the moved auto access should be the last one on the list. |
 
 #### Response
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -680,6 +680,237 @@ curl -X POST \
 
 </Section>
 
+# Auto access
+
+**Auto access** allows you to assign groups to a thread that will be created when a customer starts a chat. Those groups are
+assigned based on the conditions defined to match the customer's geolocation and the page URL the customer is currently visiting.
+Every time a customer calls [**Login**](/messaging/customer-chat-api/v3.3/rtm-reference/#login) or
+[**Update Customer Page**](/messaging/customer-chat-api/v3.3/rtm-reference/#update-customer-page), our backend checks if
+the page URL and geolocation match the pre-defined conditions. Given there's a match, the groups are assigned to a thread,
+but not until a chat starts and the thread is actually created.
+
+If a customer starts a chat via [**Start Chat**](/messaging/customer-chat-api/v3.3/rtm-reference/#start-chat) or
+[**Activate Chat**](/messaging/customer-chat-api/v3.3/rtm-reference/#activate-chat) with the `chat.access` parameter,
+`chat.access` overrides the auto access assigned to the thread.
+
+## Methods
+
+<Section>
+
+<Text>
+
+### Add Auto Access
+
+Creates an `auto access` data structure, which is a set of conditions for the tracking URL and geolocation of a customer.
+
+#### Specifics
+
+|                |                                                                               |
+| -------------- | ----------------------------------------------------------------------------- |
+| Method URL     | `https://api.livechatinc.com/v3.3/configuration/action/add_auto_access`       |
+| Required scopes| `access_rules:rw`                                                             |
+
+
+| Parameter       | Required     | Data type | Notes                         |
+| --------------- | ------------ | --------- | ----------------------------- |
+| `access`        | Yes          | `object`  | Destination access            |
+| `access.groups` | Yes          | `[]int`   | Destination groups            |
+| `conditions`__**__   | Yes          | `object`  | Conditions to check                |
+| `conditions.customer_url` | No      | `object`  | The condition that matches on `customer_page.url` from **Login** or `url` from **Update Customer Page** |
+| `conditions.customer_domain` | No   | `object`  | The condition that matches on the domain of the `customer_url` |
+| `conditions.customer_*.values` | No | `[]match_object`_*_ | Positive match, may not be used together with `exclude_values` |
+| `conditions.customer_*.exclude_values` | No | `[]match_object` | Negative match |
+| `conditions.geolocation` | No   | `object`  | The condition that matches on the customer's geolocation |
+| `conditions.geolocation.values` | Yes | `[]geolocation_object`__**__ | An array of objects; matches when at least one subcondition matches. |
+| `description`   | No           | `string`  | Description of the auto access  |
+
+__*__ `<match_object>` structure:
+
+| Parameter   | Required | Data type | Notes |
+| ----------- | -------- | --------- | ----- |
+| `value`     | Yes      | `string`  | A value to match |
+| `exact_match` | No     | `bool`    | If set to `false`, a `match_object.value` will be matched as a substring of the customer URL or domain. |
+
+__**__ the `geolocation_object` structure.  The condition is fulfilled only when all of the specified fields match:
+
+| Parameter   | Required | Data type | Example |
+| ----------- | -------- | --------- | ----- |
+| `country`   | No | `string` | "United States |
+| `country_code` | No | `string` | "US" |
+| `region` | No | `string` | "California" |
+| `city` | No | `string` | "Mountain View" |
+
+
+</Text>
+
+<Code>
+
+<CodeSample path={'REQUEST'}>
+
+```shell
+curl -X POST \
+  https://api.livechatinc.com/v3.3/configuration/action/add_auto_access \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <your_access_token>' \
+  -d '{
+        "description": "Chats on livechat.com from United States",
+        "access": {
+          "groups": [ 1 ]
+        },
+        "conditions": {
+          "customer_domain": {
+            "values": [
+              {
+                "value": "livechat.com",
+                "exact_match": true
+              }
+            ]
+          },
+          "customer_geolocation": {
+            "values": [
+              {
+                "country": "United States",
+                "country_code": "US"
+              }
+            ]
+          }
+        }
+      }'
+```
+
+</CodeSample>
+
+<CodeResponse>
+
+```json
+{
+  "id": "pqi8oasdjahuakndw9nsad9na"
+}
+```
+
+</CodeResponse>
+
+</Code>
+
+</Section>
+
+<Section>
+
+<Text>
+
+### List Auto Accesses
+
+Returns all existing `auto access` data structures.
+
+#### Specifics
+
+|                |                                                                                      |
+| -------------- | ------------------------------------------------------------------------------------ |
+| Method URL     | `https://api.livechatinc.com/v3.3/configuration/action/list_auto_accesses`           |
+| Required scopes| `access_rules:ro`                                                                    |
+
+</Text>
+
+<Code>
+
+<CodeSample path={'REQUEST'}>
+
+```shell
+curl -X POST \
+  https://api.livechatinc.com/v3.3/configuration/action/list_auto_accesses \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <your_access_token>' \
+  -d '{}'
+```
+
+</CodeSample>
+
+<CodeResponse>
+
+```json
+[
+  {
+    "id": "1faad6f5f1d6e8fdf27e8af9839783b7",
+    "description": "Chats on livechat.com from United States",
+    "access": {
+      "groups": [
+        0
+      ]
+    },
+    "conditions": {
+      "customer_geolocation": {
+        "values": [
+          {
+            "country": "United States",
+            "country_code": "US"
+          }
+        ]
+      },
+      "customer_domain": {
+        "values": [
+          {
+            "value": "livechat.com",
+            "exact_match": true
+          }
+        ]
+      }
+    }
+  }
+]
+```
+
+</CodeResponse>
+
+</Code>
+
+</Section>
+
+<Section>
+
+<Text>
+
+### Delete Auto Access
+
+Deletes an existing `auto access` data structure specified by its ID.
+
+#### Specifics
+
+|                |                                                                                  |
+| -------------- | -------------------------------------------------------------------------------- |
+| Method URL     | `https://api.livechatinc.com/v3.3/configuration/action/delete_auto_access`       |
+| Required scopes| `access_rules:rw`                                                                |
+
+
+| Parameter              | Required     | Data type | Notes                         |
+| ---------------------- | ------------ | --------- | ----------------------------- |
+| `id`                   | Yes          | `string`  | auto access ID          |
+
+#### Response
+
+No response payload (`200 OK`).
+
+</Text>
+
+<Code>
+
+<CodeSample path={'REQUEST'}>
+
+```shell
+curl -X POST \
+  https://api.livechatinc.com/v3.3/configuration/action/delete_auto_access \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <your_access_token>' \
+  -d '{
+    "id": "pqi8oasdjahuakndw9nsad9na"
+  }'
+```
+
+</CodeSample>
+
+</Code>
+
+</Section>
+
 # Bots
 
 Bot enables writing integrations using the **Agent Chat API** - both [RTM](/messaging/agent-chat-api/rtm-reference/) and [Web](/messaging/agent-chat-api/) - to communicate in chats as regular Agents.


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-5804-auto-access-rules)
- [Jira](https://livechatinc.atlassian.net/browse/API-6698)

## 📓 Description
Docs for the auto access rules feature: the rules can be managed via the new methods in configuration-api v3.3.
There was already an attempt to release the feature in the past, hence the "old" branch name.

## ✅ Checklist (for API docs)

- Changelog
- API versions
- Web & RTM
- **Table:** Available methods/webhooks/pushes
- **Table:** Specifics

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)

### Content
- New content in configuration v3.3: new section Auto access rules
- Changelog entry for v3.3
  
### Features (for the website)
- New feature
