### PR TITLE
API-6944: approve_agent: update required scopes

### DIFF
--- a/content/management/configuration-api/index.mdx
+++ b/content/management/configuration-api/index.mdx
@@ -656,7 +656,7 @@ Approves an Agent thus allowing the Agent to use the application.
 | Method URL      | `https://api.livechatinc.com/v3.2/configuration/action/approve_agent` |
 | Required scopes | `agents-all:rw` `subscription_manage` __*__                           |
 
-__*__ `subscription_manage` is a private scope, it's not possible to obtain it via Developers Platform.
+__*__ `subscription_manage` is a private scope; it's not possible to configure it in Developer Console.
 
 #### Request
 

--- a/content/management/configuration-api/index.mdx
+++ b/content/management/configuration-api/index.mdx
@@ -654,7 +654,9 @@ Approves an Agent thus allowing the Agent to use the application.
 |                 |                                                                       |
 | --------------- | --------------------------------------------------------------------- |
 | Method URL      | `https://api.livechatinc.com/v3.2/configuration/action/approve_agent` |
-| Required scopes | `agents-all:rw` `billing:rw`                                          |
+| Required scopes | `agents-all:rw` `subscription_manage` __*__                           |
+
+__*__ `subscription_manage` is a private scope, it's not possible to obtain it via Developers Platform.
 
 #### Request
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -648,7 +648,7 @@ Approves an Agent thus allowing the Agent to use the application.
 | Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/approve_agent` |
 | Required scopes | `agents-all:rw` `subscription_manage` __*__                           |
 
-__*__ `subscription_manage` is a private scope, it's not possible to obtain it via Developers Platform.
+__*__ `subscription_manage` is a private scope; it's not possible to configure it in Developer Console.
 
 #### Request
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -646,7 +646,9 @@ Approves an Agent thus allowing the Agent to use the application.
 |                 |                                                                       |
 | --------------- | --------------------------------------------------------------------- |
 | Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/approve_agent` |
-| Required scopes | `agents-all:rw` `billing:rw`                                          |
+| Required scopes | `agents-all:rw` `subscription_manage` __*__                           |
+
+__*__ `subscription_manage` is a private scope, it's not possible to obtain it via Developers Platform.
 
 #### Request
 


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-6944-approve-agent)
- [Jira](https://livechatinc.atlassian.net/browse/API-6944)

## 📓 Description
Update scopes required by `approve_agent` - previous `billing:rw` was a virtual scope that would never be published. `subscription_manage` is virtually the same as `billing:rw` but is published :)

## ✅ Checklist (for API docs)

- Changelog
- API versions
- Web & RTM
- **Table:** Available methods/webhooks/pushes
- **Table:** Specifics

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)

### Content

- Proofreading/content fixes
