### PR TITLE
Update 'restricted_access' documentation

### DIFF
--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -63,6 +63,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - There's a new method, **List Threads** ([Web](/messaging/agent-chat-api/v3.2/#list-threads) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#list-threads)).
 - There's a new push, [**chat_unfollowed**](/messaging/agent-chat-api/v3.2/rtm-reference/#chat_unfollowed), complementary to the **Unfollow Chat** method.
 - The **Get Chat Threads Summary** method was removed.
+- The `restricted_access` field of **Thread**(/messaging/customer-chat-api/v3.2/#threads) is now of type `string` and contains reason for access restriction.
   
 ### Chat access
 

--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -63,8 +63,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - There's a new method, **List Threads** ([Web](/messaging/agent-chat-api/v3.2/#list-threads) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#list-threads)).
 - There's a new push, [**chat_unfollowed**](/messaging/agent-chat-api/v3.2/rtm-reference/#chat_unfollowed), complementary to the **Unfollow Chat** method.
 - The **Get Chat Threads Summary** method was removed.
-- The `restricted_access` field of **Thread**(/messaging/customer-chat-api/v3.2/#threads) is now of type `string` and contains reason for access restriction.
-  
+
 ### Chat access
 
 - The **Grant Access** method was renamed to **Grant Chat Access** ([Web](/messaging/agent-chat-api/v3.2/#grant-chat-access) & [RTM](/messaging/agent-chat-api/v3.2/rtm-reference/#grant-chat-access)).
@@ -99,6 +98,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - The [**Thread**](/messaging/agent-chat-api/v3.2/#threads) data structure:
   - has new fields: `previous_thread_id`, `next_thread_id`, `queue`, and `queues_duration`.
   - had the `order` and `timestamp` fields replaced with a new one, `created_at` (date & time in microseconds in UTC).
+  - had the `restricted_access` field type changed to `string`. It contains the reason for access restriction.
 - The [**Form field**](/messaging/agent-chat-api/v3.2/#form-fields) data structure has a new parameter, `id` (`fields.answer.id` for the `group_chooser` field type). It's an identifier for each option Customers can choose.
 - The [**Chat summary**](/messaging/agent-chat-api/v3.2/#chat-summaries) data structure has a new field, `queue`, nested in `last_thread_summary`.
 

--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -653,9 +653,9 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | -------------------- | --------- | ------------------------------------------------------------------------------------------ |
 | `access`             | optional  |                                                                                            |
 | `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active)       |
-| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
+| `events`             | optional  | Doesn't exists if `restricted_access` is present.                                          |
 | `properties`         | optional  |                                                                                            |
-| `restricted_access`  | optional  |                                                                                            |
+| `restricted_access`  | optional  | Contains reason for access restriction.                                                    |
 | `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                               |

--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -655,7 +655,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active)       |
 | `events`             | optional  | Doesn't exists if `restricted_access` is present.                                          |
 | `properties`         | optional  |                                                                                            |
-| `restricted_access`  | optional  | Contains reason for access restriction.                                                    |
+| `restricted_access`  | optional  | Contains the reason for access restriction.                                                |
 | `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                               |

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -676,9 +676,9 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | -------------------- | --------- | ------------------------------------------------------------------------------------------ |
 | `access`             | optional  |                                                                                            |
 | `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active)       |
-| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
+| `events`             | optional  | Doesn't exists if `restricted_access` is present.                                          |
 | `properties`         | optional  |                                                                                            |
-| `restricted_access`  | optional  |                                                                                            |
+| `restricted_access`  | optional  | Contains reason for access restriction.                                                    |
 | `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `queues_duration`    | optional  | Present only in the [List Archives](#list-archives) responses if the chat was queued.      |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
@@ -3091,7 +3091,7 @@ as `away`. [Read more...](#set-away-status)
       "thread_id": "K600PKZON8",
       "thread_created_at": "2020-05-07T07:11:28.288340Z",
       "event": {
-      // "restricted_access": true
+      // "restricted_access": "User has no access to following resource"
       // or
       // Event > Message object
       }
@@ -3100,7 +3100,7 @@ as `away`. [Read more...](#set-away-status)
       "thread_id": "K600PKZON8",
       "thread_created_at": "2020-05-07T07:11:28.288340Z",
       "event": {
-      // "restricted_access": true
+      // "restricted_access": "User has no access to following resource"
       // or
       // Event > System Message object
       }

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -678,7 +678,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active)       |
 | `events`             | optional  | Doesn't exists if `restricted_access` is present.                                          |
 | `properties`         | optional  |                                                                                            |
-| `restricted_access`  | optional  | Contains reason for access restriction.                                                    |
+| `restricted_access`  | optional  | Contains the reason for access restriction.                                                |
 | `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `queues_duration`    | optional  | Present only in the [List Archives](#list-archives) responses if the chat was queued.      |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |

--- a/content/messaging/agent-chat-api/v3.3/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/index.mdx
@@ -649,9 +649,9 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | -------------------- | --------- | ------------------------------------------------------------------------------------------ |
 | `access`             | optional  |                                                                                            |
 | `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active)       |
-| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
+| `events`             | optional  | Doesn't exists if `restricted_access` is present.                                          |
 | `properties`         | optional  |                                                                                            |
-| `restricted_access`  | optional  |                                                                                            |
+| `restricted_access`  | optional  | Contains reason for access restriction.                                                    |
 | `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                               |

--- a/content/messaging/agent-chat-api/v3.3/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/index.mdx
@@ -651,7 +651,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active)       |
 | `events`             | optional  | Doesn't exists if `restricted_access` is present.                                          |
 | `properties`         | optional  |                                                                                            |
-| `restricted_access`  | optional  | Contains reason for access restriction.                                                    |
+| `restricted_access`  | optional  | Contains the reason for access restriction.                                                |
 | `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                               |

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -680,7 +680,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active)       |
 | `events`             | optional  | Doesn't exists if `restricted_access` is present.                                          |
 | `properties`         | optional  |                                                                                            |
-| `restricted_access`  | optional  | Contains reason for access restriction.                                                    |
+| `restricted_access`  | optional  | Contains the reason for access restriction.                                                |
 | `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `queues_duration`    | optional  | Present only in the [List Archives](#list-archives) responses if the chat was queued.      |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -678,9 +678,9 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | -------------------- | --------- | ------------------------------------------------------------------------------------------ |
 | `access`             | optional  |                                                                                            |
 | `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active)       |
-| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
+| `events`             | optional  | Doesn't exists if `restricted_access` is present.                                          |
 | `properties`         | optional  |                                                                                            |
-| `restricted_access`  | optional  |                                                                                            |
+| `restricted_access`  | optional  | Contains reason for access restriction.                                                    |
 | `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `queues_duration`    | optional  | Present only in the [List Archives](#list-archives) responses if the chat was queued.      |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
@@ -3093,7 +3093,7 @@ as `away`. [Read more...](#set-away-status)
       "thread_id": "K600PKZON8",
       "thread_created_at": "2020-05-07T07:11:28.288340Z",
       "event": {
-      // "restricted_access": true
+      // "restricted_access": "User has no access to following resource"
       // or
       // Event > Message object
       }
@@ -3102,7 +3102,7 @@ as `away`. [Read more...](#set-away-status)
       "thread_id": "K600PKZON8",
       "thread_created_at": "2020-05-07T07:11:28.288340Z",
       "event": {
-      // "restricted_access": true
+      // "restricted_access": "User has no access to following resource"
       // or
       // Event > System Message object
       }

--- a/content/messaging/customer-chat-api/index.mdx
+++ b/content/messaging/customer-chat-api/index.mdx
@@ -612,9 +612,8 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | -------------------- | --------- | ------------------------------------------------------------------------------------------ |
 | `access`             | optional  |                                                                                            |
 | `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active).      |
-| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
+| `events`             | optional  |                                                                                            |
 | `properties`         | optional  |                                                                                            |
-| `restricted_access`  | optional  |                                                                                            |
 | `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                               |

--- a/content/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -639,9 +639,8 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | -------------------- | --------- | ------------------------------------------------------------------------------------------ |
 | `access`             | optional  |                                                                                            |
 | `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active).      |
-| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
+| `events`             | optional  |                                                                                            |
 | `properties`         | optional  |                                                                                            |
-| `restricted_access`  | optional  |                                                                                            |
 | `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                               |

--- a/content/messaging/customer-chat-api/v3.1/index.mdx
+++ b/content/messaging/customer-chat-api/v3.1/index.mdx
@@ -854,8 +854,6 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
       "thread_id": "K600PKZON8",
       "thread_order": 3,
       "event": {
-        // "restricted_access": true
-        // or
         // "Event > Message" object
       }
     },
@@ -863,8 +861,6 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
       "thread_id": "K600PKZON6",
       "thread_order": 1,
       "event": {
-        // "restricted_access": true
-        // or
         // "Event > System message" object
       }
     }
@@ -994,7 +990,6 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
   "timestamp": 1473433500,
   "active": true,
   "user_ids": ["agent1@example.com"],
-  "restricted_access": true,
   "events": [
     // array of "Event" objects
   ],
@@ -1014,9 +1009,8 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | ------------------- | :-------: | ------------------------------------------------------------------------------------: |
 | `access`            | optional  |                                                                                     - |
 | `active`            | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active). |
-| `events`            | optional  |                                      Doesn't exists if `restricted_access` is `true`. |
+| `events`            | optional  |                                                                                     - |
 | `properties`        | optional  |                                                                                     - |
-| `restricted_access` | optional  |                                                                                     - |
 
 # Methods
 

--- a/content/messaging/customer-chat-api/v3.1/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.1/rtm-reference/index.mdx
@@ -883,8 +883,6 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
       "thread_id": "K600PKZON8",
       "thread_order": 3,
       "event": {
-        // "restricted_access": true
-        // or
         // "Event > Message" object
       }
     },
@@ -892,8 +890,6 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
       "thread_id": "K600PKZON6",
       "thread_order": 1,
       "event": {
-        // "restricted_access": true
-        // or
         // "Event > System message" object
       }
     }
@@ -1023,7 +1019,6 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
   "timestamp": 1473433500,
   "active": true,
   "user_ids": ["agent1@example.com"],
-  "restricted_access": true,
   "events": [
     // array of "Event" objects
   ],
@@ -1043,9 +1038,8 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | ------------------- | :-------: | ------------------------------------------------------------------------------------: |
 | `access`            | optional  |                                                                                       |
 | `active`            | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active). |
-| `events`            | optional  |                                      Doesn't exists if `restricted_access` is `true`. |
+| `events`            | optional  |                                                                                       |
 | `properties`        | optional  |                                                                                       |
-| `restricted_access` | optional  |                                                                                       |
 
 # Methods
 In the websocket transport, actions generate [pushes](#pushes). RTM API actions can also trigger [webhooks](/management/configuration-api/v3.1/#webhooks), but they need to be registered first. 

--- a/content/messaging/customer-chat-api/v3.3/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/index.mdx
@@ -608,9 +608,8 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | -------------------- | --------- | ------------------------------------------------------------------------------------------ |
 | `access`             | optional  |                                                                                            |
 | `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active).      |
-| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
+| `events`             | optional  |                                                                                            |
 | `properties`         | optional  |                                                                                            |
-| `restricted_access`  | optional  |                                                                                            |
 | `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                               |

--- a/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
@@ -641,9 +641,8 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | -------------------- | --------- | ------------------------------------------------------------------------------------------ |
 | `access`             | optional  |                                                                                            |
 | `active`             | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active).      |
-| `events`             | optional  | Doesn't exists if `restricted_access` is `true`.                                           |
+| `events`             | optional  |                                                                                            |
 | `properties`         | optional  |                                                                                            |
-| `restricted_access`  | optional  |                                                                                            |
 | `queue`              | optional  | Present only if the chat is in the queue. Wait time is approximated in seconds.            |
 | `previous_thread_id` | optional  | Present only if there is a preceding thread.                                               |
 | `next_thread_id`     | optional  | Present only if there is a following thread.                                               |

--- a/payloads/messaging/v3.2/agent-chat-api/other-structures/thread.json
+++ b/payloads/messaging/v3.2/agent-chat-api/other-structures/thread.json
@@ -4,7 +4,7 @@
   "user_ids": [
     "smith@example.com"
   ],
-  "restricted_access": true,
+  "restricted_access": "You can't access threads older than 60 days on starter plan",
   "events": [
     {
       "id": "0affb00a-82d6-4e07-ae61-56ba5c36f743",

--- a/payloads/messaging/v3.2/customer-chat-api/other-structures/thread.json
+++ b/payloads/messaging/v3.2/customer-chat-api/other-structures/thread.json
@@ -4,7 +4,6 @@
   "user_ids": [
     "b7eff798-f8df-4364-8059-649c35c9ed0c"
   ],
-  "restricted_access": true,
   "events": [
     {
       "id": "QA1B38GHGI_1",

--- a/payloads/messaging/v3.3/agent-chat-api/other-structures/thread.json
+++ b/payloads/messaging/v3.3/agent-chat-api/other-structures/thread.json
@@ -4,7 +4,7 @@
   "user_ids": [
     "smith@example.com"
   ],
-  "restricted_access": true,
+  "restricted_access": "You can't access threads older than 60 days on starter plan",
   "events": [
     {
       "id": "0affb00a-82d6-4e07-ae61-56ba5c36f743",

--- a/payloads/messaging/v3.3/customer-chat-api/other-structures/thread.json
+++ b/payloads/messaging/v3.3/customer-chat-api/other-structures/thread.json
@@ -4,7 +4,6 @@
   "user_ids": [
     "b7eff798-f8df-4364-8059-649c35c9ed0c"
   ],
-  "restricted_access": true,
   "events": [
     {
       "id": "QA1B38GHGI_1",


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-6878-restricted-access)
- [Jira](https://livechatinc.atlassian.net/browse/API-6878)

## 📓 Description
Update `restricted_access` documentation.
In agent-api v3.2+ it's string field with reason for restriction.
In customer-api there's no restricted_access in any version.

## ✅ Checklist (for API docs)

- Changelog ✅
- API versions ✅
- Web & RTM ✅
- **Table:** Available methods/webhooks/pushes
- **Table:** Specifics

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)
Backwards-incompatible but very important.

### Content

- Proofreading/content fixes
  
### Features (for the website)

- Breaking change
