### PR TITLE
Change naming in Apple Business Chat docs

### DIFF
--- a/content/messaging/apple-business-chat/index.mdx
+++ b/content/messaging/apple-business-chat/index.mdx
@@ -8,138 +8,142 @@ desc: "Learn how implement services for Authorization, Apple Pay, Custom Extensi
 hidden: true
 ---
 
-[**Business Chat**](https://developer.apple.com/documentation/businesschat) is a service that allows your organization to communicate directly with your customers through your **Customer Service Platform (CSP)** using the Messages app. The Apple Business Chat integration creates the communication channel between **Apple's Messages app** and **LiveChat**. In such a case, **LiveChat** plays the role of a **CSP**.
+[**Business Chat**](https://developer.apple.com/documentation/businesschat) is a service that allows your organization to communicate directly with your customers through your **Messaging Service Provider (MSP)** using the Messages app. The Apple Business Chat integration creates the communication channel between **Apple's Messages app** and **LiveChat**. In such a case, **LiveChat** plays the role of a **MSP**.
 
-This article documents how to implement services for **Authorization**, **Apple Pay**, **Custom Extensions**, as well as **List** and **Date Pickers**. 
+This article documents how to implement services for **Authorization**, **Apple Pay**, **Custom Extensions**, as well as **List** and **Date Pickers**.
 
 ## Available methods
 
 ### Send List Picker
+
 Let the customer choose from a list of items by sending a list picker. More about <a href="https://developer.apple.com/documentation/businesschatapi/messages_sent/interactive_messages/list_picker" target="_blank" rel="noopener noreferrer">**list pickers...**</a>
 
 **Method URL:** `https://apple-csp.livechatinc.com/list-picker`
 
 **Required header:** `Authorization` with the agent's token
 
-| Request object          | Required | Data type | Notes
-| ----------------------- | -------- | -------- | -----
-| `chatId`                | Yes      | `string` | ID of an ABC chat
-| `threadId`              | Yes      | `string` | ID of an ABC thread
-| `title`                 | Yes      | `string` | Title of a list picker message
-| `subtitle`              | No       | `string` | Subtitle of a list picker message
-| `image`                 | No       | `string` | URL of a list picker image
-| `groups`                | Yes      | `array`  | Array of groups in a list picker
-| `groups.title`          | Yes      | `string` | Title of a group
-| `groups.multipleChoice` | Yes      | `bool`   | Should a user select multiple items in a group?
-| `groups.items`          | Yes      | `array`  | Array of items in a group
-| `groups.items.id`       | Yes      | `string` | Unique ID of an item
-| `groups.items.image`    | No       | `string` | URL of an item image
-| `groups.items.title`    | Yes      | `string` | Title of an item
-| `groups.items.subtitle` | No       | `string` | Subtitle of an item
+| Request object          | Required | Data type | Notes                                           |
+| ----------------------- | -------- | --------- | ----------------------------------------------- |
+| `chatId`                | Yes      | `string`  | ID of an ABC chat                               |
+| `threadId`              | Yes      | `string`  | ID of an ABC thread                             |
+| `title`                 | Yes      | `string`  | Title of a list picker message                  |
+| `subtitle`              | No       | `string`  | Subtitle of a list picker message               |
+| `image`                 | No       | `string`  | URL of a list picker image                      |
+| `groups`                | Yes      | `array`   | Array of groups in a list picker                |
+| `groups.title`          | Yes      | `string`  | Title of a group                                |
+| `groups.multipleChoice` | Yes      | `bool`    | Should a user select multiple items in a group? |
+| `groups.items`          | Yes      | `array`   | Array of items in a group                       |
+| `groups.items.id`       | Yes      | `string`  | Unique ID of an item                            |
+| `groups.items.image`    | No       | `string`  | URL of an item image                            |
+| `groups.items.title`    | Yes      | `string`  | Title of an item                                |
+| `groups.items.subtitle` | No       | `string`  | Subtitle of an item                             |
 
 ### Send Date Picker
+
 Let the customer choose a date by sending a date picker. More about <a href="https://developer.apple.com/documentation/appkit/views_and_controls/date_picker" target="_blank" rel="noopener noreferrer">**date pickers...**</a>
 
 **Method URL:** `https://apple-csp.livechatinc.com/date-picker`
 
 **Required header:** `Authorization` with the agent's token
 
-| Request object          | Required | Data type | Notes
-| ----------------------- | -------- | -------- | -----
-| `chatId`                | Yes      | `string` | ID of an ABC chat
-| `threadId`              | Yes      | `string` | ID of an ABC thread
-| `title`                 | Yes      | `string` | Title of a date picker message
-| `subtitle`              | No       | `string` | Subtitle of a date picker message
-| `image`                 | No       | `string` | URL of a date picker image
-| `timeSlots`             | Yes      | `array`  | Array of time slots
-| `timeSlots.identifier`  | Yes      | `string` | Unique ID of a time slot
-| `timeSlots.duration`    | Yes      | `int`    | Duration of a time slot
-| `timeSlots.startTime`   | Yes      | `string` | Start time in the format: `2020-12-15T17:00+0000`
- 
+| Request object         | Required | Data type | Notes                                             |
+| ---------------------- | -------- | --------- | ------------------------------------------------- |
+| `chatId`               | Yes      | `string`  | ID of an ABC chat                                 |
+| `threadId`             | Yes      | `string`  | ID of an ABC thread                               |
+| `title`                | Yes      | `string`  | Title of a date picker message                    |
+| `subtitle`             | No       | `string`  | Subtitle of a date picker message                 |
+| `image`                | No       | `string`  | URL of a date picker image                        |
+| `timeSlots`            | Yes      | `array`   | Array of time slots                               |
+| `timeSlots.identifier` | Yes      | `string`  | Unique ID of a time slot                          |
+| `timeSlots.duration`   | Yes      | `int`     | Duration of a time slot                           |
+| `timeSlots.startTime`  | Yes      | `string`  | Start time in the format: `2020-12-15T17:00+0000` |
+
 ### Send Apple Pay Payment
+
 A request for payment, which includes information about payment processing capabilities, the payment amount, and shipping information. More about <a href="https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest" target="_blank" rel="noopener noreferrer">**Apple Pay payments...**</a>
 
 **Method URL:** `https://apple-csp.livechatinc.com/payment`
 
 **Required header:** `Authorization` with the agent's token
 
-| Request object                                        | Required | Data type  | Notes
-| ----------------------------------------------------- | -------- | ---------- | -----
-| `chatId`                                              | Yes      | `string`   | ID of an ABC chat
-| `threadId`                                            | Yes      | `string`   | ID of an ABC thread
-| `title`                                               | Yes      | `string`   | Title of a payment message
-| `subtitle`                                            | No       | `string`   | Subtitle of a payment message
-| `image`                                               | No       | `string`   | URL of a payment image
-| `payment`                                             | Yes      | `object`   |
-| `payment.paymentRequest.items`                        | Yes      | `array`    | 
-| `payment.paymentRequest.items.label`                  | Yes      | `string`   | 
-| `payment.paymentRequest.items.amount`                 | Yes      | `string`   | 
-| `payment.paymentRequest.items.type`                   | Yes      | `string`   | 
-| `payment.paymentRequest.total`                        | Yes      | `object`   | 
-| `payment.paymentRequest.total.label`                  | Yes      | `string`   | 
-| `payment.paymentRequest.total.amount`                 | Yes      | `string`   | 
-| `payment.paymentRequest.total.type`                   | Yes      | `string`   | 
-| `payment.paymentRequest.applePay`                     | Yes      | `object`   | 
-| `payment.paymentRequest.applePay.merchantIdentifier`  | Yes      | `object`   |
-| `payment.paymentRequest.applePay.supportedNetworks`   | Yes      | `object`   |
-| `payment.paymentRequest.applePay.merchantCapabilities`| Yes      | `object`   |
-| `payment.paymentRequest.merchantName`                 | Yes      | `string`   |
-| `payment.paymentRequest.countryCode`                  | Yes      | `string`   |
-| `payment.paymentRequest.currencyCode`                 | Yes      | `string`   |
-| `payment.paymentRequest.merchantName`                 | Yes      | `string`   | 
-| `payment.paymentRequest.requiredBillingContactFields` | Yes      | `[]string` |
-| `payment.paymentRequest.requiredShippingContactFields`| Yes      | `[]string` |
-| `payment.merchantSession`                             | Yes      | `string`   | MerchantSession encoded as `JSON` |
-| `payment.endpoints`                                   | Yes      | `object`   |
-| `payment.endpoints.paymentGatewayUrl`                 | Yes      | `string`   |
-| `payment.endpoints.fallbackUrl`                       | No       | `string`   |
-| `payment.endpoints.orderTrackingUrl`                  | No       | `string`   |
-| `payment.endpoints.paymentMethodUpdateUrl`            | No       | `string`   |
-| `payment.endpoints.shippingContactUpdateUrl`          | No       | `string`   |
-| `payment.endpoints.shippingMethodUpdateUrl`           | No       | `string`   |
- 
+| Request object                                         | Required | Data type  | Notes                             |
+| ------------------------------------------------------ | -------- | ---------- | --------------------------------- |
+| `chatId`                                               | Yes      | `string`   | ID of an ABC chat                 |
+| `threadId`                                             | Yes      | `string`   | ID of an ABC thread               |
+| `title`                                                | Yes      | `string`   | Title of a payment message        |
+| `subtitle`                                             | No       | `string`   | Subtitle of a payment message     |
+| `image`                                                | No       | `string`   | URL of a payment image            |
+| `payment`                                              | Yes      | `object`   |
+| `payment.paymentRequest.items`                         | Yes      | `array`    |
+| `payment.paymentRequest.items.label`                   | Yes      | `string`   |
+| `payment.paymentRequest.items.amount`                  | Yes      | `string`   |
+| `payment.paymentRequest.items.type`                    | Yes      | `string`   |
+| `payment.paymentRequest.total`                         | Yes      | `object`   |
+| `payment.paymentRequest.total.label`                   | Yes      | `string`   |
+| `payment.paymentRequest.total.amount`                  | Yes      | `string`   |
+| `payment.paymentRequest.total.type`                    | Yes      | `string`   |
+| `payment.paymentRequest.applePay`                      | Yes      | `object`   |
+| `payment.paymentRequest.applePay.merchantIdentifier`   | Yes      | `object`   |
+| `payment.paymentRequest.applePay.supportedNetworks`    | Yes      | `object`   |
+| `payment.paymentRequest.applePay.merchantCapabilities` | Yes      | `object`   |
+| `payment.paymentRequest.merchantName`                  | Yes      | `string`   |
+| `payment.paymentRequest.countryCode`                   | Yes      | `string`   |
+| `payment.paymentRequest.currencyCode`                  | Yes      | `string`   |
+| `payment.paymentRequest.merchantName`                  | Yes      | `string`   |
+| `payment.paymentRequest.requiredBillingContactFields`  | Yes      | `[]string` |
+| `payment.paymentRequest.requiredShippingContactFields` | Yes      | `[]string` |
+| `payment.merchantSession`                              | Yes      | `string`   | MerchantSession encoded as `JSON` |
+| `payment.endpoints`                                    | Yes      | `object`   |
+| `payment.endpoints.paymentGatewayUrl`                  | Yes      | `string`   |
+| `payment.endpoints.fallbackUrl`                        | No       | `string`   |
+| `payment.endpoints.orderTrackingUrl`                   | No       | `string`   |
+| `payment.endpoints.paymentMethodUpdateUrl`             | No       | `string`   |
+| `payment.endpoints.shippingContactUpdateUrl`           | No       | `string`   |
+| `payment.endpoints.shippingMethodUpdateUrl`            | No       | `string`   |
 
-### Send Authentication request 
+### Send Authentication request
+
 Pass authentication data between LiveChat and the customer's device using OAuth. More about the <a href="https://developer.apple.com/documentation/businesschatapi/sending_an_authentication_message" target="_blank" rel="noopener noreferrer">**authentication message...**</a>
 
 **Method URL:** `https://apple-csp.livechatinc.com/authenticate`
 
 **Required header:** `Authorization` with the agent's token
 
-| Request object                              | Required | Data type | Notes
-| ------------------------------------------- | -------- | -------- | -----
-| `chatId`                                    | Yes      | `string` | ID of an ABC chat
-| `threadId`                                  | Yes      | `string` | ID of an ABC thread
-| `title`                                     | Yes      | `string` | Title of an authentication message
-| `subtitle`                                  | No       | `string` | Subtitle of an authentication message
-| `authenticate`                              | Yes      | `object` |
-| `authenticate.oauth2`                       | Yes      | `object` |
-| `authenticate.oauth2.responseType`          | Yes      | `string` |
-| `authenticate.oauth2.scope`                 | Yes      | `string` |
-| `authenticate.oauth2.clientSecret`          | Yes      | `string` |
-| `authenticate.oauth2.state`                 | Yes      | `string` |
-| `authenticate.oauth2.responseEncryptionKey` | Yes      | `string` |
-
+| Request object                              | Required | Data type | Notes                                 |
+| ------------------------------------------- | -------- | --------- | ------------------------------------- |
+| `chatId`                                    | Yes      | `string`  | ID of an ABC chat                     |
+| `threadId`                                  | Yes      | `string`  | ID of an ABC thread                   |
+| `title`                                     | Yes      | `string`  | Title of an authentication message    |
+| `subtitle`                                  | No       | `string`  | Subtitle of an authentication message |
+| `authenticate`                              | Yes      | `object`  |
+| `authenticate.oauth2`                       | Yes      | `object`  |
+| `authenticate.oauth2.responseType`          | Yes      | `string`  |
+| `authenticate.oauth2.scope`                 | Yes      | `string`  |
+| `authenticate.oauth2.clientSecret`          | Yes      | `string`  |
+| `authenticate.oauth2.state`                 | Yes      | `string`  |
+| `authenticate.oauth2.responseEncryptionKey` | Yes      | `string`  |
 
 ### Invoke Custom Extension
-Invoke a custom extension of an app. More about <a href="https://developer.apple.com/documentation/businesschatapi/messages_sent/interactive_messages/custom_interactive_messages" target="_blank" rel="noopener noreferrer">**custom app extensions...**</a> 
+
+Invoke a custom extension of an app. More about <a href="https://developer.apple.com/documentation/businesschatapi/messages_sent/interactive_messages/custom_interactive_messages" target="_blank" rel="noopener noreferrer">**custom app extensions...**</a>
 
 **Method URL:** `https://apple-csp.livechatinc.com/custom-interactive`
 
 **Required header:** `Authorization` with the agent's token
 
-| Request object                                 | Required | Data type | Notes
-| ---------------------------------------------- | -------- | -------- | -----
-| `chatId`                                       | Yes      | `string` | ID of an ABC chat
-| `threadId`                                     | Yes      | `string` | ID of an ABC thread
-| `interactiveData`                              | Yes      | `object` |
-| `interactiveData.appId`                        | Yes      | `string` |
-| `interactiveData.appName`                      | Yes      | `string` |
-| `interactiveData.receiveMessage`               | Yes      | `object` |
-| `interactiveData.receiveMessage.title`         | Yes      | `object` |
-| `interactiveData.receiveMessage.subtitle`      | Yes      | `object` |
-| `interactiveData.receiveMessage.useLiveLayout` | Yes      | `bool`   |
+| Request object                                 | Required | Data type | Notes               |
+| ---------------------------------------------- | -------- | --------- | ------------------- |
+| `chatId`                                       | Yes      | `string`  | ID of an ABC chat   |
+| `threadId`                                     | Yes      | `string`  | ID of an ABC thread |
+| `interactiveData`                              | Yes      | `object`  |
+| `interactiveData.appId`                        | Yes      | `string`  |
+| `interactiveData.appName`                      | Yes      | `string`  |
+| `interactiveData.receiveMessage`               | Yes      | `object`  |
+| `interactiveData.receiveMessage.title`         | Yes      | `object`  |
+| `interactiveData.receiveMessage.subtitle`      | Yes      | `object`  |
+| `interactiveData.receiveMessage.useLiveLayout` | Yes      | `bool`    |
 
 ## Resources
+
 - [Apple Business Register](https://register.apple.com/)
 - [Business Chat REST API](https://developer.apple.com/documentation/businesschatapi)


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/fix-naming-in-abc-docs)

## 📓 Description
Change:

>  "CSP" reference to "MSP" for Messaging Service Provider

as requested.

## 👷 Type of change (remove not needed)

### Content

- Proofreading/content fixes
