### PR TITLE
API-6468: Add `target` property to RM `button`

### DIFF
--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -24,8 +24,9 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 ### Events
 
 - The **File** ([Web](/messaging/agent-chat-api/v3.3/#file) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#file)) event has a new parameter for images, `alternative_text`.
-- The **Rich Message** ([Web](/messaging/agent-chat-api/v3.3/#rich-message) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#rich-message)) images have a new parameter, `alternative_text`.
-- The **Rich Message** ([Web](/messaging/agent-chat-api/v3.3/#rich-message) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#rich-message)) buttons have a new property, `target`.
+- The **Rich Message** ([Web](/messaging/agent-chat-api/v3.3/#rich-message) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#rich-message)) data structure:
+  - has a new parameter for images, `alternative_text`,
+  - has a new property for buttons, `target`.
 
 ### Properties
 

--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -25,6 +25,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 
 - The **File** ([Web](/messaging/agent-chat-api/v3.3/#file) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#file)) event has a new parameter for images, `alternative_text`.
 - The **Rich Message** ([Web](/messaging/agent-chat-api/v3.3/#rich-message) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#rich-message)) images have a new parameter, `alternative_text`.
+- The **Rich Message** ([Web](/messaging/agent-chat-api/v3.3/#rich-message) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#rich-message)) buttons have a new property, `target`.
 
 ### Properties
 

--- a/content/messaging/agent-chat-api/v3.3/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/index.mdx
@@ -220,6 +220,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 | `elements.buttons.webview_height`| yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.         |
 | `elements.buttons.postback_id`   | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
 | `elements.buttons.user_ids`      | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.|
+| `elements.buttons.target`        | no       | `string`  | Should be used for the `url` button `type`. Possible values: `new`, `current`.                    |
 
 ### Response
 
@@ -244,6 +245,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 | `elements.buttons.webview_height`| always     | Unless button `type` is different than `webview`.                   |
 | `elements.buttons.postback_id`   | always     |                                                                     |
 | `elements.buttons.user_ids`      | always     |                                                                     |
+| `elements.buttons.target`        | optionally |                                                                     |
 
 </Text>
 <Code>

--- a/content/messaging/agent-chat-api/v3.3/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/index.mdx
@@ -220,7 +220,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 | `elements.buttons.webview_height`| yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.         |
 | `elements.buttons.postback_id`   | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
 | `elements.buttons.user_ids`      | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.|
-| `elements.buttons.target`        | no       | `string`  | Should be used for the `url` button `type`. Possible values: `new`, `current`.                    |
+| `elements.buttons.target`        | no       | `string`  | Should be used for the `url` button `type`. Specifies if the URL should open in the current or a new tab. Possible values: `new`, `current`.                    |
 
 ### Response
 

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -249,6 +249,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 | `elements.buttons.webview_height`| yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.         |
 | `elements.buttons.postback_id`   | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
 | `elements.buttons.user_ids`      | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.|
+| `elements.buttons.target`        | no       | `string`  | Should be used for the `url` button `type`. Possible values: `new`, `current`.                    |
 
 ### Response
 
@@ -273,6 +274,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 | `elements.buttons.webview_height`| always     | Unless button `type` is different than `webview`.                   |
 | `elements.buttons.postback_id`   | always     |                                                                     |
 | `elements.buttons.user_ids`      | always     |                                                                     |
+| `elements.buttons.target`        | optionally |                                                                     |
 
 </Text>
 <Code>

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -249,7 +249,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 | `elements.buttons.webview_height`| yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.         |
 | `elements.buttons.postback_id`   | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
 | `elements.buttons.user_ids`      | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.|
-| `elements.buttons.target`        | no       | `string`  | Should be used for the `url` button `type`. Possible values: `new`, `current`.                    |
+| `elements.buttons.target`        | no       | `string`  | Should be used for the `url` button `type`. Specifies if the URL should open in the current or a new tab. Possible values: `new`, `current`.                    |
 
 ### Response
 

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -23,8 +23,9 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 ### Events
 
 - The **File** ([Web](/messaging/customer-chat-api/v3.3/#file) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#file)) event has a new parameter for images, `alternative_text`.
-- The **Rich Message** ([Web](/messaging/customer-chat-api/v3.3/#rich-message) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#rich-message)) images have a new parameter, `alternative_text`.
-- The **Rich Message** ([Web](/messaging/customer-chat-api/v3.3/#rich-message) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#rich-message)) buttons have a new property, `target`.
+- The **Rich Message** ([Web](/messaging/customer-chat-api/v3.3/#rich-message) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#rich-message)) data structure:
+  - has a new parameter for images, `alternative_text`,
+  - has a new property for buttons, `target`.
 
 ## Localization
 

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -24,6 +24,7 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 
 - The **File** ([Web](/messaging/customer-chat-api/v3.3/#file) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#file)) event has a new parameter for images, `alternative_text`.
 - The **Rich Message** ([Web](/messaging/customer-chat-api/v3.3/#rich-message) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#rich-message)) images have a new parameter, `alternative_text`.
+- The **Rich Message** ([Web](/messaging/customer-chat-api/v3.3/#rich-message) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#rich-message)) buttons have a new property, `target`.
 
 ## Localization
 

--- a/content/messaging/customer-chat-api/v3.3/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/index.mdx
@@ -214,6 +214,7 @@ Rich message event contains rich message data structure. [Read more](/extending-
 | `elements.buttons.webview_height`| yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.         |
 | `elements.buttons.postback_id`   | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
 | `elements.buttons.user_ids`      | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.|
+| `elements.buttons.target`        | no       | `string`  | Should be used for the `url` button `type`. Possible values: `new`, `current`.                    |
 
 ### Response
 
@@ -237,6 +238,7 @@ Rich message event contains rich message data structure. [Read more](/extending-
 | `elements.buttons.webview_height`| always     | Unless button `type` is different than `webview`.                   |
 | `elements.buttons.postback_id`   | always     |                                                                     |
 | `elements.buttons.user_ids`      | always     |                                                                     |
+| `elements.buttons.target`        | optionally |                                                                     |
 
 </Text>
 

--- a/content/messaging/customer-chat-api/v3.3/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/index.mdx
@@ -214,7 +214,7 @@ Rich message event contains rich message data structure. [Read more](/extending-
 | `elements.buttons.webview_height`| yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.         |
 | `elements.buttons.postback_id`   | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
 | `elements.buttons.user_ids`      | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.|
-| `elements.buttons.target`        | no       | `string`  | Should be used for the `url` button `type`. Possible values: `new`, `current`.                    |
+| `elements.buttons.target`        | no       | `string`  | Should be used for the `url` button `type`. Specifies if the URL should open in the current or a new tab. Possible values: `new`, `current`.                    |
 
 ### Response
 

--- a/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
@@ -246,7 +246,7 @@ Rich message event contains rich message data structure. [Read more](/extending-
 | `elements.buttons.webview_height`| yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.         |
 | `elements.buttons.postback_id`   | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
 | `elements.buttons.user_ids`      | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.|
-| `elements.buttons.target`        | no       | `string`  | Should be used for the `url` button `type`. Possible values: `new`, `current`.                    |
+| `elements.buttons.target`        | no       | `string`  | Should be used for the `url` button `type`. Specifies if the URL should open in the current or a new tab. Possible values: `new`, `current`.                    |
 
 ### Response
 

--- a/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
@@ -246,6 +246,7 @@ Rich message event contains rich message data structure. [Read more](/extending-
 | `elements.buttons.webview_height`| yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.         |
 | `elements.buttons.postback_id`   | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
 | `elements.buttons.user_ids`      | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.|
+| `elements.buttons.target`        | no       | `string`  | Should be used for the `url` button `type`. Possible values: `new`, `current`.                    |
 
 ### Response
 
@@ -269,6 +270,7 @@ Rich message event contains rich message data structure. [Read more](/extending-
 | `elements.buttons.webview_height`| always     | Unless button `type` is different than `webview`.                   |
 | `elements.buttons.postback_id`   | always     |                                                                     |
 | `elements.buttons.user_ids`      | always     |                                                                     |
+| `elements.buttons.target`        | optionally |                                                                     |
 
 </Text>
 

--- a/payloads/messaging/v3.3/agent-chat-api/events/richMessage.json
+++ b/payloads/messaging/v3.3/agent-chat-api/events/richMessage.json
@@ -43,7 +43,8 @@
           "value": "790034890",
           "webview_height": "tall",
           "postback_id": "action_call",
-          "user_ids": []
+          "user_ids": [],
+          "target": "current"
         }
       ]
     }

--- a/payloads/messaging/v3.3/customer-chat-api/events/richMessage.json
+++ b/payloads/messaging/v3.3/customer-chat-api/events/richMessage.json
@@ -42,7 +42,8 @@
           "value": "790034890",
           "webview_height": "tall",
           "postback_id": "action_call",
-          "user_ids": []
+          "user_ids": [],
+          "target": "current"
         }
       ]
     }


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-6468-rich-message-button-target)
- [Jira](https://livechatinc.atlassian.net/browse/API-6468)

## 📓 Description
Add new `target` property to rich message's `button`.

## ✅ Checklist (for API docs)

- Changelog ✅ 
- API versions ✅
- Web & RTM ✅
- **Table:** Available methods/webhooks/pushes
- **Table:** Specifics

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)
New parameter in existing structure.

### Content

- New content 
  
### Features (for the website)

- New feature
