### PR TITLE
customer/v3.3: Prefix configuration endpoints with verbs

### DIFF
--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -17,8 +17,8 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 
 ## Config
 
-- There's a new method, [**Dynamic Config**](/messaging/customer-chat-api/v3.3/#dynamic-config).
-- There's a new method, [**Config**](/messaging/customer-chat-api/v3.3/#config).
+- There's a new method, [**Get Dynamic Configuration**](/messaging/customer-chat-api/v3.3/#get-dynamic-configuration).
+- There's a new method, [**Get Configuration**](/messaging/customer-chat-api/v3.3/#get-configuration).
 
 ### Events
 
@@ -27,7 +27,7 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 
 ## Localization
 
-- There's a new method, [**Localization**](/messaging/customer-chat-api/v3.3/#localization).
+- There's a new method, [**Get Localization**](/messaging/customer-chat-api/v3.3/#get-localization).
 
 ### Properties
 

--- a/content/messaging/customer-chat-api/v3.3/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/index.mdx
@@ -420,7 +420,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 | HTTP method | The API endpoint                                            | Methods                                                                                                                                                                                                         |
 | ----------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **POST**    | `https://api.livechatinc.com/v3.3/customer/action/<action>` | All except for **List License Properties**, **List Group Properties**, **Dynamic Config**, **Config** and **Localization**                                                                                        |
-| **GET**     | `https://api.livechatinc.com/v3.3/customer/action/<action>` | [**List License Properties**](#list-license-properties), [**List Group Properties**](#list-group-properties), [**Dynamic Config**](#dynamic-config), [**Config**](#config) and [**Localization**](#localization)  |
+| **GET**     | `https://api.livechatinc.com/v3.3/customer/action/<action>` | [**List License Properties**](#list-license-properties), [**List Group Properties**](#list-group-properties), [**Get Dynamic Configuration**](#get-dynamic-configuration), [**Get Configuration**](#get-configuration) and [**Get Localization**](#get-localization)  |
 
 | Header          |                   Value                    |                                                                                                                                                                                                         Notes |
 | --------------- | :----------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
@@ -462,9 +462,9 @@ curl -X POST \
 |                  |                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Chats**        | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat)                                                                                                                                                                                                                                                                     |
-| **Config**       | [`dynamic_config`](#dynamic-config) [`config`](#config)                                                                                                                                                                                                                                                                                                                                                                                                     |
+| **Configuration** | [`get_dynamic_configuration`](#get-dynamic-configuration) [`get_configuration`](#get-configuration)                                                                                                                                                                                                                                                                                                                                                                                                     |
 | **Events**       | [`send_event`](#send-event) [`upload_file`](#upload-file) [`send_rich_message_postback`](#send-rich-message-postback) [`send_sneak_peek`](#send-sneak-peek)                                                                                                                                                                                                                                                                                                 |
-| **Localization** | [`localization`](#localization)                                                                                                                                                                                                                                                                                                                                                                                                               |
+| **Localization** | [`get_localization`](#get-localization)                                                                                                                                                                                                                                                                                                                                                                                                               |
 | **Properties**   | [`update_chat_properties`](#update-chat-properties) [`delete_chat_properties`](#delete-chat-properties) [`update_thread_properties`](#update-thread-properties) [`delete_thread_properties`](#delete-thread-properties) [`update_event_properties`](#update-event-properties) [`delete_event_properties`](#delete-event-properties) [`list_license_properties`](#list-license-properties) [`list_group_properties`](#list-group-properties)                 |
 | **Customers**    | [`update_customer`](#update-customer) [`set_customer_session_fields`](#set-customer-session-fields) [`get_customer`](#get-customer)                                                                                                                                                                                                                                                                                                                         |
 | **Status**       | [`list_group_statuses`](#list-group-statuses)                                                                                                                                                                                                                                                                                                                                                                                                               |
@@ -941,22 +941,22 @@ curl -X POST \
 
 </Section>
 
-## Config
+## Configuration
 
 <Section>
 
 <Text>
 
-### Dynamic Config
+### Dynamic Configuration
 
-Returns the dynamic config of a given group. It provides data to call [**Config**](#config) and [**Localization**](#localization).
+Returns the dynamic configuration of a given group. It provides data to call [**Get Configuration**](#get-configuration) and [**Get Localization**](#get-localization).
 
 #### Specifics
 
 |                        |
 | ---------------------- | ----------------------------------------------------------------- |
 | **HTTP Method**        | **GET**                                                           |
-| **Method URL**         | `https://api.livechatinc.com/v3.3/customer/action/dynamic_config` |
+| **Method URL**         | `https://api.livechatinc.com/v3.3/customer/action/get_dynamic_configuration` |
 | **RTM API equivalent** | -                                                                 |
 | **Webhook**            | -                                                                 |
 
@@ -964,10 +964,10 @@ Returns the dynamic config of a given group. It provides data to call [**Config*
 
 | Parameters              | Required | Data type | Notes                                                       |
 | ----------------------- | -------- | --------- | ----------------------------------------------------------- |
-| `group_id`              | Yes      | `number`  | The ID of the group that you want to get a dynamic config for.  |
-| `url`                   | No       | `string`  | The URL that you want to get a dynamic config for.          |
-| `channel_type`          | No       | `string`  | The channel type that you want to get a dynamic config for. |
-| `test`                  | No       | `bool`    | Treats a dynamic config request as a test.                  |
+| `group_id`              | Yes      | `number`  | The ID of the group that you want to get a dynamic configuration for.  |
+| `url`                   | No       | `string`  | The URL that you want to get a dynamic configuration for.          |
+| `channel_type`          | No       | `string`  | The channel type that you want to get a dynamic configuration for. |
+| `test`                  | No       | `bool`    | Treats a dynamic configuration request as a test.                  |
 
 </Text>
 
@@ -977,7 +977,7 @@ Returns the dynamic config of a given group. It provides data to call [**Config*
 
 ```shell
 curl -X GET \
-  'https://api.livechatinc.com/v3.3/customer/action/dynamic_config?license_id=<license_id>&group_id=0'
+  'https://api.livechatinc.com/v3.3/customer/action/get_dynamic_configuration?license_id=<license_id>&group_id=0'
 ```
 
 </CodeSample>
@@ -1004,16 +1004,16 @@ curl -X GET \
 
 <Text>
 
-### Config
+### Configuration
 
-Returns the config of a given group in a given version. Contains data based on which the Chat Widget can be built.
+Returns the configuration of a given group in a given version. Contains data based on which the Chat Widget can be built.
 
 #### Specifics
 
 |                        |
 | ---------------------- | ----------------------------------------------------------------- |
 | **HTTP Method**        | **GET**                                                           |
-| **Method URL**         | `https://api.livechatinc.com/v3.3/customer/action/config`         |
+| **Method URL**         | `https://api.livechatinc.com/v3.3/customer/action/get_configuration`         |
 | **RTM API equivalent** | -                                                                 |
 | **Webhook**            | -                                                                 |
 
@@ -1021,8 +1021,8 @@ Returns the config of a given group in a given version. Contains data based on w
 
 | Parameters              | Required | Data type | Notes                                              |
 | ----------------------- | -------- | --------- | -------------------------------------------------- |
-| `group_id`              | Yes      | `number`  | The ID of the group that you want to get a config for. |
-| `version`               | Yes      | `string`  | The version that you want to get a config for. Returned from [**Dynamic Config**](#dynamic-config) as the `config_version` parameter. |
+| `group_id`              | Yes      | `number`  | The ID of the group that you want to get a configuration for. |
+| `version`               | Yes      | `string`  | The version that you want to get a configuration for. Returned from [**Get Dynamic Configuration**](#get-dynamic-configuration) as the `config_version` parameter. |
 
 </Text>
 
@@ -1032,7 +1032,7 @@ Returns the config of a given group in a given version. Contains data based on w
 
 ```shell
 curl -X GET \
-  'https://api.livechatinc.com/v3.3/customer/action/config?license_id=<license_id>&group_id=0&version=84cc87cxza5ee24ed0f84fe3027fjf0c71'
+  'https://api.livechatinc.com/v3.3/customer/action/get_configuration?license_id=<license_id>&group_id=0&version=84cc87cxza5ee24ed0f84fe3027fjf0c71'
 ```
 
 </CodeSample>
@@ -1376,7 +1376,7 @@ curl -X POST \
 
 <Text>
 
-### Localization
+### Get Localization
 
 Returns the <a href="https://en.wikipedia.org/wiki/Language_localisation" rel="noopener nofollow" target="_blank">localization</a> of a given language and group in a given version. Contains translated phrases for the Chat Widget.
 
@@ -1385,7 +1385,7 @@ Returns the <a href="https://en.wikipedia.org/wiki/Language_localisation" rel="n
 |                        |
 | ---------------------- | ----------------------------------------------------------------- |
 | **HTTP Method**        | **GET**                                                           |
-| **Method URL**         | `https://api.livechatinc.com/v3.3/customer/action/localization`   |
+| **Method URL**         | `https://api.livechatinc.com/v3.3/customer/action/get_localization`   |
 | **RTM API equivalent** | -                                                                 |
 | **Webhook**            | -                                                                 |
 
@@ -1395,7 +1395,7 @@ Returns the <a href="https://en.wikipedia.org/wiki/Language_localisation" rel="n
 | ----------------------- | -------- | --------- | -------------------------------------------------------- |
 | `group_id`              | Yes      | `number`  | The ID of the group that you want to get a localization for. |
 | `language`              | Yes      | `string`  | The language that you want to get a localization for.    |
-| `version`               | Yes      | `string`  | The version that you want to get a localization for. Returned from [**Dynamic Config**](#dynamic-config) as the `localization_version` parameter.|
+| `version`               | Yes      | `string`  | The version that you want to get a localization for. Returned from [**Get Dynamic Configuration**](#get-dynamic-configuration) as the `localization_version` parameter.|
 
 </Text>
 
@@ -1405,7 +1405,7 @@ Returns the <a href="https://en.wikipedia.org/wiki/Language_localisation" rel="n
 
 ```shell
 curl -X GET \
-  'https://api.livechatinc.com/v3.3/customer/action/localization?license_id=<license_id>&group_id=0&language=en&version=79cc87cea5ee24ed0f84fe3027fc0c74'
+  'https://api.livechatinc.com/v3.3/customer/action/get_localization?license_id=<license_id>&group_id=0&language=en&version=79cc87cea5ee24ed0f84fe3027fc0c74'
 ```
 
 </CodeSample>

--- a/content/messaging/customer-chat-api/v3.3/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/index.mdx
@@ -947,7 +947,7 @@ curl -X POST \
 
 <Text>
 
-### Dynamic Configuration
+### Get Dynamic Configuration
 
 Returns the dynamic configuration of a given group. It provides data to call [**Get Configuration**](#get-configuration) and [**Get Localization**](#get-localization).
 
@@ -1004,7 +1004,7 @@ curl -X GET \
 
 <Text>
 
-### Configuration
+### Get Configuration
 
 Returns the configuration of a given group in a given version. Contains data based on which the Chat Widget can be built.
 


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/adjust-configuration-endpoints)

## 📓 Description

Prefix new customer configuration endpoints with `get_`. Use full "configuration", not "config".

## ✅ Checklist (for API docs)

- Changelog ✅ 
- API versions ✅ 
- Web & RTM ✅ 
- **Table:** Available methods/webhooks/pushes ✅ 
- **Table:** Specifics 

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)
Update methods in dev preview.

### Content

- Proofreading/content fixes
  
### Features (for the website)

- Breaking change ✅ 
