### PR TITLE
Address no retries for pushes

### DIFF
--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -366,6 +366,7 @@ System message event is native system event sent in specific situations.
 | Field            | Req./Opt. |                                              Note |
 | ---------------- | :-------: | ------------------------------------------------: |
 | `routing_status` | optional  | Returned only if the Agent's currently logged in. |
+| `events_seen_up_to`| optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Agent—all the previous events are considered seen. |
 
 ### My profile
 
@@ -3423,8 +3424,8 @@ Here's what you need to know about **pushes**:
 - They notify you when specific events occur.
 - Can be **delivered** only in the websocket transport.
 - You don't need to register pushes to receive them.
-- Their equivalents in Web API are [webhooks](/management/configuration-api/#webhooks).
-- Pushes and webhooks have similar payloads.
+- Their equivalents in Web API are [webhooks](/management/configuration-api/#webhooks). Pushes and webhooks have similar payloads.
+- There are no retries for pushes. To determine if a user has seen an event, compare the [event's](#response) `created_at` parameter with the [user's](#users) `events_seen_up_to` field.
 
 |                 |                                                                                                                                                                                                                                                                                                                                                                     |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -102,30 +102,30 @@ The **File** event informs about an uploaded file.
 
 ### Request
 
-| Field                                                 | Required | Data type | Notes                                                               |
-| ----------------------------------------------------- | -------- | --------- | ------------------------------------------------------------------: |
-| `custom_id`                                           | no       | `string`  |                                                                     |
-| `type`                                                | yes      | `string`  | `file`                                                              |
-| `recipients`                                          | yes      | `string`  | Possible values: `all` (default), `agents`                          |
-| `properties`                                          | no       | `object`  | [Properties](#properties)                                           |
-| `url`                                                 | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file).|
+| Field        | Required | Data type |                                                                                                                                     Notes |
+| ------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
+| `custom_id`  | no       | `string`  |                                                                                                                                           |
+| `type`       | yes      | `string`  |                                                                                                                                    `file` |
+| `recipients` | yes      | `string`  |                                                                                                Possible values: `all` (default), `agents` |
+| `properties` | no       | `object`  |                                                                                                                 [Properties](#properties) |
+| `url`        | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file). |
 
 ### Response
 
-| Field                               | Returned        | Notes                                                               |
-| ----------------------------------- | :-------------- | ------------------------------------------------------------------: |
-| `id`                                | always          |                                                                     |
-| `custom_id`                         | optionally      |                                                                     |
-| `created_at`                        | always          | Date & time format with a resolution of microseconds, `UTC string`. |
-| `type`                              | always          |                                                                     |
-| `author_id`                         | always          |                                                                     |
-| `recipients`                        | always          |                                                                     |
-| `properties`                        | optionally      |                                                                     |
-| `name`                              | always          |                                                                     |
-| `url`                               | always          |                                                                     |
-| `thumbnail_url`, `thumbnail2x_url`  | only for images |                                                                     |
-| `content_type`                      | always          |                                                                     |
-| `size`, `width`, `height`           | only for images |                                                                     |
+| Field                              | Returned        |                                                               Notes |
+| ---------------------------------- | :-------------- | ------------------------------------------------------------------: |
+| `id`                               | always          |                                                                     |
+| `custom_id`                        | optionally      |                                                                     |
+| `created_at`                       | always          | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`                             | always          |                                                                     |
+| `author_id`                        | always          |                                                                     |
+| `recipients`                       | always          |                                                                     |
+| `properties`                       | optionally      |                                                                     |
+| `name`                             | always          |                                                                     |
+| `url`                              | always          |                                                                     |
+| `thumbnail_url`, `thumbnail2x_url` | only for images |                                                                     |
+| `content_type`                     | always          |                                                                     |
+| `size`, `width`, `height`          | only for images |                                                                     |
 
 </Text>
 <Code>
@@ -142,28 +142,28 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 
 ### Request
 
-| Field                   | Required | Data type  |  Notes                                                                    |
-| ------------------------| -------- | -----------| ------------------------------------------------------------------------- |
-| `custom_id`             | no       | `string`   |                                                                           |
-| `type`                  | yes      | `string`   | `filled_form`                                                             |
-| `recipients`            | yes      | `string`   | Possible values: `all` (default), `agents`                                |
-| `properties`            | no       | `object`   | [Properties](#properties)                                                 |
-| `form_id`               | yes      | `string`   |                                                                           |
-| `fields`                | yes      | `array`    | The fields a form contains. See [form fields](#form-fields) for details.  |
+| Field        | Required | Data type | Notes                                                                    |
+| ------------ | -------- | --------- | ------------------------------------------------------------------------ |
+| `custom_id`  | no       | `string`  |                                                                          |
+| `type`       | yes      | `string`  | `filled_form`                                                            |
+| `recipients` | yes      | `string`  | Possible values: `all` (default), `agents`                               |
+| `properties` | no       | `object`  | [Properties](#properties)                                                |
+| `form_id`    | yes      | `string`  |                                                                          |
+| `fields`     | yes      | `array`   | The fields a form contains. See [form fields](#form-fields) for details. |
 
 ### Response
 
-| Field                   | Returned    | Notes |
-| ------------------------| ----------- | ----- |
-| `id`                    | always      |       |
-| `custom_id`             | optionally  |       |
-| `created_at`            | always      | Date & time format with a resolution of microseconds, `UTC string`. |
-| `type`                  | always      |       |
-| `author_id`             | always      |       |
-| `recipients`            | always      |       |
-| `properties`            | optionally  |       |
-| `form_id`               | always      |       |
-| `fields`                | always      | An array of [form fields](#form-fields) |
+| Field        | Returned   | Notes                                                               |
+| ------------ | ---------- | ------------------------------------------------------------------- |
+| `id`         | always     |                                                                     |
+| `custom_id`  | optionally |                                                                     |
+| `created_at` | always     | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`       | always     |                                                                     |
+| `author_id`  | always     |                                                                     |
+| `recipients` | always     |                                                                     |
+| `properties` | optionally |                                                                     |
+| `form_id`    | always     |                                                                     |
+| `fields`     | always     | An array of [form fields](#form-fields)                             |
 
 </Text>
 
@@ -181,38 +181,38 @@ The **Message** event contains text message to other chat users.
 
 ### Request
 
-| Field                 | Required| Data type | Notes                                                               |
-| --------------------- | ------- | --------- | ------------------------------------------------------------------  |
-| `custom_id`           | no      | `string`  |                                                                     |
-| `text`                | yes     | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
-| `type`                | yes     | `string`  | `message`                                                           |
-| `recipients`          | yes     | `string`  | Possible values: `all` (default), `agents`                          |
-| `properties`          | no      | `object`  | [Properties](#properties)                                           |
-| `postback`            | no      | `object`  | Indicates that the message event was generated in response to a rich message event. |
-| `postback.id`         | yes     | `string`  | ID of the postback from the rich message event.                     |
-| `postback.thread_id`  | yes     | `string`  | ID of the thread with the rich message event.                       |
-| `postback.event_id`   | yes     | `string`  | ID of the rich message event.                                       |
-| `postback.type`       | no      | `string`  | Should be used together with `postback.value` (when  one of them is present, the other is required).                      |
-| `postback.value`      | no      | `string`  | Should be used together with `postback.type` (when  one of them is present, the other is required).                       |
+| Field                | Required | Data type | Notes                                                                                                                        |
+| -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `custom_id`          | no       | `string`  |                                                                                                                              |
+| `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
+| `type`               | yes      | `string`  | `message`                                                                                                                    |
+| `recipients`         | yes      | `string`  | Possible values: `all` (default), `agents`                                                                                   |
+| `properties`         | no       | `object`  | [Properties](#properties)                                                                                                    |
+| `postback`           | no       | `object`  | Indicates that the message event was generated in response to a rich message event.                                          |
+| `postback.id`        | yes      | `string`  | ID of the postback from the rich message event.                                                                              |
+| `postback.thread_id` | yes      | `string`  | ID of the thread with the rich message event.                                                                                |
+| `postback.event_id`  | yes      | `string`  | ID of the rich message event.                                                                                                |
+| `postback.type`      | no       | `string`  | Should be used together with `postback.value` (when  one of them is present, the other is required).                         |
+| `postback.value`     | no       | `string`  | Should be used together with `postback.type` (when  one of them is present, the other is required).                          |
 
 ### Response
 
-| Field                   | Returned    | Notes                                                                 |
-| ------------------------| ----------- | ----------------------------------------------------------------------|
-| `id`                    | always      |                                                                       |
-| `custom_id`             | optionally  |                                                                       |
-| `created_at`            | always      | Date & time format with a resolution of microseconds, `UTC string`.   |
-| `type`                  | always      | `message`                                                             |
-| `author_id`             | always      |                                                                       |
-| `recipients`            | always      |                                                                       |
-| `text`                  | always      |                                                                       |
-| `postback`              | optionally  | Appears in a message only when triggered by a rich message.           |
-| `postback.id`           | always      |                                                                       |
-| `postback.thread_id`    | always      |                                                                       |
-| `postback.event_id`     | always      |                                                                       |
-| `postback.type`         | optionally  | Appears only if `postback.value` is present.                          |
-| `postback.value`        | optionally  | Appears only if `postback.type` is present.                           |
-| `properties`            | optionally  | [Properties](#properties)                                             |
+| Field                | Returned   | Notes                                                               |
+| -------------------- | ---------- | ------------------------------------------------------------------- |
+| `id`                 | always     |                                                                     |
+| `custom_id`          | optionally |                                                                     |
+| `created_at`         | always     | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`               | always     | `message`                                                           |
+| `author_id`          | always     |                                                                     |
+| `recipients`         | always     |                                                                     |
+| `text`               | always     |                                                                     |
+| `postback`           | optionally | Appears in a message only when triggered by a rich message.         |
+| `postback.id`        | always     |                                                                     |
+| `postback.thread_id` | always     |                                                                     |
+| `postback.event_id`  | always     |                                                                     |
+| `postback.type`      | optionally | Appears only if `postback.value` is present.                        |
+| `postback.value`     | optionally | Appears only if `postback.type` is present.                         |
+| `properties`         | optionally | [Properties](#properties)                                           |
 
 </Text>
 <Code>
@@ -229,48 +229,48 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 
 ### Request
 
-| Field                            | Required | Data type | Notes                                                                                             |
-| -------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------- |
-| `custom_id`                      | no       | `string`  | You can give your RM a custom ID.                                                                 |
-| `type`                           | yes      | `string`  | Event type: `rich_message`                                                                        |
-| `recipients`                     | yes      | `string`  | Those who can display the rich message: `all` (default) or `agents`                               |
-| `properties`                     | no       | `object`  | The [properties](#properties) data structure                                                      |
-| `template_id`                    | yes      | `string`  | Defines how every Rich Message will be presented. Values: `cards`, `sticker`, or `quick_replies`. |
-| `elements`                       | no       | `array`   | Can contain up to 10 `element` objects.                                                           |
-| `elements.title`                 | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.subtitle`              | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.image`                 | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`.|
-| `elements.buttons`               | no       | `array`   | Displays buttons. Can contain up to 13 `button` objects.                                          |
-| `elements.buttons.text`          | yes      | `string`  | Text displayed on a button.                                                                       |
-| `elements.buttons.type`          | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value` (when  one of them is present, the other is required). Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)  |
-| `elements.buttons.value`         | yes      | `string`  | Should be used together with `elements.buttons.type` (when  one of them is present, the other is required).                                             |
-| `elements.buttons.webview_height`| yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.         |
-| `elements.buttons.postback_id`   | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
-| `elements.buttons.user_ids`      | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.|
+| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                                                                                  |
+| --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                                                                      |
+| `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                                                                             |
+| `recipients`                      | yes      | `string`  | Those who can display the rich message: `all` (default) or `agents`                                                                                                                                                                                                                                    |
+| `properties`                      | no       | `object`  | The [properties](#properties) data structure                                                                                                                                                                                                                                                           |
+| `template_id`                     | yes      | `string`  | Defines how every Rich Message will be presented. Values: `cards`, `sticker`, or `quick_replies`.                                                                                                                                                                                                      |
+| `elements`                        | no       | `array`   | Can contain up to 10 `element` objects.                                                                                                                                                                                                                                                                |
+| `elements.title`                  | yes      | `string`  | Displays formatted text on RMs.                                                                                                                                                                                                                                                                        |
+| `elements.subtitle`               | yes      | `string`  | Displays formatted text on RMs.                                                                                                                                                                                                                                                                        |
+| `elements.image`                  | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`.                                                                                                                                                                                     |
+| `elements.buttons`                | no       | `array`   | Displays buttons. Can contain up to 13 `button` objects.                                                                                                                                                                                                                                               |
+| `elements.buttons.text`           | yes      | `string`  | Text displayed on a button.                                                                                                                                                                                                                                                                            |
+| `elements.buttons.type`           | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value` (when  one of them is present, the other is required). Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
+| `elements.buttons.value`          | yes      | `string`  | Should be used together with `elements.buttons.type` (when  one of them is present, the other is required).                                                                                                                                                                                            |
+| `elements.buttons.webview_height` | yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.                                                                                                                                                                                                              |
+| `elements.buttons.postback_id`    | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)                                                                                                                            |
+| `elements.buttons.user_ids`       | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.                                                                                                                                                                                                                                         |
 
 ### Response
 
-| Field                            | Returned   | Notes                                                               |
-| -------------------------------- | ---------- | ------------------------------------------------------------------- |
-| `id`                             | always     | Generated server-side                                               |
-| `custom_id`                      | optionally |                                                                     |
-| `type`                           | always     |                                                                     |
-| `author_id`                      | always     | Generated server-side                                               |
-| `created_at`                     | always     | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
-| `recipients`                     | always     |                                                                     |
-| `properties`                     | optionally |                                                                     |
-| `template_id`                    | always     |                                                                     |
-| `elements`                       | optionally |                                                                     |
-| `elements.title`                 | always     |                                                                     |
-| `elements.subtitle`              | always     |                                                                     |
-| `elements.image`                 | always     |                                                                     |
-| `elements.buttons`               | optionally |                                                                     |
-| `elements.buttons.text`          | always     |                                                                     |
-| `elements.buttons.type`          | always     |                                                                     |
-| `elements.buttons.value`         | always     |                                                                     |
-| `elements.buttons.webview_height`| always     | Unless button `type` is different than `webview`.                   |
-| `elements.buttons.postback_id`   | always     |                                                                     |
-| `elements.buttons.user_ids`      | always     |                                                                     |
+| Field                             | Returned   | Notes                                                                                      |
+| --------------------------------- | ---------- | ------------------------------------------------------------------------------------------ |
+| `id`                              | always     | Generated server-side                                                                      |
+| `custom_id`                       | optionally |                                                                                            |
+| `type`                            | always     |                                                                                            |
+| `author_id`                       | always     | Generated server-side                                                                      |
+| `created_at`                      | always     | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
+| `recipients`                      | always     |                                                                                            |
+| `properties`                      | optionally |                                                                                            |
+| `template_id`                     | always     |                                                                                            |
+| `elements`                        | optionally |                                                                                            |
+| `elements.title`                  | always     |                                                                                            |
+| `elements.subtitle`               | always     |                                                                                            |
+| `elements.image`                  | always     |                                                                                            |
+| `elements.buttons`                | optionally |                                                                                            |
+| `elements.buttons.text`           | always     |                                                                                            |
+| `elements.buttons.type`           | always     |                                                                                            |
+| `elements.buttons.value`          | always     |                                                                                            |
+| `elements.buttons.webview_height` | always     | Unless button `type` is different than `webview`.                                          |
+| `elements.buttons.postback_id`    | always     |                                                                                            |
+| `elements.buttons.user_ids`       | always     |                                                                                            |
 
 </Text>
 <Code>
@@ -287,7 +287,7 @@ Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                               |                                                                                   |
+| Field        | Required | Data type | Notes                                                               |  |
 | ------------ | -------- | --------- | ------------------------------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.                                 |
 | `type`       | yes      | `string`  | Event type: `custom`                                                |
@@ -323,14 +323,14 @@ System message event is native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required  | Data type | Notes                                                                                          |
-| --------------------- | --------- |---------- | ---------------------------------------------------------------------------------------------: |
-| `custom_id`           | no        | `string`  | You can give the system message a custom ID.                                                   |
-| `type`                | yes       | `string`  | `system_message`                                                                               |
-| `text`                | no        | `string`  | Text displayed to recipients                                                                   |
-| `system_message_type` | yes       | `string`  | [System message type](/messaging/references/system-messages/)                                              |
-| `recipients`          | no        | `string`  | It can be specified when sending system messages via the [**Send Event**](#send-event) method. Possible values: `all`, `agents`.|
-| `text_vars`           | no        | `object`  | Variables used in the text                                                                     |
+| Field                 | Required | Data type |                                                                                                                            Notes |
+| --------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------: |
+| `custom_id`           | no       | `string`  |                                                                                     You can give the system message a custom ID. |
+| `type`                | yes      | `string`  |                                                                                                                 `system_message` |
+| `text`                | no       | `string`  |                                                                                                     Text displayed to recipients |
+| `system_message_type` | yes      | `string`  |                                                                    [System message type](/messaging/references/system-messages/) |
+| `recipients`          | no       | `string`  | It can be specified when sending system messages via the [**Send Event**](#send-event) method. Possible values: `all`, `agents`. |
+| `text_vars`           | no       | `object`  |                                                                                                       Variables used in the text |
 
 ### Response
 
@@ -363,18 +363,18 @@ System message event is native system event sent in specific situations.
 
 <CodeResponse version="v3.2" type="agent" title={'Sample Agent data structure'} json="agent"/>
 
-| Field            | Req./Opt. |                                              Note |
-| ---------------- | :-------: | ------------------------------------------------: |
-| `routing_status` | optional  | Returned only if the Agent's currently logged in. |
-| `events_seen_up_to`| optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Agent—all the previous events are considered seen. |
+| Field               | Req./Opt. |                                                                                                                            Note |
+| ------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------: |
+| `routing_status`    | optional  |                                                                               Returned only if the Agent's currently logged in. |
+| `events_seen_up_to` | optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Agent—all the previous events are considered seen. |
 
 ### My profile
 
 <CodeResponse version="v3.2" type="agent" title={'Sample My profile data structure'} json="myProfile"/>
 
-| Field                            | Req./Opt. | Notes                                                                                 |
-| -------------------------------- | --------- | ------------------------------------------------------------------------------------- |
-| `events_seen_up_to`              | optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Agent—all the previous events are considered seen. |
+| Field               | Req./Opt. | Notes                                                                                                                           |
+| ------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `events_seen_up_to` | optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Agent—all the previous events are considered seen. |
 
 ## Customer
 
@@ -434,16 +434,16 @@ A component of the [Filled form](#filled-form) event.
 
 <CodeResponse version="v3.2" type="agent" title={'Sample Form fields'} json="formFields"/>
 
-| Field                   | Required | Data type               |  Notes                                                                                                   |
-| ------------------------| -------- | ----------------------- | -------------------------------------------------------------------------------------------------------: |
-| `fields`                | yes      | `array of objects`      | The fields a form contains.                                                                              |
-| `type`                  | yes      | `string`                | Possible values: `checkbox`, `email`, `name`, `question`, `textarea`, `group_chooser`, `radio`, `select` |
-| `id`                    | yes      | `string`                | Field id, for all field types                                                                            |
-| `label`                 | yes      | `string`                | Field label; for all field types                                                                         |
-| `answer`                | yes      | `any`                   | For all field types                                                                                      |
-| `answer.id`             | yes      | `string`                | An identifier of each option a Customer can choose. For all field types.                           |
-| `answer.label`          | yes      | `string`                | Answer label; for all field types                                                                        |
-| `answer.group_id`       | yes      | `number`                | For `group_chooser`                                                                                      |
+| Field             | Required | Data type          |                                                                                                    Notes |
+| ----------------- | -------- | ------------------ | -------------------------------------------------------------------------------------------------------: |
+| `fields`          | yes      | `array of objects` |                                                                              The fields a form contains. |
+| `type`            | yes      | `string`           | Possible values: `checkbox`, `email`, `name`, `question`, `textarea`, `group_chooser`, `radio`, `select` |
+| `id`              | yes      | `string`           |                                                                            Field id, for all field types |
+| `label`           | yes      | `string`           |                                                                         Field label; for all field types |
+| `answer`          | yes      | `any`              |                                                                                      For all field types |
+| `answer.id`       | yes      | `string`           |                                 An identifier of each option a Customer can choose. For all field types. |
+| `answer.label`    | yes      | `string`           |                                                                        Answer label; for all field types |
+| `answer.group_id` | yes      | `number`           |                                                                                      For `group_chooser` |
 
 ## Properties
 
@@ -478,17 +478,17 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 
 ## Available methods
 
-|                 |                                                                                                                                                                                                                                                                                                                                                         |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                 |
-| **Chat access** | [`grant_chat_access`](#grant-chat-access) [`revoke_chat_access`](#revoke-chat-access) [`transfer_chat`](#transfer-chat)                                                                                                                                                                                                                           |
-| **Chat users**  | [`add_user_to_chat`](#add-user-to-chat) [`remove_user_from_chat`](#remove-user-from-chat)                                                                                                                                                                                                                                                               |
-| **Events**      | [`send_event`](#send-event) [`send_rich_message_postback`](#send-rich-message-postback)                                                                                                                                                                                                                                                                 |
+|                 |                                                                                                                                                                                                                                                                                                                                     |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                                           |
+| **Chat access** | [`grant_chat_access`](#grant-chat-access) [`revoke_chat_access`](#revoke-chat-access) [`transfer_chat`](#transfer-chat)                                                                                                                                                                                                             |
+| **Chat users**  | [`add_user_to_chat`](#add-user-to-chat) [`remove_user_from_chat`](#remove-user-from-chat)                                                                                                                                                                                                                                           |
+| **Events**      | [`send_event`](#send-event) [`send_rich_message_postback`](#send-rich-message-postback)                                                                                                                                                                                                                                             |
 | **Properties**  | [`update_chat_properties`](#update-chat-properties) [`delete_chat_properties`](#delete-chat-properties) [`update_thread_properties`](#update-thread-properties) [`delete_thread_properties`](#delete-thread-properties) [`update_event_properties`](#update-event-properties) [`delete_event_properties`](#delete-event-properties) |
 | **Thread tags** | [`tag_thread`](#tag-thread) [`untag_thread`](#untag-thread)                                                                                                                                                                                                                                                                         |
-| **Customers**   | [`get_customer`](#get-customer) [`list_customers`](#list-customers) [`create_customer`](#create-customer) [`update_customer`](#update-customer) [`ban_customer`](#ban-customer)                                                                                                                                                                           |
-| **Status**      | [`login`](#login) [`change_push_notifications`](#change-push-notifications) [`set_routing_status`](#set-routing-status) [`set_away_status`](#set-away-status) [`logout`](#logout)                                                                                                                                                                       |
-| **Other**       | [`mark_events_as_seen`](#mark-events-as-seen) [`send_typing_indicator`](#send-typing-indicator) [`multicast`](#multicast) [`list_agents_for_transfer`](#list-agents-for-transfer)                                                                                                                                                                         |
+| **Customers**   | [`get_customer`](#get-customer) [`list_customers`](#list-customers) [`create_customer`](#create-customer) [`update_customer`](#update-customer) [`ban_customer`](#ban-customer)                                                                                                                                                     |
+| **Status**      | [`login`](#login) [`change_push_notifications`](#change-push-notifications) [`set_routing_status`](#set-routing-status) [`set_away_status`](#set-away-status) [`logout`](#logout)                                                                                                                                                   |
+| **Other**       | [`mark_events_as_seen`](#mark-events-as-seen) [`send_typing_indicator`](#send-typing-indicator) [`multicast`](#multicast) [`list_agents_for_transfer`](#list-agents-for-transfer)                                                                                                                                                   |
 
 </Text>
 <Code>
@@ -536,7 +536,7 @@ It returns [summaries](#chat-summaries) of the chats an Agent has access to.
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
+| ---------------------- | ------------------------------------------------- |
 | **Action**             | `list_chats`                                      |
 | **Required scopes \*** | `chats--all:ro` `chats--access:ro` `chats--my:ro` |
 | **Web API equivalent** | [`list_chats`](../#list-chats)                    |
@@ -551,8 +551,8 @@ It returns [summaries](#chat-summaries) of the chats an Agent has access to.
 | `filters.include_chats_without_threads`               | No       | `bool`   | Defines if the returned chat summary includes chats without any threads; default: `true`.   |
 | `filters.group_ids`                                   | No       | `array`  | Array of group IDs. Max array size: 200                                                     |
 | `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`    |                                                                                             |
-| `sort_order`                                               | No       | `string` | Possible values: `asc` - oldest chats firstm `desc` - newest chats first (default)          |
-| `limit`                                               | No       | `number` | Default: 10, maximum: 100                                                                    |
+| `sort_order`                                          | No       | `string` | Possible values: `asc` - oldest chats firstm `desc` - newest chats first (default)          |
+| `limit`                                               | No       | `number` | Default: 10, maximum: 100                                                                   |
 | `page_id`                                             | No       | `string` |                                                                                             |
 
 `filter_type` can take the following values:
@@ -565,12 +565,12 @@ There's only one value allowed for a single property.
 
 #### Response
 
-| Parameter          | Data type   | Notes                                                                     |
-| ------------------ | ----------- | ------------------------------------------------------------------------- |
-| `chats_summary`    | `array`     | An array of [Chat summary](#chat-summaries) data structures |
-| `next_page_id`     | `string`    | In relation to `page_id` specified in the request. Appears in the response only when there's a next page. |
-| `previous_page_id` | `string`    | In relation to `page_id` specified in the request Appears in the response only when there's a previous page.|
-| `found_chats`      | `number`    | An estimated number. The real number of found chats can slightly differ. |
+| Parameter          | Data type | Notes                                                                                                        |
+| ------------------ | --------- | ------------------------------------------------------------------------------------------------------------ |
+| `chats_summary`    | `array`   | An array of [Chat summary](#chat-summaries) data structures                                                  |
+| `next_page_id`     | `string`  | In relation to `page_id` specified in the request. Appears in the response only when there's a next page.    |
+| `previous_page_id` | `string`  | In relation to `page_id` specified in the request Appears in the response only when there's a previous page. |
+| `found_chats`      | `number`  | An estimated number. The real number of found chats can slightly differ.                                     |
 
 </Text>
 <Code>
@@ -665,20 +665,20 @@ It returns threads that the current Agent has access to in a given chat.
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
-| **Action**             | `list_threads`                                      |
-| **Required scopes** | `chats--all:ro` `chats--access:ro` `chats--my:ro` |
-| **Web API equivalent** | [`list_threads`](../#list-threads)                    |
+| ---------------------- | ------------------------------------------------- |
+| **Action**             | `list_threads`                                    |
+| **Required scopes**    | `chats--all:ro` `chats--access:ro` `chats--my:ro` |
+| **Web API equivalent** | [`list_threads`](../#list-threads)                |
 | **Push message**       | -                                                 |
 
 #### Request
 
-| Parameter          | Required | Data type | Notes                                                                                      |
-| ------------------ | -------- | --------- | ------------------------------------------------------------------------------------------ |
-| `chat_id`          | Yes      | `string`  |                                                                                            |
-| `sort_order`       | No       | `string`  | Possible values: `asc` - oldest threads first and `desc` - newest threads first (default). |
-| `limit`            | No       | `number`  | Default: 3, maximum: 100                                                                   |
-| `page_id`          | No       | `string`  |                                                                                            |
+| Parameter          | Required | Data type | Notes                                                                                                                                                                                                                                                       |
+| ------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`          | Yes      | `string`  |                                                                                                                                                                                                                                                             |
+| `sort_order`       | No       | `string`  | Possible values: `asc` - oldest threads first and `desc` - newest threads first (default).                                                                                                                                                                  |
+| `limit`            | No       | `number`  | Default: 3, maximum: 100                                                                                                                                                                                                                                    |
+| `page_id`          | No       | `string`  |                                                                                                                                                                                                                                                             |
 | `min_events_count` | No       | `number`  | Range: 1-100; Specifies the minimum number of events to be returned in the response. It's the **total** number of events, so they can come from more than one thread. You'll get as many latest threads as needed to meet the `min_events_count` condition. |
 
 You cannot use both `limit` and `min_events_count` at the same time.
@@ -754,7 +754,7 @@ It returns a thread that the current Agent has access to in a given chat.
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
+| ---------------------- | ------------------------------------------------- |
 | **Action**             | `get_chat`                                        |
 | **Required scopes**    | `chats--all:ro` `chats--access:ro` `chats--my:ro` |
 | **Web API equivalent** | [`get_chat`](../#get-chat)                        |
@@ -763,7 +763,7 @@ It returns a thread that the current Agent has access to in a given chat.
 #### Request
 
 | Parameter   | Required | Data type | Notes                                  |
-|-------------|----------|-----------|----------------------------------------|
+| ----------- | -------- | --------- | -------------------------------------- |
 | `chat_id`   | Yes      | `string`  |                                        |
 | `thread_id` | No       | `string`  | Default: the latest thread (if exists) |
 
@@ -866,7 +866,7 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
+| ---------------------- | ------------------------------------------------- |
 | **Action**             | `list_archives`                                   |
 | **Required scopes**    | `chats--all:ro` `chats--access:ro` `chats--my:ro` |
 | **Web API equivalent** | [`list_archives`](../#list-archives)              |
@@ -874,26 +874,26 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 
 #### Request
 
-| Parameter                                             | Required | Data type | Notes                                                                                     |
-| ----------------------------------------------------- | -------- | --------- | ----------------------------------------------------------------------------------------- |
-| `filters`                                             | No       | `object`  |                                                                                           |
-| `filters.query`                                       | No       | `string`  |                                                                                           |
-| `filters.from`                                        | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.ssssssZHH:MM` |
-| `filters.to`                                           | No       | `string` | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.ssssssZHH:MM` |
-| `filters.group_ids`                                   | No       | `array`   | Array of group IDs. Max array size: 200                                                   |
-| `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     | **\* described below**                                                                    |
-| `filters.agents.<filter_type>`                        | No       | `any`     |  `exists` see to `false` will return unassigned chats; `true` will return the assigned ones.|
-| `filters.tags.<filter_type>`                          | No       | `any`     |                                                                                           |
-| `filters.sales.<filter_type>`                         | No       | `any`     |                                                                                           |
-| `filters.goals.<filter_type>`                         | No       | `any`     |                                                                                           |
-| `filters.surveys.<survey>`                            | No       | `array`   | **\*\*** **described below**                                                              |
-| `filters.events.types`                                | No       | `array`   | Array of [Event](#events) types. Duplicates are ignored.                                  |
-| `page_id`                                             | No       | `string`  |                                                                                           |
-| `sort_order` **\*\*\***                               | No       | `string`  |  Default: `desc`                                                                          |
-| `limit`                                               | No       | `number`  | Default: 10, min: 1, max: 100                                                             |
-| `highlights`                                          | No       | `object`  | Use it to highlight the match of `filters.query`. To enable highlights with default parameters, pass an empty object.|
-| `highlights.pre_tag`                                  | No       | `string`  | An HTML tag to use for highlighting the matched text; default: `<em>`. Use it together with `highlights.post_tag`.   |
-| `highlights.post_tag`                                 | No       | `string`  | An HTML tag to use for highlighting the matched text; default: `</em>`. Use it together with `highlights.pre_tag`.   |
+| Parameter                                             | Required | Data type | Notes                                                                                                                 |
+| ----------------------------------------------------- | -------- | --------- | --------------------------------------------------------------------------------------------------------------------- |
+| `filters`                                             | No       | `object`  |                                                                                                                       |
+| `filters.query`                                       | No       | `string`  |                                                                                                                       |
+| `filters.from`                                        | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.ssssssZHH:MM`                  |
+| `filters.to`                                          | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.ssssssZHH:MM`                  |
+| `filters.group_ids`                                   | No       | `array`   | Array of group IDs. Max array size: 200                                                                               |
+| `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     | **\* described below**                                                                                                |
+| `filters.agents.<filter_type>`                        | No       | `any`     | `exists` see to `false` will return unassigned chats; `true` will return the assigned ones.                           |
+| `filters.tags.<filter_type>`                          | No       | `any`     |                                                                                                                       |
+| `filters.sales.<filter_type>`                         | No       | `any`     |                                                                                                                       |
+| `filters.goals.<filter_type>`                         | No       | `any`     |                                                                                                                       |
+| `filters.surveys.<survey>`                            | No       | `array`   | **\*\*** **described below**                                                                                          |
+| `filters.events.types`                                | No       | `array`   | Array of [Event](#events) types. Duplicates are ignored.                                                              |
+| `page_id`                                             | No       | `string`  |                                                                                                                       |
+| `sort_order` **\*\*\***                               | No       | `string`  | Default: `desc`                                                                                                       |
+| `limit`                                               | No       | `number`  | Default: 10, min: 1, max: 100                                                                                         |
+| `highlights`                                          | No       | `object`  | Use it to highlight the match of `filters.query`. To enable highlights with default parameters, pass an empty object. |
+| `highlights.pre_tag`                                  | No       | `string`  | An HTML tag to use for highlighting the matched text; default: `<em>`. Use it together with `highlights.post_tag`.    |
+| `highlights.post_tag`                                 | No       | `string`  | An HTML tag to use for highlighting the matched text; default: `</em>`. Use it together with `highlights.pre_tag`.    |
 
 **\*)**
 `<filter_type>` can take the following values:
@@ -1024,7 +1024,7 @@ Starts a chat.
 #### Specifics
 
 |                        |                                                                                          |
-|------------------------|------------------------------------------------------------------------------------------|
+| ---------------------- | ---------------------------------------------------------------------------------------- |
 | **Action**             | `start_chat`                                                                             |
 | **Required scopes \*** | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
 | **Web API equivalent** | [`start_chat`](../#start-chat)                                                           |
@@ -1039,25 +1039,25 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Request
 
-| Parameters               | Required | Data type | Notes                                                                   |
-| ------------------------ | -------- | --------- | ----------------------------------------------------------------------- |
-| `chat`                   | No       | `object`  |                                                                         |
-| `chat.properties`        | No       | `object`  |                                                                         |
-| `chat.access`            | No       | `object`  |                                                                         |
+| Parameters               | Required | Data type  | Notes                                                                                                    |
+| ------------------------ | -------- | ---------- | -------------------------------------------------------------------------------------------------------- |
+| `chat`                   | No       | `object`   |                                                                                                          |
+| `chat.properties`        | No       | `object`   |                                                                                                          |
+| `chat.access`            | No       | `object`   |                                                                                                          |
 | `chat.users`             | No       | `[]object` | The list of existing users. Up to 4 additional (other than the requester) agents and 1 customer allowed. |
-| `chat.users.id`          | Yes      | `string`  | User ID                                                               |
-| `chat.users.type`        | Yes      | `string`  | `agent` or `customer`.                                                  |
-| `chat.thread`            | No       | `object`  |                                                                         |
-| `chat.thread.events`     | No       | `array`   | The list of initial chat events                                         |
-| `chat.thread.properties` | No       | `object`  |                                                                         |
-| `continuous`             | No       | `bool`    | Starts chat as continuous (online group is not required); default: `false`. |
+| `chat.users.id`          | Yes      | `string`   | User ID                                                                                                  |
+| `chat.users.type`        | Yes      | `string`   | `agent` or `customer`.                                                                                   |
+| `chat.thread`            | No       | `object`   |                                                                                                          |
+| `chat.thread.events`     | No       | `array`    | The list of initial chat events                                                                          |
+| `chat.thread.properties` | No       | `object`   |                                                                                                          |
+| `continuous`             | No       | `bool`     | Starts chat as continuous (online group is not required); default: `false`.                              |
 
 #### Response
 
-| Parameter   | Data type  | Notes |
-| ----------- | ---------- | ----- |
-| `chat_id`   | `string`   |       |
-| `thread_id` | `string`   |       |
+| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`   | `string`   |                                                                                                                                                                         |
+| `thread_id` | `string`   |                                                                                                                                                                         |
 | `event_ids` | `[]string` | Returned only when the chat was started with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
 
 </Text>
@@ -1154,7 +1154,7 @@ Restarts an archived chat.
 | **Action**             | `activate_chat`                                                                          |
 | **Required scopes \*** | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
 | **Web API equivalent** | [`activate_chat`](../#activate-chat)                                                     |
-| **Push message**       | [`incoming_chat`](#incoming_chat)                                          |
+| **Push message**       | [`incoming_chat`](#incoming_chat)                                                        |
 
 **\*)**
 When `chat.users` is defined, one of following scopes is required:
@@ -1165,26 +1165,26 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Request
 
-| Request object           | Required | Type     | Notes                                                               |
-| ------------------------ | -------- | -------- | ------------------------------------------------------------------- |
-| `chat`                   | Yes      | `object` |                                                                     |
-| `chat.id`                | Yes      | `string` | The ID of the chat that will be activated.                          |
-| `chat.access`            | No       | `object` | Chat access to set, default: all agents.                            |
-| `chat.properties`        | No       | `object` | Initial chat properties                                             |
+| Request object           | Required | Type       | Notes                                                                                                    |
+| ------------------------ | -------- | ---------- | -------------------------------------------------------------------------------------------------------- |
+| `chat`                   | Yes      | `object`   |                                                                                                          |
+| `chat.id`                | Yes      | `string`   | The ID of the chat that will be activated.                                                               |
+| `chat.access`            | No       | `object`   | Chat access to set, default: all agents.                                                                 |
+| `chat.properties`        | No       | `object`   | Initial chat properties                                                                                  |
 | `chat.users`             | No       | `[]object` | The list of existing users. Up to 4 additional (other than the requester) agents and 1 customer allowed. |
-| `chat.users.id`          | Yes      | `string` | User ID                                                             |
-| `chat.users.type`        | Yes      | `string` | `agent` or `customer`                                               |
-| `chat.thread`            | No       | `object` |                                                                     |
-| `chat.thread.events`     | No       | `array`  | Initial chat events array                                           |
-| `chat.thread.properties` | No       | `object` | Initial thread properties                                      |
-| `continuous`             | No       | `bool`   | Sets a chat to the continuous mode. When unset, leaves the mode unchanged. |
+| `chat.users.id`          | Yes      | `string`   | User ID                                                                                                  |
+| `chat.users.type`        | Yes      | `string`   | `agent` or `customer`                                                                                    |
+| `chat.thread`            | No       | `object`   |                                                                                                          |
+| `chat.thread.events`     | No       | `array`    | Initial chat events array                                                                                |
+| `chat.thread.properties` | No       | `object`   | Initial thread properties                                                                                |
+| `continuous`             | No       | `bool`     | Sets a chat to the continuous mode. When unset, leaves the mode unchanged.                               |
 
 #### Response
 
-| Parameter   | Data type  | Notes |
-| ----------- | ---------- | ----- |
-| `thread_id` | `string`   |       |
-| `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array.|
+| Parameter   | Data type  | Notes                                                                                                                                                                     |
+| ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `thread_id` | `string`   |                                                                                                                                                                           |
+| `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
 
 </Text>
 <Code>
@@ -1272,7 +1272,7 @@ Deactivates a chat by closing the currently open thread. Sending messages to thi
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
+| ---------------------- | ------------------------------------------------- |
 | **Action**             | `deactivate_chat`                                 |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw` |
 | **Web API equivalent** | [`deactivate_chat`](../#deactivate-chat)          |
@@ -1280,9 +1280,9 @@ Deactivates a chat by closing the currently open thread. Sending messages to thi
 
 #### Request
 
-| Parameter | Required | Data type |  |
-| --------- | -------- | --------- | ----- |
-| `chat_id` | Yes      | `string`  |       |
+| Parameter | Required | Data type |     |
+| --------- | -------- | --------- | --- |
+| `chat_id` | Yes      | `string`  |     |
 
 </Text>
 <Code>
@@ -1327,7 +1327,7 @@ Marks a chat as followed. All changes to the chat will be sent to the requester 
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
+| ---------------------- | ------------------------------------------------- |
 | **Action**             | `follow_chat`                                     |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw` |
 | **Web API equivalent** | [`follow_chat`](../#follow-chat)                  |
@@ -1338,9 +1338,9 @@ It won't be sent when the requester already follows the chat or is the chat memb
 
 #### Request
 
-| Parameter | Required | Data type |  |
-| --------- | -------- | --------- | ----- |
-| `chat_id` | Yes      | `string`  |       |
+| Parameter | Required | Data type |     |
+| --------- | -------- | --------- | --- |
+| `chat_id` | Yes      | `string`  |     |
 
 </Text>
 <Code>
@@ -1450,12 +1450,12 @@ Grants access to a new chat without overwriting the existing ones.
 
 #### Request
 
-| Parameter     | Required | Data ype | Notes                |
-| ------------- | -------- | -------- | -------------------- |
-| `id`          | Yes      | `string` | Chat Id              |
-| `access`      | Yes      | `object` |                      |
-| `access.type` | Yes      | `string` | `group`              |
-| `access.id`   | Yes      | any      |                      |
+| Parameter     | Required | Data ype | Notes   |
+| ------------- | -------- | -------- | ------- |
+| `id`          | Yes      | `string` | Chat Id |
+| `access`      | Yes      | `object` |         |
+| `access.type` | Yes      | `string` | `group` |
+| `access.id`   | Yes      | any      |         |
 
 </Text>
 <Code>
@@ -1510,12 +1510,12 @@ Grants access to a new chat without overwriting the existing ones.
 
 #### Request
 
-| Parameter     | Required | Data type | Notes                |
-| ------------- | -------- | --------- | -------------------- |
-| `id`          | Yes      | `string`  | Chat Id              |
-| `access`      | Yes      | `object`  |                      |
-| `access.type` | Yes      | `string`  | `group` or `agent`   |
-| `access.id`   | Yes      | `number`  |                      |
+| Parameter     | Required | Data type | Notes              |
+| ------------- | -------- | --------- | ------------------ |
+| `id`          | Yes      | `string`  | Chat Id            |
+| `access`      | Yes      | `object`  |                    |
+| `access.type` | Yes      | `string`  | `group` or `agent` |
+| `access.id`   | Yes      | `number`  |                    |
 
 </Text>
 <Code>
@@ -1568,13 +1568,13 @@ Transfers a chat to an Agent or a group.
 | **Action**             | `transfer_chat`                                   |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw` |
 | **Web API equivalent** | [`transfer_chat`](../#transfer-chat)              |
-| **Push message**       | [`chat_transferred`](#chat_transferred)         |
+| **Push message**       | [`chat_transferred`](#chat_transferred)           |
 
 #### Request
 
 | Parameter     | Required | Data ype | Notes                                                                                                                           |
 | ------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `chat_id`     | Yes      | `string` | Chat Id                                                                                                                     |
+| `chat_id`     | Yes      | `string` | Chat Id                                                                                                                         |
 | `target`      | No       | `object` | If missing, the chat will be transferred within the current group.                                                              |
 | `target.type` | Yes      | `string` | `group` or `agent`                                                                                                              |
 | `target.ids`  | Yes      | `array`  | `group` or `agent` IDs array                                                                                                    |
@@ -1637,11 +1637,11 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 
 #### Request
 
-| Request object          | Required | Type     | Notes                                                                   |
-| ----------------------- | -------- | -------- | ----------------------------------------------------------------------- |
-| `chat_id`               | Yes      | `string` |                                                                         |
-| `user_id`               | Yes      | `string` |                                                                         |
-| `user_type`             | Yes      | `string` | Possible values: `agent` or `customer`                                  |
+| Request object          | Required | Type     | Notes                                                                                        |
+| ----------------------- | -------- | -------- | -------------------------------------------------------------------------------------------- |
+| `chat_id`               | Yes      | `string` |                                                                                              |
+| `user_id`               | Yes      | `string` |                                                                                              |
+| `user_type`             | Yes      | `string` | Possible values: `agent` or `customer`                                                       |
 | `require_active_thread` | No       | `bool`   | If `true`, it adds a user to a chat only if that chat has an active thread; default `false`. |
 
 </Text>
@@ -1753,11 +1753,11 @@ It's possible to write to a chat without joining it. The user sending an event w
 #### Specifics
 
 |                        |
-| ---------------------- | ----------------------------------------------------------------------------------------
-| **Action**             | `send_event`
-| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw`
-| **Web API equivalent** | [`send_event`](../#send-event)
-| **Push message**       | [`incoming_event`](#incoming_event)
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| **Action**             | `send_event`                                                                             |
+| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
+| **Web API equivalent** | [`send_event`](../#send-event)                                                           |
+| **Push message**       | [`incoming_event`](#incoming_event)                                                      |
 
 #### Request
 
@@ -1889,10 +1889,10 @@ It's possible to write to a chat without joining it. The user sending an event w
 
 #### Request
 
-| Parameter    | Required | Data type | Notes                                     |
-| ------------ | -------- | --------- | ----------------------------------------- |
-| `chat_id`    | Yes      | `string`  | Id of the chat you to set a property for. |
-| `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| Parameter    | Required | Data type | Notes                                                                                                                                                                        |
+| ------------ | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`    | Yes      | `string`  | Id of the chat you to set a property for.                                                                                                                                    |
+| `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_. |
 
 </Text>
 <Code>
@@ -1951,7 +1951,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 | Parameter    | Required | Data type | Notes                                           |
 | ------------ | -------- | --------- | ----------------------------------------------- |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete property for. |
-| `properties` | Yes      | `object`  | Chat properties to delete. |
+| `properties` | Yes      | `object`  | Chat properties to delete.                      |
 
 </Text>
 <Code>
@@ -1999,7 +1999,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 #### Specifics
 
 |                        |                                                                                          |
-|------------------------|------------------------------------------------------------------------------------------|
+| ---------------------- | ---------------------------------------------------------------------------------------- |
 | **Action**             | `update_thread_properties`                                                               |
 | **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
 | **Web API equivalent** | [`update_thread_properties`](../#update-thread-properties)                               |
@@ -2007,11 +2007,11 @@ It's possible to write to a chat without joining it. The user sending an event w
 
 #### Request
 
-| Parameter    | Required | Data type | Notes                                            |
-| ------------ | -------- | --------- | ------------------------------------------------ |
-| `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.   |
-| `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for. |
-| `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| Parameter    | Required | Data type | Notes                                                                                                                                                                        |
+| ------------ | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.                                                                                                                               |
+| `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for.                                                                                                                             |
+| `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_. |
 
 </Text>
 <Code>
@@ -2060,7 +2060,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 #### Specifics
 
 |                        |                                                                                          |
-|------------------------|------------------------------------------------------------------------------------------|
+| ---------------------- | ---------------------------------------------------------------------------------------- |
 | **Action**             | `delete_thread_properties`                                                               |
 | **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
 | **Web API equivalent** | [`delete_thread_properties`](../#delete-thread-properties)                               |
@@ -2069,7 +2069,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 #### Request
 
 | Parameter    | Required | Data type | Notes                                             |
-|--------------|----------|-----------|---------------------------------------------------|
+| ------------ | -------- | --------- | ------------------------------------------------- |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete property for.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to delete property for. |
 | `properties` | Yes      | `object`  | Chat properties to delete.                        |
@@ -2134,7 +2134,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for. |
 | `event_id`   | Yes      | `string`  | Id of the event you want to set properties for.  |
-| `properties` | Yes      | `object`  | Chat properties to set. |
+| `properties` | Yes      | `object`  | Chat properties to set.                          |
 
 </Text>
 <Code>
@@ -2192,12 +2192,12 @@ It's possible to write to a chat without joining it. The user sending an event w
 
 #### Request
 
-| Parameter    | Required | Data type | Notes                                             |
-| ------------ | -------- | --------- | ------------------------------------------------- |
-| `chat_id`    | Yes      | `string`  | Id of the chat you want to delete the properties of.   |
-| `thread_id`  | Yes      | `string`  | Id of the thread you want to delete the properties of. |
-| `event_id`   | Yes      | `string`  | Id of the event you want to delete the properties of.  |
-| `properties` | Yes      | `object`  | Event properties to delete. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| Parameter    | Required | Data type | Notes                                                                                                                                                                            |
+| ------------ | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`    | Yes      | `string`  | Id of the chat you want to delete the properties of.                                                                                                                             |
+| `thread_id`  | Yes      | `string`  | Id of the thread you want to delete the properties of.                                                                                                                           |
+| `event_id`   | Yes      | `string`  | Id of the event you want to delete the properties of.                                                                                                                            |
+| `properties` | Yes      | `object`  | Event properties to delete. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_. |
 
 </Text>
 <Code>
@@ -2249,7 +2249,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
+| ---------------------- | ------------------------------------------------- |
 | **Action**             | `tag_thread`                                      |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw` |
 | **Web API equivalent** | [`tag_thread`](../#tag-thread)                    |
@@ -2306,7 +2306,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
+| ---------------------- | ------------------------------------------------- |
 | **Action**             | `untag_thread`                                    |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw` |
 | **Web API equivalent** | [`untag_thread`](../#untag-thread)                |
@@ -2484,7 +2484,7 @@ It returns the list of Customers.
 #### Specifics
 
 |                        |                                        |
-|------------------------|----------------------------------------|
+| ---------------------- | -------------------------------------- |
 | **Action**             | `list_customers`                       |
 | **Required scopes**    | `customers:ro`                         |
 | **Web API equivalent** | [`list_customers`](../#list-customers) |
@@ -2495,7 +2495,7 @@ It returns the list of Customers.
 All parameters are optional.
 
 | Parameter                                                                      | Data type | Notes                     |
-|--------------------------------------------------------------------------------|-----------|---------------------------|
+| ------------------------------------------------------------------------------ | --------- | ------------------------- |
 | `page_id`                                                                      | `string`  |                           |
 | `limit`                                                                        | `number`  | Default: 10, maximum: 100 |
 | `sort_order` **\***                                                            | `string`  | Default: `desc`           |
@@ -2551,10 +2551,10 @@ Dates are represented in ISO 8601 format with microseconds resolution, e.g. `201
 
 #### Response
 
-| Parameter         | Data type | Notes                                              |
-| ----------------- | --------- | -------------------------------------------------- |
-| `next_page_id`    | `string`  | In relation to `page_id` specified in the request. |
-| `previous_page_id`| `string`  | In relation to `page_id` specified in the request. |
+| Parameter          | Data type | Notes                                              |
+| ------------------ | --------- | -------------------------------------------------- |
+| `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
+| `previous_page_id` | `string`  | In relation to `page_id` specified in the request. |
 
 </Text>
 <Code>
@@ -2601,12 +2601,12 @@ Creates a new [Customer](#customer) user type.
 
 #### Specifics
 
-|                        |                                         |
-| ---------------------- | --------------------------------------- |
-| **Action**             | `create_customer`                       |
-| **Required scopes**    | `customers:rw`                          |
-| **Web API equivalent** | [`create_customer`](../#create-customer)  |
-| **Push message**       | [`customer_created`](#customer_created) |
+|                        |                                          |
+| ---------------------- | ---------------------------------------- |
+| **Action**             | `create_customer`                        |
+| **Required scopes**    | `customers:rw`                           |
+| **Web API equivalent** | [`create_customer`](../#create-customer) |
+| **Push message**       | [`customer_created`](#customer_created)  |
 
 #### Request
 
@@ -2797,7 +2797,7 @@ It returns the initial state of the current Agent.
 #### Specifics
 
 |                        |                                                                                        |
-|------------------------|----------------------------------------------------------------------------------------|
+| ---------------------- | -------------------------------------------------------------------------------------- |
 | **Action**             | `login`                                                                                |
 | **Required scopes**    | `chats--access:ro` `customers:ro` `multicast:ro` `agents--all:ro` `agents-bot--all:ro` |
 | **Web API equivalent** | -                                                                                      |
@@ -2816,17 +2816,17 @@ It returns the initial state of the current Agent.
 | `application`                       | No       | `object`  |                                                                                                                                  |
 | `application.name`                  | No       | `string`  | Application name                                                                                                                 |
 | `application.version`               | No       | `string`  | Application version                                                                                                              |
-| `away` __*__                        | No       | `bool`    | When `true`, the connection is set to the `away` state. Defaults to `false`.  |
+| `away` __*__                        | No       | `bool`    | When `true`, the connection is set to the `away` state. Defaults to `false`.                                                     |
 
 __*__ You can use the `away` param to **prevent assigning chats** to Agents **after random reconnections** when their status was set to `not_accepting_chats` by the auto-away feature. When an Agent logs in with `away: true`, the connection is immediately recognized
 as `away`. [Read more...](#set-away-status)
 
 #### Response
 
-| Parameter     | Data type | Notes |
-| ------------- | --------- | ----- |
-| `access`      | `object`  |       |
-| `properties`  | `object`  |       |
+| Parameter    | Data type | Notes |
+| ------------ | --------- | ----- |
+| `access`     | `object`  |       |
+| `properties` | `object`  |       |
 
 </Text>
 <Code>
@@ -3048,19 +3048,19 @@ Unlike [**Set Away Status**](#set-away-status), which is another mechanism of st
 
 #### Specifics
 
-|                        |                                                                            |
-| ---------------------- | -------------------------------------------------------------------------- |
-| **Action**             | `set_routing_status`                                                       |
-| **Required scopes**    | for Agents: `agents--my:rw` `agents--all:rw`; for Bot Agents: `agents-bot--my:rw` `agents-bot--all:rw`|
-| **Web API equivalent** | [`set_routing_status`](../#set-routing-status)                             |
-| **Push message**       | [`routing_status_set`](#routing_status_set)  |
+|                        |                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Action**             | `set_routing_status`                                                                                   |
+| **Required scopes**    | for Agents: `agents--my:rw` `agents--all:rw`; for Bot Agents: `agents-bot--my:rw` `agents-bot--all:rw` |
+| **Web API equivalent** | [`set_routing_status`](../#set-routing-status)                                                         |
+| **Push message**       | [`routing_status_set`](#routing_status_set)                                                            |
 
 #### Request
 
-| Parameter  | Required | Data type| Notes                                                            |
-| -----------| -------- | -------- | ---------------------------------------------------------------- |
-| `status`   |   Yes    | `string` | For Agents: `accepting_chats` or `not_accepting_chats`; for Bot Agents: `accepting_chats`, `not_accepting_chats`, or `offline` |
-| `agent_id` |   No     | `string` | If not specified, the requester's status will be updated.        |
+| Parameter  | Required | Data type | Notes                                                                                                                          |
+| ---------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `status`   | Yes      | `string`  | For Agents: `accepting_chats` or `not_accepting_chats`; for Bot Agents: `accepting_chats`, `not_accepting_chats`, or `offline` |
+| `agent_id` | No       | `string`  | If not specified, the requester's status will be updated.                                                                      |
 
 </Text>
 <Code>
@@ -3152,19 +3152,19 @@ Logs the Agent out.
 
 #### Specifics
 
-|                        |                                                               |
-| ---------------------- | ------------------------------------------------------------- |
-| **Action**             | `mark_events_as_seen`                                         |
-| **Required scopes**    | `chats--access:ro` `chats--all:ro`                            |
-| **Web API equivalent** | [`mark_events_as_seen`](../#mark-events-as-seen)              |
+|                        |                                                   |
+| ---------------------- | ------------------------------------------------- |
+| **Action**             | `mark_events_as_seen`                             |
+| **Required scopes**    | `chats--access:ro` `chats--all:ro`                |
+| **Web API equivalent** | [`mark_events_as_seen`](../#mark-events-as-seen)  |
 | **Push message**       | [`events_marked_as_seen`](#events_marked_as_seen) |
 
 #### Request
 
-| Parameter    | Required | Data type   | Notes |
-| ------------ | -------- | ----------- | ----- |
-| `chat_id`    | Yes      | `string`    |       |
-| `seen_up_to` | Yes      | `string`    | RFC 3339 date-time format |
+| Parameter    | Required | Data type | Notes                     |
+| ------------ | -------- | --------- | ------------------------- |
+| `chat_id`    | Yes      | `string`  |                           |
+| `seen_up_to` | Yes      | `string`  | RFC 3339 date-time format |
 
 </Text>
 <Code>
@@ -3277,7 +3277,7 @@ For example, it could be used in an app that sends notifications to Agents or Cu
 #### Request
 
 | Parameter    | Required | Data type | Notes                     |
-|--------------|----------|-----------|---------------------------|
+| ------------ | -------- | --------- | ------------------------- |
 | `recipients` | Yes      | `object`  | **\***                    |
 | `content`    | Yes      | `any`     | A JSON message to be sent |
 | `type`       | No       | `string`  | Multicast message type    |
@@ -3363,7 +3363,7 @@ It returns the Agents you can transfer a chat to. Agents are sorted ascendingly 
 #### Specifics
 
 |                        |                                                            |
-|------------------------|------------------------------------------------------------|
+| ---------------------- | ---------------------------------------------------------- |
 | **Action**             | `list_agents_for_transfer`                                 |
 | **Required scopes**    | -                                                          |
 | **Web API equivalent** | [`list_agents_for_transfer`](../#list-agents-for-transfer) |
@@ -3371,9 +3371,9 @@ It returns the Agents you can transfer a chat to. Agents are sorted ascendingly 
 
 #### Request
 
-| Parameter  | Required | Data type | Notes                                   |
-| ---------- | -------- | --------- | --------------------------------------- |
-| `chat_id`  | Yes      | `string`  | The ID of the chat you want to transfer |
+| Parameter | Required | Data type | Notes                                   |
+| --------- | -------- | --------- | --------------------------------------- |
+| `chat_id` | Yes      | `string`  | The ID of the chat you want to transfer |
 
 </Text>
 <Code>
@@ -3427,16 +3427,16 @@ Here's what you need to know about **pushes**:
 - Their equivalents in Web API are [webhooks](/management/configuration-api/#webhooks). Pushes and webhooks have similar payloads.
 - There are no retries for pushes. To determine if a user has seen an event, compare the [event's](#response) `created_at` parameter with the [user's](#users) `events_seen_up_to` field.
 
-|                 |                                                                                                                                                                                                                                                                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                                   |
-| **Chat access** | [`chat_access_granted`](#chat_access_granted) [`chat_access_revoked`](#chat_access_revoked) [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                           |
+|                 |                                                                                                                                                                                                                                                                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                       |
+| **Chat access** | [`chat_access_granted`](#chat_access_granted) [`chat_access_revoked`](#chat_access_revoked) [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                             |
 | **Chat users**  | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                 |
-| **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                            |
+| **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                        |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
 | **Thread tags** | [`thread_tagged`](#thread_tagged) [`thread_untagged`](#thread_untagged)                                                                                                                                                                                                                                                                         |
-| **Customers**   | [`customer_visit_started`](#customer_visit_started) [`customer_created`](#customer_created) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_banned`](#customer_banned) [`customer_visit_ended`](#customer_visit_ended)                                                                                         |
-| **Status**      | [`routing_status_set`](#routing_status_set) [`agent_disconnected`](#agent_disconnected)                                                                                                                                                                                                                                                                             |
+| **Customers**   | [`customer_visit_started`](#customer_visit_started) [`customer_created`](#customer_created) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_banned`](#customer_banned) [`customer_visit_ended`](#customer_visit_ended)                                                                     |
+| **Status**      | [`routing_status_set`](#routing_status_set) [`agent_disconnected`](#agent_disconnected)                                                                                                                                                                                                                                                         |
 | **Other**       | [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_sneak_peek`](#incoming_sneak_peek) [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`chat_unfollowed`](#chat_unfollowed) [`queue_positions_updated`](#queue_positions_updated)                                               |
 
 </Text>
@@ -3500,7 +3500,7 @@ Informs about a chat coming with a new thread. The push payload contains the who
 #### Specifics
 
 |                        |                                                                 |
-|------------------------|-----------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------- |
 | **Action**             | `incoming_chat`                                                 |
 | **Webhook equivalent** | [`incoming_chat`](/management/configuration-api/#incoming_chat) |
 
@@ -3523,7 +3523,7 @@ Informs that a chat was deactivated by closing the currently open thread.
 #### Specifics
 
 |                        |                                                                       |
-|------------------------|-----------------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------------- |
 | **Action**             | `chat_deactivated`                                                    |
 | **Webhook equivalent** | [`chat_deactivated`](/management/configuration-api/#chat_deactivated) |
 
@@ -3554,16 +3554,16 @@ Informs that new, single access to a chat was granted. The existing access isn't
 
 #### Specifics
 
-|                        |                                                                             |
-| ---------------------- | --------------------------------------------------------------------------- |
-| **Action**             | `chat_access_granted`                                                       |
+|                        |                                                                                  |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| **Action**             | `chat_access_granted`                                                            |
 | **Webhook equivalent** | [`chat_access_granted`](/management/configuration-api/v3.2/#chat_access_granted) |
 
 #### Push payload
 
-| Object     | Notes         |
-| ---------- | ------------- |
-| `id`       | Chat id   |
+| Object | Notes   |
+| ------ | ------- |
+| `id`   | Chat id |
 
 ### `chat_access_revoked`
 
@@ -3584,16 +3584,16 @@ Informs that access to a certain chat was revoked.
 
 #### Specifics
 
-|                        |                                                                             |
-| ---------------------- | --------------------------------------------------------------------------- |
-| **Action**             | `chat_access_revoked`                                                       |
+|                        |                                                                                  |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| **Action**             | `chat_access_revoked`                                                            |
 | **Webhook equivalent** | [`chat_access_revoked`](/management/configuration-api/v3.2/#chat_access_revoked) |
 
 #### Push payload
 
-| Object     | Notes         |
-| ---------- | ------------- |
-| `id`       | Chat Id   |
+| Object | Notes   |
+| ------ | ------- |
+| `id`   | Chat Id |
 
 ### `chat_transferred`
 
@@ -3629,11 +3629,11 @@ Informs that a chat was transferred to a different group or to an Agent.
 
 #### Push payload
 
-| Object | Notes                        |
-| ------ | ---------------------------- |
-| `thread_id`      | Present if the chat is active                        |
+| Object                  | Notes                                                |
+| ----------------------- | ---------------------------------------------------- |
+| `thread_id`             | Present if the chat is active                        |
 | `transferred_to` **\*** | IDs of groups and Agents the chat is now assigned to |
-| `queue`          | Present if the chat is queued after the transfer     |
+| `queue`                 | Present if the chat is queued after the transfer     |
 
 **\*)**
 One of the following combinations of IDs is possible:
@@ -3668,15 +3668,15 @@ This push can be emitted with `user.present` set to `false` when a user writes t
 
 #### Specifics
 
-|                        |                                                             |
-| ---------------------- | ----------------------------------------------------------- |
+|                        |                                                                           |
+| ---------------------- | ------------------------------------------------------------------------- |
 | **Action**             | `user_added_to_chat`                                                      |
 | **Webhook equivalent** | [`user_added_to_chat`](/management/configuration-api/#user_added_to_chat) |
 
 #### Push payload
 
-| Object      | Notes                                |
-| ----------- | ------------------------------------ |
+| Object         | Notes                                            |
+| -------------- | ------------------------------------------------ |
 | `thread_id`    | Present when a user was added to an active chat. |
 | `reason`       | Why the user was added.                          |
 | `requester_id` | Present if the user was added by an agent.       |
@@ -3701,15 +3701,15 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Specifics
 
-|                        |                                                                 |
-| ---------------------- | --------------------------------------------------------------- |
+|                        |                                                                                   |
+| ---------------------- | --------------------------------------------------------------------------------- |
 | **Action**             | `user_removed_from_chat`                                                          |
 | **Webhook equivalent** | [`user_removed_from_chat`](/management/configuration-api/#user_removed_from_chat) |
 
 #### Push payload
 
-| Object      | Notes                                |
-| ----------- | ------------------------------------ |
+| Object         | Notes                                                |
+| -------------- | ---------------------------------------------------- |
 | `thread_id`    | Present when a user was removed from an active chat. |
 | `reason`       | Why the user was removed.                            |
 | `requester_id` | Present if the user was removed by an agent.         |
@@ -3746,9 +3746,9 @@ Informs about an incoming [event](#events) sent to a chat.
 
 #### Specifics
 
-|                        |                                                           |
-| ---------------------- | --------------------------------------------------------- |
-| **Action**             | `incoming_event`                                          |
+|                        |                                                                   |
+| ---------------------- | ----------------------------------------------------------------- |
+| **Action**             | `incoming_event`                                                  |
 | **Webhook equivalent** | [`incoming_event`](/management/configuration-api/#incoming_event) |
 
 ### `event_updated`
@@ -3771,9 +3771,9 @@ Informs that an [event](#events) was updated.
 
 #### Specifics
 
-|                        |                                                         |
-| ---------------------- | ------------------------------------------------------- |
-| **Action**             | `event_updated`                                         |
+|                        |                                                                 |
+| ---------------------- | --------------------------------------------------------------- |
+| **Action**             | `event_updated`                                                 |
 | **Webhook equivalent** | [`event_updated`](/management/configuration-api/#event_updated) |
 
 ### `incoming_rich_message_postback`
@@ -3799,9 +3799,9 @@ Informs about an incoming [rich message](#rich-message) postback. The push paylo
 
 #### Specifics
 
-|                        |                                                                                           |
-| ---------------------- | ----------------------------------------------------------------------------------------- |
-| **Action**             | `incoming_rich_message_postback`                                                          |
+|                        |                                                                                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------- |
+| **Action**             | `incoming_rich_message_postback`                                                                  |
 | **Webhook equivalent** | [`incoming_rich_message_postback`](/management/configuration-api/#incoming_rich_message_postback) |
 
 ## Properties
@@ -3829,9 +3829,9 @@ Informs about those chat properties that were updated.
 
 #### Specifics
 
-|                        |                                                                             |
-| ---------------------- | --------------------------------------------------------------------------- |
-| **Action**             | `chat_properties_updated`                                                   |
+|                        |                                                                                     |
+| ---------------------- | ----------------------------------------------------------------------------------- |
+| **Action**             | `chat_properties_updated`                                                           |
 | **Webhook equivalent** | [`chat_properties_updated`](/management/configuration-api/#chat_properties_updated) |
 
 #### Push payload
@@ -3860,9 +3860,9 @@ Informs about those chat properties that were deleted.
 
 #### Specifics
 
-|                        |                                                                             |
-| ---------------------- | --------------------------------------------------------------------------- |
-| **Action**             | `chat_properties_deleted`                                                   |
+|                        |                                                                                     |
+| ---------------------- | ----------------------------------------------------------------------------------- |
+| **Action**             | `chat_properties_deleted`                                                           |
 | **Webhook equivalent** | [`chat_properties_deleted`](/management/configuration-api/#chat_properties_deleted) |
 
 #### Push payload
@@ -3896,7 +3896,7 @@ Informs about those thread properties that were updated.
 #### Specifics
 
 |                        |                                                                                         |
-|------------------------|-----------------------------------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------------------------------- |
 | **Action**             | `thread_properties_updated`                                                             |
 | **Webhook equivalent** | [`thread_properties_updated`](/management/configuration-api/#thread_properties_updated) |
 
@@ -3929,7 +3929,7 @@ Informs about those thread properties that were deleted.
 #### Specifics
 
 |                        |                                                                                         |
-|------------------------|-----------------------------------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------------------------------- |
 | **Action**             | `thread_properties_deleted`                                                             |
 | **Webhook equivalent** | [`thread_properties_deleted`](/management/configuration-api/#thread_properties_deleted) |
 
@@ -3963,9 +3963,9 @@ Informs about those event properties that were updated.
 
 #### Specifics
 
-|                        |                                                                               |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| **Action**             | `event_properties_updated`                                                    |
+|                        |                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------- |
+| **Action**             | `event_properties_updated`                                                            |
 | **Webhook equivalent** | [`event_properties_updated`](/management/configuration-api/#event_properties_updated) |
 
 #### Push payload
@@ -3996,9 +3996,9 @@ Informs about those event properties that were deleted.
 
 #### Specifics
 
-|                        |                                                                               |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| **Action**             | `event_properties_deleted`                                                    |
+|                        |                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------- |
+| **Action**             | `event_properties_deleted`                                                            |
 | **Webhook equivalent** | [`event_properties_deleted`](/management/configuration-api/#event_properties_deleted) |
 
 #### Push payload
@@ -4028,7 +4028,7 @@ Informs that a chat thread was tagged.
 #### Specifics
 
 |                        |                                                                 |
-|------------------------|-----------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------- |
 | **Action**             | `thread_tagged`                                                 |
 | **Webhook equivalent** | [`thread_tagged`](/management/configuration-api/#thread_tagged) |
 
@@ -4051,7 +4051,7 @@ Informs that a chat thread was untagged.
 #### Specifics
 
 |                        |                                                                     |
-|------------------------|---------------------------------------------------------------------|
+| ---------------------- | ------------------------------------------------------------------- |
 | **Action**             | `thread_untagged`                                                   |
 | **Webhook equivalent** | [`thread_untagged`](/management/configuration-api/#thread_untagged) |
 
@@ -4119,9 +4119,9 @@ Informs that a new Customer registered.
 
 #### Specifics
 
-|                        |                                                               |
-| ---------------------- | ------------------------------------------------------------- |
-| **Action**             | `customer_created`                                            |
+|                        |                                                                       |
+| ---------------------- | --------------------------------------------------------------------- |
+| **Action**             | `customer_created`                                                    |
 | **Webhook equivalent** | [`customer_created`](/management/configuration-api/#customer_created) |
 
 ### `customer_updated`
@@ -4250,10 +4250,10 @@ Informs that an Agent's or Bot Agent's status was changed.
 
 #### Specifics
 
-|                        |                      |
-| ---------------------- | -------------------- |
-| **Action**             | `routing_status_set` |
-| **Webhook equivalent** | [`routing_status_set`](/management/configuration-api/v3.2/#routing_status_set)|
+|                        |                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| **Action**             | `routing_status_set`                                                           |
+| **Webhook equivalent** | [`routing_status_set`](/management/configuration-api/v3.2/#routing_status_set) |
 
 ### `agent_disconnected`
 
@@ -4378,9 +4378,9 @@ Informs that a user has seen events up to a specific time.
 
 #### Specifics
 
-|                        |                                                                                     |
-| ---------------------- | ----------------------------------------------------------------------------------- |
-| **Action**             | `events_marked_as_seen`                                                       |
+|                        |                                                                                 |
+| ---------------------- | ------------------------------------------------------------------------------- |
+| **Action**             | `events_marked_as_seen`                                                         |
 | **Webhook equivalent** | [`events_marked_as_seen`](/management/configuration-api/#events_marked_as_seen) |
 
 ### `incoming_multicast`
@@ -4412,11 +4412,11 @@ Informs about messages sent via the `multicast` method or by the system.
 
 #### Push payload
 
-| Object      | Required | Notes |
-| ----------- | -------- | ----- |
+| Object      | Required | Notes                                                                                            |
+| ----------- | -------- | ------------------------------------------------------------------------------------------------ |
 | `author_id` | No       | Present only if the push was generated by the **Multicast** method and not sent from the server. |
-| `content`   | Yes      |       |
-| `type`      | No       |       |
+| `content`   | Yes      |                                                                                                  |
+| `type`      | No       |                                                                                                  |
 
 ### `chat_unfollowed`
 
@@ -4468,7 +4468,7 @@ New positions and wait times for queued chats.
 #### Specifics
 
 |                        |                           |
-|------------------------|---------------------------|
+| ---------------------- | ------------------------- |
 | **Action**             | `queue_positions_updated` |
 | **Webhook equivalent** | -                         |
 

--- a/content/messaging/agent-chat-api/v3.1/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.1/rtm-reference/index.mdx
@@ -101,30 +101,30 @@ The **File** event informs about an uploaded file.
 
 ### Request
 
-| Field         | Required | Data type | Notes                                                               |
-| ------------- | -------- | --------- | ------------------------------------------------------------------: |
-| `custom_id`   | no       | `string`  |                                                                     |
-| `type`        | yes      | `string`  | `file`                                                              |
-| `recipients`  | yes      | `string`  | Possible values: `all` (default), `agents`                          |
-| `properties`  | no       | `object`  | [Properties](#properties)                                           |
-| `url`         | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/agent-chat-api/v3.1/#upload-file).|
+| Field        | Required | Data type |                                                                                                                                       Notes |
+| ------------ | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------: |
+| `custom_id`  | no       | `string`  |                                                                                                                                             |
+| `type`       | yes      | `string`  |                                                                                                                                      `file` |
+| `recipients` | yes      | `string`  |                                                                                                  Possible values: `all` (default), `agents` |
+| `properties` | no       | `object`  |                                                                                                                   [Properties](#properties) |
+| `url`        | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/agent-chat-api/v3.1/#upload-file). |
 
 ### Response
 
-| Field                               | Returned        | Notes                                                               |
-| ----------------------------------- | :-------------- | ------------------------------------------------------------------: |
-| `id`                                | always          |                                                                     |
-| `custom_id`                         | optionally      |                                                                     |
-| `created_at`                        | always          | Date & time format with a resolution of microseconds, `UTC string`. |
-| `type`                              | always          |                                                                     |
-| `author_id`                         | always          |                                                                     |
-| `recipients`                        | always          |                                                                     |
-| `properties`                        | optionally      |                                                                     |
-| `name`                              | always          |                                                                     |
-| `url`                               | always          |                                                                     |
-| `thumbnail_url`, `thumbnail2x_url`  | only for images |                                                                     |
-| `content_type`                      | always          |                                                                     |
-| `size`, `width`, `height`           | only for images |                                                                     |
+| Field                              | Returned        |                                                               Notes |
+| ---------------------------------- | :-------------- | ------------------------------------------------------------------: |
+| `id`                               | always          |                                                                     |
+| `custom_id`                        | optionally      |                                                                     |
+| `created_at`                       | always          | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`                             | always          |                                                                     |
+| `author_id`                        | always          |                                                                     |
+| `recipients`                       | always          |                                                                     |
+| `properties`                       | optionally      |                                                                     |
+| `name`                             | always          |                                                                     |
+| `url`                              | always          |                                                                     |
+| `thumbnail_url`, `thumbnail2x_url` | only for images |                                                                     |
+| `content_type`                     | always          |                                                                     |
+| `size`, `width`, `height`          | only for images |                                                                     |
 
 </Text>
 <Code>
@@ -165,28 +165,28 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 
 ### Request
 
-| Field                   | Required | Data type  |  Notes                                                                    |
-| ------------------------| -------- | -----------| ------------------------------------------------------------------------- |
-| `custom_id`             | no       | `string`   |                                                                           |
-| `type`                  | yes      | `string`   | `filled_form`                                                             |
-| `recipients`            | yes      | `string`   | Possible values: `all` (default), `agents`                                |
-| `properties`            | no       | `object`   | [Properties](#properties)                                                 |
-| `form_id`               | yes      | `string`   |                                                                           |
-| `fields`                | yes      | `array`    | The fields a form contains. See [form fields](#form-fields) for details.  |
+| Field        | Required | Data type | Notes                                                                    |
+| ------------ | -------- | --------- | ------------------------------------------------------------------------ |
+| `custom_id`  | no       | `string`  |                                                                          |
+| `type`       | yes      | `string`  | `filled_form`                                                            |
+| `recipients` | yes      | `string`  | Possible values: `all` (default), `agents`                               |
+| `properties` | no       | `object`  | [Properties](#properties)                                                |
+| `form_id`    | yes      | `string`  |                                                                          |
+| `fields`     | yes      | `array`   | The fields a form contains. See [form fields](#form-fields) for details. |
 
 ### Response
 
-| Field                   | Returned    | Notes |
-| ------------------------| ----------- | ----- |
-| `id`                    | always      |       |
-| `custom_id`             | optionally  |       |
-| `created_at`            | always      | Date & time format with a resolution of microseconds, `UTC string`. |
-| `type`                  | always      |       |
-| `author_id`             | always      |       |
-| `recipients`            | always      |       |
-| `properties`            | optionally  |       |
-| `form_id`               | always      |       |
-| `fields`                | always      | An array of [form fields](#form-fields) |
+| Field        | Returned   | Notes                                                               |
+| ------------ | ---------- | ------------------------------------------------------------------- |
+| `id`         | always     |                                                                     |
+| `custom_id`  | optionally |                                                                     |
+| `created_at` | always     | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`       | always     |                                                                     |
+| `author_id`  | always     |                                                                     |
+| `recipients` | always     |                                                                     |
+| `properties` | optionally |                                                                     |
+| `form_id`    | always     |                                                                     |
+| `fields`     | always     | An array of [form fields](#form-fields)                             |
 
 </Text>
 
@@ -259,38 +259,38 @@ The **Message** event contains text message to other chat users.
 
 ### Request
 
-| Field                 | Required| Data type | Notes                                                               |
-| --------------------- | ------- | --------- | ------------------------------------------------------------------  |
-| `custom_id`           | no      | `string`  |                                                                     |
-| `text`                | yes     | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
-| `type`                | yes     | `string`  | `message`                                                           |
-| `recipients`          | yes     | `string`  | Possible values: `all` (default), `agents`                          |
-| `properties`          | no      | `object`  | [Properties](#properties)                                           |
-| `postback`            | no      | `object`  | Indicates that the message event was generated in response to a rich message event. |
-| `postback.id`         | yes     | `string`  | ID of the postback from the rich message event.                     |
-| `postback.thread_id`  | yes     | `string`  | ID of the thread with the rich message event.                       |
-| `postback.event_id`   | yes     | `string`  | ID of the rich message event.                                       |
-| `postback.type`       | no      | `string`  | Should be used together with `postback.value` (when  one of them is present, the other is required). |
-| `postback.value`      | no      | `string`  | Should be used together with `postback.type`(when  one of them is present, the other is required). |
+| Field                | Required | Data type | Notes                                                                                                                        |
+| -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `custom_id`          | no       | `string`  |                                                                                                                              |
+| `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
+| `type`               | yes      | `string`  | `message`                                                                                                                    |
+| `recipients`         | yes      | `string`  | Possible values: `all` (default), `agents`                                                                                   |
+| `properties`         | no       | `object`  | [Properties](#properties)                                                                                                    |
+| `postback`           | no       | `object`  | Indicates that the message event was generated in response to a rich message event.                                          |
+| `postback.id`        | yes      | `string`  | ID of the postback from the rich message event.                                                                              |
+| `postback.thread_id` | yes      | `string`  | ID of the thread with the rich message event.                                                                                |
+| `postback.event_id`  | yes      | `string`  | ID of the rich message event.                                                                                                |
+| `postback.type`      | no       | `string`  | Should be used together with `postback.value` (when  one of them is present, the other is required).                         |
+| `postback.value`     | no       | `string`  | Should be used together with `postback.type`(when  one of them is present, the other is required).                           |
 
 ### Response
 
-| Field                   | Returned    | Notes                                                                 |
-| ------------------------| ----------- | ----------------------------------------------------------------------|
-| `id`                    | always      |                                                                       |
-| `custom_id`             | optionally  |                                                                       |
-| `created_at`            | always      | Date & time format with a resolution of microseconds, `UTC string`.   |
-| `type`                  | always      | `message`                                                             |
-| `author_id`             | always      |                                                                       |
-| `recipients`            | always      |                                                                       |
-| `text`                  | always      |                                                                       |
-| `postback`              | optionally  | Appears in a message only when triggered by a rich message.           |
-| `postback.id`           | always      |                                                                       |
-| `postback.thread_id`    | always      |                                                                       |
-| `postback.event_id`     | always      |                                                                       |
-| `postback.type`         | optionally  | Appears only if `postback.value` is present.                          |
-| `postback.value`        | optionally  | Appears only if `postback.type` is present.                           |
-| `properties`            | optionally  | [Properties](#properties)                                             |
+| Field                | Returned   | Notes                                                               |
+| -------------------- | ---------- | ------------------------------------------------------------------- |
+| `id`                 | always     |                                                                     |
+| `custom_id`          | optionally |                                                                     |
+| `created_at`         | always     | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`               | always     | `message`                                                           |
+| `author_id`          | always     |                                                                     |
+| `recipients`         | always     |                                                                     |
+| `text`               | always     |                                                                     |
+| `postback`           | optionally | Appears in a message only when triggered by a rich message.         |
+| `postback.id`        | always     |                                                                     |
+| `postback.thread_id` | always     |                                                                     |
+| `postback.event_id`  | always     |                                                                     |
+| `postback.type`      | optionally | Appears only if `postback.value` is present.                        |
+| `postback.value`     | optionally | Appears only if `postback.type` is present.                         |
+| `properties`         | optionally | [Properties](#properties)                                           |
 
 </Text>
 <Code>
@@ -331,48 +331,48 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 
 ### Request
 
-| Field                            | Required | Data type | Notes                                                                                             |
-| -------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------- |
-| `custom_id`                      | no       | `string`  | You can give your RM a custom ID.                                                                 |
-| `type`                           | yes      | `string`  | Event type: `rich_message`                                                                        |
-| `recipients`                     | yes      | `string`  | Those who can display the rich message: `all` (default) or `agents`                               |
-| `properties`                     | no       | `object`  | The [properties](#properties) data structure                                                      |
-| `template_id`                    | yes      | `string`  | Defines how every Rich Message will be presented. Values: `cards`, `sticker`, or `quick_replies`. |
-| `elements`                       | no       | `array`   | Can contain up to 10 `element` objects.                                                           |
-| `elements.title`                 | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.subtitle`              | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.image`                 | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`.|
-| `elements.buttons`               | no       | `array`   | Displays buttons. Can contain up to 11 `button` objects.                                          |
-| `elements.buttons.text`          | yes      | `string`  | Text displayed on a button.                                                                       |
-| `elements.buttons.type`          | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value`. Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)  |
-| `elements.buttons.value`         | yes      | `string`  | Should be used together with `elements.buttons.type`. |
-| `elements.buttons.webview_height`| yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.         |
-| `elements.buttons.postback_id`   | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
-| `elements.buttons.user_ids`      | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.|
+| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
+| --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                |
+| `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                       |
+| `recipients`                      | yes      | `string`  | Those who can display the rich message: `all` (default) or `agents`                                                                                                                                                                              |
+| `properties`                      | no       | `object`  | The [properties](#properties) data structure                                                                                                                                                                                                     |
+| `template_id`                     | yes      | `string`  | Defines how every Rich Message will be presented. Values: `cards`, `sticker`, or `quick_replies`.                                                                                                                                                |
+| `elements`                        | no       | `array`   | Can contain up to 10 `element` objects.                                                                                                                                                                                                          |
+| `elements.title`                  | yes      | `string`  | Displays formatted text on RMs.                                                                                                                                                                                                                  |
+| `elements.subtitle`               | yes      | `string`  | Displays formatted text on RMs.                                                                                                                                                                                                                  |
+| `elements.image`                  | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`.                                                                                                                               |
+| `elements.buttons`                | no       | `array`   | Displays buttons. Can contain up to 11 `button` objects.                                                                                                                                                                                         |
+| `elements.buttons.text`           | yes      | `string`  | Text displayed on a button.                                                                                                                                                                                                                      |
+| `elements.buttons.type`           | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value`. Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
+| `elements.buttons.value`          | yes      | `string`  | Should be used together with `elements.buttons.type`.                                                                                                                                                                                            |
+| `elements.buttons.webview_height` | yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.                                                                                                                                                        |
+| `elements.buttons.postback_id`    | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)                                                                      |
+| `elements.buttons.user_ids`       | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.                                                                                                                                                                                   |
 
 ### Response
 
-| Field                            | Returned   | Notes                                                               |
-| -------------------------------- | ---------- | ------------------------------------------------------------------- |
-| `id`                             | always     | Generated server-side                                               |
-| `custom_id`                      | optionally |                                                                     |
-| `type`                           | always     |                                                                     |
-| `author_id`                      | always     | Generated server-side                                               |
-| `created_at`                     | always     | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
-| `recipients`                     | always     |                                                                     |
-| `properties`                     | optionally |                                                                     |
-| `template_id`                    | always     |                                                                     |
-| `elements`                       | optionally |                                                                     |
-| `elements.title`                 | always     |                                                                     |
-| `elements.subtitle`              | always     |                                                                     |
-| `elements.image`                 | always     |                                                                     |
-| `elements.buttons`               | optionally |                                                                     |
-| `elements.buttons.text`          | always     |                                                                     |
-| `elements.buttons.type`          | always     |                                                                     |
-| `elements.buttons.value`         | always     |                                                                     |
-| `elements.buttons.webview_height`| always     | Unless button `type` is different than `webview`.                   |
-| `elements.buttons.postback_id`   | always     |                                                                     |
-| `elements.buttons.user_ids`      | always     |                                                                     |
+| Field                             | Returned   | Notes                                                                                      |
+| --------------------------------- | ---------- | ------------------------------------------------------------------------------------------ |
+| `id`                              | always     | Generated server-side                                                                      |
+| `custom_id`                       | optionally |                                                                                            |
+| `type`                            | always     |                                                                                            |
+| `author_id`                       | always     | Generated server-side                                                                      |
+| `created_at`                      | always     | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
+| `recipients`                      | always     |                                                                                            |
+| `properties`                      | optionally |                                                                                            |
+| `template_id`                     | always     |                                                                                            |
+| `elements`                        | optionally |                                                                                            |
+| `elements.title`                  | always     |                                                                                            |
+| `elements.subtitle`               | always     |                                                                                            |
+| `elements.image`                  | always     |                                                                                            |
+| `elements.buttons`                | optionally |                                                                                            |
+| `elements.buttons.text`           | always     |                                                                                            |
+| `elements.buttons.type`           | always     |                                                                                            |
+| `elements.buttons.value`          | always     |                                                                                            |
+| `elements.buttons.webview_height` | always     | Unless button `type` is different than `webview`.                                          |
+| `elements.buttons.postback_id`    | always     |                                                                                            |
+| `elements.buttons.user_ids`       | always     |                                                                                            |
 
 </Text>
 <Code>
@@ -440,7 +440,7 @@ The Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                               |                                                                                   |
+| Field        | Required | Data type | Notes                                                               |  |
 | ------------ | -------- | --------- | ------------------------------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.                                 |
 | `type`       | yes      | `string`  | Event type: `custom`                                                |
@@ -497,14 +497,14 @@ System message event is native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required  | Data type | Notes                                                                                          |
-| --------------------- | --------- |---------- | --------------------------------------------------------------------------------------------- |
-| `custom_id`           | no        | `string`  | You can give the system message a custom ID.                                                   |
-| `type`                | yes       | `string`  | `system_message`                                                                               |
-| `text`                | no        | `string`  | Text displayed to recipients                                                                   |
-| `system_message_type` | yes       | `string`  | [System message type](/messaging/references/system-messages/)                                              |
-| `recipients`          | no        | `string`  | It can be specified when sending system messages via the [**Send Event**](#send-event) method. Possible values: `all`, `agents`.|
-| `text_vars`           | no        | `object`  | Variables used in the text                                                                     |
+| Field                 | Required | Data type | Notes                                                                                                                            |
+| --------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `custom_id`           | no       | `string`  | You can give the system message a custom ID.                                                                                     |
+| `type`                | yes      | `string`  | `system_message`                                                                                                                 |
+| `text`                | no       | `string`  | Text displayed to recipients                                                                                                     |
+| `system_message_type` | yes      | `string`  | [System message type](/messaging/references/system-messages/)                                                                    |
+| `recipients`          | no       | `string`  | It can be specified when sending system messages via the [**Send Event**](#send-event) method. Possible values: `all`, `agents`. |
+| `text_vars`           | no       | `object`  | Variables used in the text                                                                                                       |
 
 ### Response
 
@@ -568,10 +568,10 @@ System message event is native system event sent in specific situations.
 
 </CodeResponse>
 
-| Field            | Req./Opt. |                                              Note |
-| ---------------- | :-------: | ------------------------------------------------: |
-| `routing_status` | optional  | Returned only if the Agent's currently logged in. |
-| `events_seen_up_to`| optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Agent—all the previous events are considered seen. |
+| Field               | Req./Opt. |                                                                                                                            Note |
+| ------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------: |
+| `routing_status`    | optional  |                                                                               Returned only if the Agent's currently logged in. |
+| `events_seen_up_to` | optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Agent—all the previous events are considered seen. |
 
 ### My profile
 
@@ -657,7 +657,7 @@ System message event is native system event sent in specific situations.
 | `email`                          | optional  |                                          |
 | `fields`                         | optional  | Isn't present when the chat is archived. |
 | `name`                           | optional  |                                          |
-| `events_seen_up_to`              | optional  | RFC 3339 datetime string                 |
+| `events_seen_up_to`              | optional  |                 RFC 3339 datetime string |
 | `last_visit`                     | optional  |                                          |
 | `present`                        | optional  |                                          |
 | `statistics`                     | optional  |                                          |
@@ -792,16 +792,16 @@ Apart from [Events](#events) and [Users](#users), there are also other common da
 
 A component of the [Filled form](#filled-form) event.
 
-| Field                   | Required | Data type               |  Notes                                                                                                   |
-| ------------------------| -------- | ----------------------- | -------------------------------------------------------------------------------------------------------: |
-| `fields`                | yes      | `array of objects`      | The fields a form contains.                                                                              |
-| `type`                  | yes      | `string`                | Possible values: `checkbox`, `email`, `name`, `question`, `textarea`, `group_chooser`, `radio`, `select` |
-| `id`                    | yes      | `string`                | Field id, for all field types                                                                            |
-| `label`                 | yes      | `string`                | Field label; for all field types                                                                         |
-| `answer`                | yes      | `any`                   | For all field types                                                                                      |
-| `answer.id`             | yes      | `string`                | Answer id; for all field types                                                                           |
-| `answer.label`          | yes      | `string`                | Answer label; for all field types                                                                        |
-| `answer.group_id`       | yes      | `number`                | For `group_chooser`                                                                                      |
+| Field             | Required | Data type          |                                                                                                    Notes |
+| ----------------- | -------- | ------------------ | -------------------------------------------------------------------------------------------------------: |
+| `fields`          | yes      | `array of objects` |                                                                              The fields a form contains. |
+| `type`            | yes      | `string`           | Possible values: `checkbox`, `email`, `name`, `question`, `textarea`, `group_chooser`, `radio`, `select` |
+| `id`              | yes      | `string`           |                                                                            Field id, for all field types |
+| `label`           | yes      | `string`           |                                                                         Field label; for all field types |
+| `answer`          | yes      | `any`              |                                                                                      For all field types |
+| `answer.id`       | yes      | `string`           |                                                                           Answer id; for all field types |
+| `answer.label`    | yes      | `string`           |                                                                        Answer label; for all field types |
+| `answer.group_id` | yes      | `number`           |                                                                                      For `group_chooser` |
 
 <CodeResponse>
 
@@ -999,7 +999,7 @@ It returns [summaries](#chat-summaries) of the chats an Agent has access to.
 | `filters.group_ids`                                   | No       | `array`  | Array of group IDs.                                                                         |
 | `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`    |                                                                                             |
 | `order`                                               | No       | `string` | Possible values: `asc` - oldest chats firstm `desc` - newest chats first (default)          |
-| `limit`                                               | No       | `number` | Default: 10, maximum: 100                                                                    |
+| `limit`                                               | No       | `number` | Default: 10, maximum: 100                                                                   |
 | `page_id`                                             | No       | `string` |                                                                                             |
 
 `filter_type` can take the following values:
@@ -1012,11 +1012,11 @@ There's only one value allowed for a single property.
 
 #### Response
 
-| Parameter         | Data type | Notes                                                                     |
-| ----------------- | --------- | ------------------------------------------------------------------------- |
-| `found_chats`     | `number`  | An estimated number. The real number of found chats can slightly differ . |
-| `next_page_id`    | `string`  | In relation to `page_id` specified in the request.                       |
-| `previous_page_id`| `string`  | In relation to `page_id` specified in the request.                       |
+| Parameter          | Data type | Notes                                                                     |
+| ------------------ | --------- | ------------------------------------------------------------------------- |
+| `found_chats`      | `number`  | An estimated number. The real number of found chats can slightly differ . |
+| `next_page_id`     | `string`  | In relation to `page_id` specified in the request.                        |
+| `previous_page_id` | `string`  | In relation to `page_id` specified in the request.                        |
 
 </Text>
 <Code>
@@ -1133,11 +1133,11 @@ There's only one value allowed for a single property.
 
 #### Response
 
-| Parameter       | Data type | Notes                           |
-| --------------- | --------- | ------------------------------- |
-| `found_threads` | `number`  | The number of threads in a chat |
-| `next_page_id`    | `string`  | In relation to `page_id` specified in the request. |
-| `previous_page_id`| `string`  | In relation to `page_id` specified in the request. |
+| Parameter          | Data type | Notes                                              |
+| ------------------ | --------- | -------------------------------------------------- |
+| `found_threads`    | `number`  | The number of threads in a chat                    |
+| `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
+| `previous_page_id` | `string`  | In relation to `page_id` specified in the request. |
 
 </Text>
 <Code>
@@ -1308,7 +1308,7 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 | `filters.agent_ids`                                   | No       | `array`   | Array of agent IDs                                                                        |
 | `filters.thread_ids`                                  | No       | `array`   | Array of thread IDs. Cannot be used with other filters or pagination; max array size: 20. |
 | `filters.group_ids`                                   | No       | `array`   | Array of group IDs                                                                        |
-| `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     | **\*** __described below__                                                                |    
+| `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     | **\*** __described below__                                                                |
 | `filters.tags.<filter_type>`                          | No       | `any`     |                                                                                           |
 | `filters.sales.<filter_type>`                         | No       | `any`     |                                                                                           |
 | `filters.goals.<filter_type>`                         | No       | `any`     |                                                                                           |
@@ -1465,24 +1465,24 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Request
 
-| Parameters               | Required | Data type | Notes                                                                   |
-| ------------------------ | -------- | --------- | ----------------------------------------------------------------------- |
-| `chat`                   | No       | `object`  |                                                                         |
-| `chat.properties`        | No       | `object`  |                                                                         |
-| `chat.access`            | No       | `object`  |                                                                         |
-| `chat.users`             | No       | `array`   | The list of existing users. Only one user is allowed (type `customer`). |
-| `chat.thread`            | No       | `object`  |                                                                         |
-| `chat.thread.events`     | No       | `array`   | The list of initial chat events                                         |
-| `chat.thread.properties` | No       | `object`  |                                                                         |
+| Parameters               | Required | Data type | Notes                                                                       |
+| ------------------------ | -------- | --------- | --------------------------------------------------------------------------- |
+| `chat`                   | No       | `object`  |                                                                             |
+| `chat.properties`        | No       | `object`  |                                                                             |
+| `chat.access`            | No       | `object`  |                                                                             |
+| `chat.users`             | No       | `array`   | The list of existing users. Only one user is allowed (type `customer`).     |
+| `chat.thread`            | No       | `object`  |                                                                             |
+| `chat.thread.events`     | No       | `array`   | The list of initial chat events                                             |
+| `chat.thread.properties` | No       | `object`  |                                                                             |
 | `continuous`             | No       | `bool`    | Starts chat as continuous (online group is not required); default: `false`. |
 
 #### Response
 
-| Parameter   | Data type  | Notes |
-| ----------- | ---------- | ----- |
-| `chat_id`   | `string`   |       |
-| `thread_id` | `string`   |       |
-| `event_ids` | `[]string` | Returned only when the chat was started with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. | 
+| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`   | `string`   |                                                                                                                                                                         |
+| `thread_id` | `string`   |                                                                                                                                                                         |
+| `event_ids` | `[]string` | Returned only when the chat was started with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
 
 </Text>
 <Code>
@@ -1496,54 +1496,6 @@ When `chat.users` is defined, one of following scopes is required:
 ```
 
 </CodeSample>
-
-<!-- > **`start_chat`** sample **request** with optional params
-
-```json
-{
-	"action": "start_chat",
-	"payload": {
-	"chat": {
-		"properties": {
-			"source": {
-				"type": "facebook"
-			},
-			// ...
-		},
-		"users": [{
-			"id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
-			"type": "customer"
-		}],
-		"thread": {
-			"events": [{
-				"type": "message",
-				"custom_id": "31-0C-1C-07-DB-16",
-				"text": "hello there",
-				"recipients": "all"
-			}, {
-				"type": "system_message",
-				"custom_id": "31-0C-1C-07-DB-16",
-				"text": "hello there",
-				"recipients": "agents"
-			}],
-			"properties": {
-				"source": {
-					"type": "facebook"
-				},
-				// ...
-			},
-			"tags": ["bug_report"]
-		}
-		"access": {
-			"group_ids": [1]
-		},
-		"is_followed": true
-	},
-	"continuous": true
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 
@@ -1589,24 +1541,24 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Request
 
-| Request object           | Required | Type     | Notes                                                               |
-| ------------------------ | -------- | -------- | ------------------------------------------------------------------- |
-| `chat`                   | Yes      | `object` |                                                                     |
-| `chat.id`                | Yes      | `string` | The ID of the chat that will be activated.                          |
-| `chat.access`            | No       | `object` | Chat access to set, default: all agents.                            |
-| `chat.properties`        | No       | `object` | Initial chat properties                                             |
-| `chat.users`             | No       | `array`  | List of existing users. Only one user is allowed (type `customer`). |
-| `chat.thread`            | No       | `object` |                                                                     |
-| `chat.thread.events`     | No       | `array`  | Initial chat events array                                           |
-| `chat.thread.properties` | No       | `object` | Initial chat thread properties                                      |
+| Request object           | Required | Type     | Notes                                                                      |
+| ------------------------ | -------- | -------- | -------------------------------------------------------------------------- |
+| `chat`                   | Yes      | `object` |                                                                            |
+| `chat.id`                | Yes      | `string` | The ID of the chat that will be activated.                                 |
+| `chat.access`            | No       | `object` | Chat access to set, default: all agents.                                   |
+| `chat.properties`        | No       | `object` | Initial chat properties                                                    |
+| `chat.users`             | No       | `array`  | List of existing users. Only one user is allowed (type `customer`).        |
+| `chat.thread`            | No       | `object` |                                                                            |
+| `chat.thread.events`     | No       | `array`  | Initial chat events array                                                  |
+| `chat.thread.properties` | No       | `object` | Initial chat thread properties                                             |
 | `continuous`             | No       | `bool`   | Sets a chat to the continuous mode. When unset, leaves the mode unchanged. |
 
 #### Response
 
-| Parameter   | Data type  | Notes |
-| ----------- | ---------- | ----- |
-| `thread_id` | `string`   |       |
-| `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array.|
+| Parameter   | Data type  | Notes                                                                                                                                                                     |
+| ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `thread_id` | `string`   |                                                                                                                                                                           |
+| `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
 
 </Text>
 <Code>
@@ -1624,47 +1576,6 @@ When `chat.users` is defined, one of following scopes is required:
 ```
 
 </CodeSample>
-
-<!-- > **`activate_chat`** sample **request** with optional params
-
-```json
-{
-	"request_id": "7676",
-	"action": "activate_chat",
-	"payload": {
-	"chat": {
-		"id": "PJ0MRSHTDG",
-		"access": {
-			"group_ids": [1]
-		},
-		"properties": {
-			"source": {
-				"type": "facebook"
-			}
-		},
-		"thread": {
-			"events": [{
-				"type": "message",
-				"custom_id": "31-0C-1C-07-DB-16",
-				"text": "hello there"
-			}, {
-				"type": "system_message",
-				"custom_id": "31-0C-1C-07-DB-16",
-				"text": "hello there"
-			}],
-			"properties": {
-				"source": {
-					"type": "facebook"
-				},
-				// ...
-			},
-			"tags": ["bug_report"]
-			}
-		}
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 
@@ -1702,9 +1613,9 @@ Closes a thread. Sending messages to this thread will no longer be possible.
 
 #### Request
 
-| Parameter | Required | Data type |  |
-| --------- | -------- | --------- | ----- |
-| `chat_id` | Yes      | `string`  |       |
+| Parameter | Required | Data type |     |
+| --------- | -------- | --------- | --- |
+| `chat_id` | Yes      | `string`  |     |
 
 </Text>
 <Code>
@@ -1872,13 +1783,13 @@ Grants access to a new resource without overwriting the existing ones.
 
 #### Request
 
-| Parameter     | Required | Data ype | Notes                |
-| ------------- | -------- | -------- | -------------------- |
-| `resource`    | Yes      | `string` | `chat` or `customer` |
-| `id`          | Yes      | `string` | Resource Id          |
+| Parameter     | Required | Data ype | Notes                                                       |
+| ------------- | -------- | -------- | ----------------------------------------------------------- |
+| `resource`    | Yes      | `string` | `chat` or `customer`                                        |
+| `id`          | Yes      | `string` | Resource Id                                                 |
 | `access`      | Yes      | `object` | The entity that is granted access to the specified resource |
-| `access.type` | Yes      | `string` | `group`              |
-| `access.id`   | Yes      | `number` |                      |
+| `access.type` | Yes      | `string` | `group`                                                     |
+| `access.id`   | Yes      | `number` |                                                             |
 
 </Text>
 <Code>
@@ -1934,13 +1845,13 @@ Grants access to a new resource without overwriting the existing ones.
 
 #### Request
 
-| Parameter     | Required | Data type | Notes                |
-| ------------- | -------- | --------- | -------------------- |
-| `resource`    | Yes      | `string`  | `chat` or `customer` |
-| `id`          | Yes      | `string`  | Resource Id          |
+| Parameter     | Required | Data type | Notes                                                  |
+| ------------- | -------- | --------- | ------------------------------------------------------ |
+| `resource`    | Yes      | `string`  | `chat` or `customer`                                   |
+| `id`          | Yes      | `string`  | Resource Id                                            |
 | `access`      | Yes      | `object`  | The entity that loses access to the specified resource |
-| `access.type` | Yes      | `string`  | `group`              |
-| `access.id`   | Yes      | `number` |                    |
+| `access.type` | Yes      | `string`  | `group`                                                |
+| `access.id`   | Yes      | `number`  |                                                        |
 
 </Text>
 <Code>
@@ -1998,13 +1909,13 @@ Gives access to a new resource overwriting the existing ones.
 
 #### Request
 
-| Request object | Required | Type     | Notes                |
-| -------------- | -------- | -------- | -------------------- |
-| `resource`     | Yes      | `string` | `chat` or `customer` |
-| `id`           | Yes      | `string` | Resource Id          |
+| Request object | Required | Type     | Notes                                                     |
+| -------------- | -------- | -------- | --------------------------------------------------------- |
+| `resource`     | Yes      | `string` | `chat` or `customer`                                      |
+| `id`           | Yes      | `string` | Resource Id                                               |
 | `access`       | Yes      | `object` | The entity that is given access to the specified resource |
-| `access.type`  | Yes      | `string` | `group`              |
-| `access.id`    | Yes      | `number` |                   |
+| `access.type`  | Yes      | `string` | `group`                                                   |
+| `access.id`    | Yes      | `number` |                                                           |
 
 </Text>
 <Code>
@@ -2240,12 +2151,12 @@ It's possible to write to a chat without joining it. The user sending an event w
 
 #### Specifics
 
-|                        |                                                                                          
-| ---------------------- | ---------------------------------------------------------------------------------------- 
-| **Action**             | `send_event`                                                                             
-| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` 
-| **Web API equivalent** | [`send_event`](../#send-event)                                                           
-| **Push message**       | [`incoming_event`](#incoming_event)                                                                                        
+|                        |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| **Action**             | `send_event`                                                                             |
+| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
+| **Web API equivalent** | [`send_event`](../#send-event)                                                           |
+| **Push message**       | [`incoming_event`](#incoming_event)                                                      |
 
 #### Request
 
@@ -2274,20 +2185,6 @@ It's possible to write to a chat without joining it. The user sending an event w
 ```
 
 </CodeSample>
-
-<!-- > **`send_event`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "send_event",
-	"payload": {
-		  "event_id": "K600PKZON8"
-		},
-	}
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 
@@ -2355,25 +2252,6 @@ It's possible to write to a chat without joining it. The user sending an event w
 
 </CodeSample>
 
-<!-- > **`send_rich_message_postback`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "send_rich_message_postback",
-	"payload": {
-		"chat_id": "PJ0MRSHTDG",
-        "thread_id": "K600PKZON8",
-        "event_id": "a0c22fdd-fb71-40b5-bfc6-a8a0bc3117f7",
-        "postback": {
-            "id": "Method URL_yes",
-            "toggled": true
-        }
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
-
 <CodeResponse>
 
 ```json
@@ -2410,10 +2288,10 @@ It's possible to write to a chat without joining it. The user sending an event w
 
 #### Request
 
-| Parameter    | Required | Data type | Notes                                     |
-| ------------ | -------- | --------- | ----------------------------------------- |
-| `chat_id`    | Yes      | `string`  | Id of the chat you to set a property for. |
-| `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/v3.1/#properties) and include _namespace_, _property name_ and _value_.  |
+| Parameter    | Required | Data type | Notes                                                                                                                                                                             |
+| ------------ | -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`    | Yes      | `string`  | Id of the chat you to set a property for.                                                                                                                                         |
+| `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/v3.1/#properties) and include _namespace_, _property name_ and _value_. |
 
 </Text>
 <Code>
@@ -2435,25 +2313,6 @@ It's possible to write to a chat without joining it. The user sending an event w
 ```
 
 </CodeSample>
-
-<!-- > **`update_chat_properties`** sample **request** with optional params
-
-```json
-{
-	"request_id": "93875", // optional
-	"action": "update_chat_properties",
-	"payload": {
-		"chat_id": "PW94SJTGW6",
-        "properties": {
-            "bb9e5b2f1ab480e4a715977b7b1b4279": {
-                "score": 10,
-                "comment": "Thank you!"
-            }
-        }
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 
@@ -2492,7 +2351,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 | Parameter    | Required | Data type | Notes                                           |
 | ------------ | -------- | --------- | ----------------------------------------------- |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete property for. |
-| `properties` | Yes      | `object`  | Chat properties to delete. |
+| `properties` | Yes      | `object`  | Chat properties to delete.                      |
 
 </Text>
 <Code>
@@ -2511,25 +2370,6 @@ It's possible to write to a chat without joining it. The user sending an event w
 ```
 
 </CodeSample>
-
-<!-- > **`delete_chat_properties`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "delete_chat_properties",
-	"payload": {
-		"chat_id": "PW94SJTGW6",
-        "properties": {
-            "bb9e5b2f1ab480e4a715977b7b1b4279": [
-                "score",
-                "comment"
-            ]
-        }
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 
@@ -2565,11 +2405,11 @@ It's possible to write to a chat without joining it. The user sending an event w
 
 #### Request
 
-| Parameter    | Required | Data type | Notes                                            |
-| ------------ | -------- | --------- | ------------------------------------------------ |
-| `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.   |
-| `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for. |
-| `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/v3.1/#properties) and include _namespace_, _property name_ and _value_.  |
+| Parameter    | Required | Data type | Notes                                                                                                                                                                             |
+| ------------ | -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.                                                                                                                                    |
+| `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for.                                                                                                                                  |
+| `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/v3.1/#properties) and include _namespace_, _property name_ and _value_. |
 
 </Text>
 <Code>
@@ -2592,26 +2432,6 @@ It's possible to write to a chat without joining it. The user sending an event w
 ```
 
 </CodeSample>
-
-<!-- > **`update_chat_thread_properties`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "update_chat_thread_properties",
-	"payload": {
-		"chat_id": "PW94SJTGW6",
-        "thread_id": "K600PKZON8",
-        "properties": {
-            "bb9e5b2f1ab480e4a715977b7b1b4279": {
-                "score": 10,
-                "comment": "Thank you!"
-            }
-        }
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 
@@ -2651,7 +2471,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 | ------------ | -------- | --------- | ------------------------------------------------- |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete property for.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to delete property for. |
-| `properties` | Yes      | `object`  | Chat thread properties to delete. |
+| `properties` | Yes      | `object`  | Chat thread properties to delete.                 |
 
 </Text>
 <Code>
@@ -2671,26 +2491,6 @@ It's possible to write to a chat without joining it. The user sending an event w
 ```
 
 </CodeSample>
-
-<!-- > **`delete_chat_thread_properties`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "delete_chat_thread_properties",
-	"payload": {
-		"chat_id": "PW94SJTGW6",
-        "thread_id": "K600PKZON8",
-        "properties": {
-            "bb9e5b2f1ab480e4a715977b7b1b4279": [
-                "score",
-                "comment"
-            ]
-        }
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 
@@ -2731,7 +2531,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for. |
 | `event_id`   | Yes      | `string`  | Id of the event you want to set properties for.  |
-| `properties` | Yes      | `object`  | Chat properties to set. |
+| `properties` | Yes      | `object`  | Chat properties to set.                          |
 
 </Text>
 <Code>
@@ -2755,27 +2555,6 @@ It's possible to write to a chat without joining it. The user sending an event w
 ```
 
 </CodeSample>
-
-<!-- > **`update_event_properties`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "update_event_properties",
-	"payload": {
-		"chat_id": "PW94SJTGW6",
-        "thread_id": "K600PKZON8",
-        "event_id": "2_EW2WQSA8",
-        "properties": {
-            "bb9e5b2f1ab480e4a715977b7b1b4279": {
-                "score": 10,
-                "comment": "Thank you!"
-            }
-        }
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 
@@ -2811,12 +2590,12 @@ It's possible to write to a chat without joining it. The user sending an event w
 
 #### Request
 
-| Parameter    | Required | Data type | Notes                                             |
-| ------------ | -------- | --------- | ------------------------------------------------- |
-| `chat_id`    | Yes      | `string`  | Id of the chat you want to delete the properties of.   |
-| `thread_id`  | Yes      | `string`  | Id of the thread you want to delete the properties of. |
-| `event_id`   | Yes      | `string`  | Id of the event you want to delete the properties of.  |
-| `properties` | Yes      | `object`  | Event properties to delete. You should stick to the [general properties format](/management/configuration-api/v3.1/#properties) and include _namespace_, _property name_ and _value_.  |
+| Parameter    | Required | Data type | Notes                                                                                                                                                                                 |
+| ------------ | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`    | Yes      | `string`  | Id of the chat you want to delete the properties of.                                                                                                                                  |
+| `thread_id`  | Yes      | `string`  | Id of the thread you want to delete the properties of.                                                                                                                                |
+| `event_id`   | Yes      | `string`  | Id of the event you want to delete the properties of.                                                                                                                                 |
+| `properties` | Yes      | `object`  | Event properties to delete. You should stick to the [general properties format](/management/configuration-api/v3.1/#properties) and include _namespace_, _property name_ and _value_. |
 
 </Text>
 <Code>
@@ -2839,29 +2618,6 @@ It's possible to write to a chat without joining it. The user sending an event w
 ```
 
 </CodeSample>
-
-<!-- > **`delete_event_properties`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "delete_event_properties",
-	"payload": {
-		"chat_id": "PW94SJTGW6",
-        "thread_id": "K600PKZON8",
-        "event_id": "2_EW2WQSA8",
-        "properties": {
-            "bb9e5b2f1ab480e4a715977b7b1b4279": {
-                "rating": [
-                    "score",
-                    "comment"
-                ]
-            }
-        }
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 
@@ -2922,21 +2678,6 @@ It's possible to write to a chat without joining it. The user sending an event w
 
 </CodeSample>
 
-<!-- > **`tag_chat_thread`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "tag_chat_thread",
-	"payload": {
-		"chat_id": "PW94SJTGW6",
-		"thread_id": "PWS6GIKAKH",
-		"tag": "support"
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
-
 <CodeResponse>
 
 ```json
@@ -2993,21 +2734,6 @@ It's possible to write to a chat without joining it. The user sending an event w
 ```
 
 </CodeSample>
-
-<!-- > **`untag_chat_thread`** sample **request** with optional params
-
-```json
-{
-	"request_id": "1245", // optional
-	"action": "untag_chat_thread",
-	"payload": {
-		"chat_id": "PW94SJTGW6",
-		"thread_id": "PWS6GIKAKH",
-		"tag": "support"
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 
@@ -3106,10 +2832,10 @@ Dates are represented in ISO 8601 format with microseconds resolution, e.g. `201
 
 #### Response
 
-| Parameter         | Data type | Notes                           |
-| ----------------- | --------- | ------------------------------- |
-| `next_page_id`    | `string`  | In relation to `page_id` specified in the request. |
-| `previous_page_id`| `string`  | In relation to `page_id` specified in the request. |
+| Parameter          | Data type | Notes                                              |
+| ------------------ | --------- | -------------------------------------------------- |
+| `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
+| `previous_page_id` | `string`  | In relation to `page_id` specified in the request. |
 
 </Text>
 <Code>
@@ -3123,30 +2849,6 @@ Dates are represented in ISO 8601 format with microseconds resolution, e.g. `201
 ```
 
 </CodeSample>
-
-<!-- > **`get_customers`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "get_customers",
-	"payload": {
-		"filters": {
-		"country": {
-			"values": ["United States", "Poland"]
-		},
-		"visits_count": {
-			"gte": 20
-		},
-		"created_at": {
-			"gte": "2017-10-12T15:19:21.010200+01:00"
-		}
-	},
-	"page_id": "MTUxNzM5ODEzMTQ5Ng=="
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 
@@ -3180,12 +2882,12 @@ Creates a new [Customer](#customer) user type.
 
 #### Specifics
 
-|                        |                                         |
-| ---------------------- | --------------------------------------- |
-| **Action**             | `create_customer`                       |
-| **Required scopes**    | `customers:rw`                          |
-| **Web API equivalent** | [`create_customer`](../#create-customer)  |
-| **Push message**       | [`customer_created`](#customer_created) |
+|                        |                                          |
+| ---------------------- | ---------------------------------------- |
+| **Action**             | `create_customer`                        |
+| **Required scopes**    | `customers:rw`                           |
+| **Web API equivalent** | [`create_customer`](../#create-customer) |
+| **Push message**       | [`customer_created`](#customer_created)  |
 
 #### Request
 
@@ -3208,23 +2910,6 @@ Creates a new [Customer](#customer) user type.
 ```
 
 </CodeSample>
-
-<!-- > **`create_customer`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "create_customer",
-	"payload": {
-		"email": "customer1@example.com",
-		"avatar": "https://example.com/avatars/1.jpg",
-		"fields": {
-			"some_key": "some_value"
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-	}
-}
-``` -->
 
 <CodeResponse>
 
@@ -3288,24 +2973,6 @@ Apart from `customer_id`, which is a required parameter, you also need to includ
 
 </CodeSample>
 
-<!-- > **`update_customer`** sample **request** with optional params
-
-```json
-{
-	"request_id": "13425", // optional
-	"action": "update_customer",
-	"payload": {
-		"customer_id": "d4efab70-984f-40ee-aa09-c9cc3c4b0882",
-		"name": "John Doe",
-		"avatar": "https://example.com/avatars/1.jpg",
-		"fields": {
-			"score": "low"
-		}
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
-
 <CodeResponse>
 
 ```json
@@ -3366,22 +3033,6 @@ Bans the customer for a specific period of time. It immediately disconnects all 
 
 </CodeSample>
 
-<!-- > **`ban_customer`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "ban_customer",
-	"payload": {
-		"customer_id": "3cd19fff-f852-4402-59ce-ebd03af3f15a",
-        "ban": {
-            "days": 3
-        }
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
-
 <CodeResponse>
 
 ```json
@@ -3412,7 +3063,7 @@ It returns the initial state of the current Agent.
 #### Specifics
 
 |                        |                                                                                        |
-|------------------------|----------------------------------------------------------------------------------------|
+| ---------------------- | -------------------------------------------------------------------------------------- |
 | **Action**             | `login`                                                                                |
 | **Required scopes**    | `chats--access:ro` `customers:ro` `multicast:ro` `agents--all:ro` `agents-bot--all:ro` |
 | **Web API equivalent** | -                                                                                      |
@@ -3579,19 +3230,6 @@ It returns the initial state of the current Agent.
 
 </CodeSample>
 
-<!-- > **`set_away_status`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "set_away_status",
-	"payload": {
-		"away": true
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
-
 <CodeResponse>
 
 ```json
@@ -3650,21 +3288,6 @@ Change the firebase push notifications properties.
 ```
 
 </CodeSample>
-
-<!-- > **`change_push_notifications`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "change_push_notifications",
-	"payload": {
-		"firebase_token": "8daDAD9dada8ja1JADA11",
-		"platform": "ios",
-		"enabled": true
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 
@@ -3770,17 +3393,6 @@ Logs the Agent out.
 
 </CodeSample>
 
-<!-- > **`logout`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "logout",
-	"payload": {},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
-
 <CodeResponse>
 
 ```json
@@ -3808,19 +3420,19 @@ Logs the Agent out.
 
 #### Specifics
 
-|                        |                                                               |
-| ---------------------- | ------------------------------------------------------------- |
-| **Action**             | `mark_events_as_seen`                                         |
-| **Required scopes**    | `chats--access:ro` `chats--all:ro`                            |
-| **Web API equivalent** | [`mark_events_as_seen`](../#mark-events-as-seen)              |
+|                        |                                                   |
+| ---------------------- | ------------------------------------------------- |
+| **Action**             | `mark_events_as_seen`                             |
+| **Required scopes**    | `chats--access:ro` `chats--all:ro`                |
+| **Web API equivalent** | [`mark_events_as_seen`](../#mark-events-as-seen)  |
 | **Push message**       | [`events_marked_as_seen`](#events_marked_as_seen) |
 
 #### Request
 
-| Parameter    | Required | Data type   | Notes |
-| ------------ | -------- | ----------- | ----- |
-| `chat_id`    | Yes      | `string`    |       |
-| `seen_up_to` | Yes      | `string`    | RFC 3339 date-time format |
+| Parameter    | Required | Data type | Notes                     |
+| ------------ | -------- | --------- | ------------------------- |
+| `chat_id`    | Yes      | `string`  |                           |
+| `seen_up_to` | Yes      | `string`  | RFC 3339 date-time format |
 
 </Text>
 <Code>
@@ -3892,21 +3504,6 @@ Logs the Agent out.
 ```
 
 </CodeSample>
-
-<!-- > **`send_typing_indicator`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "send_typing_indicator",
-	"payload": {
-		"chat_id": "PJ0MRSHTDG",
-		"recipients": "all",
-		"is_typing": true
-		},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 
@@ -4003,43 +3600,6 @@ At least one `scopes` type (`agents.all`, `agents.ids`, `agents.groups`, `custom
 
 </CodeSample>
 
-<!-- > **`multicast`** sample **request** with optional params
-
-```json
-{
-	"request_id": "125", // optional
-	"action": "multicast",
-	"payload": {
-		"scopes": {
-            "agents": {
-                "all": true,
-                "ids": [
-                    "agent1@example.com",
-                    "agent2@example.com"
-                ],
-                "groups": [
-                    1,
-                    2
-                ]
-            },
-            "customers": {
-                "ids": [
-                    "b7eff798-f8df-4364-8059-649c35c9ed0c"
-                ]
-            }
-        },
-        "content": {
-            "example": {
-                "nested": "json"
-				}
-			}
-		},
-		"type": "type1"
-	},
-	"author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
-
 <CodeResponse>
 
 ```json
@@ -4076,14 +3636,14 @@ Here's what you need to know about **pushes**:
 |                 |                                                                                                                                                                                                                                                                                                                                                                     |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Chats**       | [`incoming_chat_thread`](#incoming_chat_thread) [`thread_closed`](#thread_closed)                                                                                                                                                                                                                                                                                   |
-| **Chat access** | [`access_granted`](#access_granted) [`access_revoked`](#access_revoked) [`access_set`](#access_set) [`chat_transferred`](#chat_transferred-1)                                                                                                                                                                                                                         |
+| **Chat access** | [`access_granted`](#access_granted) [`access_revoked`](#access_revoked) [`access_set`](#access_set) [`chat_transferred`](#chat_transferred-1)                                                                                                                                                                                                                       |
 | **Chat users**  | [`chat_user_added`](#chat_user_added) [`chat_user_removed`](#chat_user_removed)                                                                                                                                                                                                                                                                                     |
 | **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                            |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`chat_thread_properties_updated`](#chat_thread_properties_updated) [`chat_thread_properties_deleted`](#chat_thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
 | **Thread tags** | [`chat_thread_tagged`](#chat_thread_tagged) [`chat_thread_untagged`](#chat_thread_untagged)                                                                                                                                                                                                                                                                         |
 | **Customers**   | [`customer_visit_started`](#customer_visit_started) [`customer_created`](#customer_created) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_banned`](#customer_banned) [`customer_visit_ended`](#customer_visit_ended)                                                                                         |
 | **Status**      | [`agent_updated`](#agent_updated) [`agent_disconnected`](#agent_disconnected)                                                                                                                                                                                                                                                                                       |
-| **Other**       | [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_sneak_peek`](#incoming_sneak_peek) [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast)                                                                                                                                                   |
+| **Other**       | [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_sneak_peek`](#incoming_sneak_peek) [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast)                                                                                                                                                               |
 
 </Text>
 
@@ -4139,9 +3699,9 @@ Informs about a new thread coming in the chat. The push payload contains not onl
 
 #### Specifics
 
-|                        |                                                                       |
-| ---------------------- | --------------------------------------------------------------------- |
-| **Action**             | `incoming_chat_thread`                                                |
+|                        |                                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| **Action**             | `incoming_chat_thread`                                                             |
 | **Webhook equivalent** | [`incoming_chat_thread`](/management/configuration-api/v3.1/#incoming_chat_thread) |
 
 ### `thread_closed`
@@ -4161,9 +3721,9 @@ Informs that a thread was closed.
 
 #### Specifics
 
-|                        |                                                         |
-| ---------------------- | ------------------------------------------------------- |
-| **Action**             | `thread_closed`                                         |
+|                        |                                                                      |
+| ---------------------- | -------------------------------------------------------------------- |
+| **Action**             | `thread_closed`                                                      |
 | **Webhook equivalent** | [`thread_closed`](/management/configuration-api/v3.1/#thread_closed) |
 
 #### Push payload
@@ -4193,9 +3753,9 @@ Informs that new, single access to a resource was granted. The existing access i
 
 #### Specifics
 
-|                        |                                                           |
-| ---------------------- | --------------------------------------------------------- |
-| **Action**             | `access_granted`                                          |
+|                        |                                                                        |
+| ---------------------- | ---------------------------------------------------------------------- |
+| **Action**             | `access_granted`                                                       |
 | **Webhook equivalent** | [`access_granted`](/management/configuration-api/v3.1/#access_granted) |
 
 #### Push payload
@@ -4224,9 +3784,9 @@ Informs that access to a certain resource was revoked.
 
 #### Specifics
 
-|                        |                                                           |
-| ---------------------- | --------------------------------------------------------- |
-| **Action**             | `access_revoked`                                          |
+|                        |                                                                        |
+| ---------------------- | ---------------------------------------------------------------------- |
+| **Action**             | `access_revoked`                                                       |
 | **Webhook equivalent** | [`access_revoked`](/management/configuration-api/v3.1/#access_revoked) |
 
 #### Push payload
@@ -4255,9 +3815,9 @@ Informs that new, single access to a resource was set. The existing access is ov
 
 #### Specifics
 
-|                        |                                                   |
-| ---------------------- | ------------------------------------------------- |
-| **Action**             | `access_set`                                      |
+|                        |                                                                |
+| ---------------------- | -------------------------------------------------------------- |
+| **Action**             | `access_set`                                                   |
 | **Webhook equivalent** | [`access_set`](/management/configuration-api/v3.1/#access_set) |
 
 #### Push payload
@@ -4321,16 +3881,16 @@ This push can be emitted with `user.present` set to `false` when a user writes t
 
 #### Specifics
 
-|                        |                                                             |
-| ---------------------- | ----------------------------------------------------------- |
-| **Action**             | `chat_user_added`                                           |
+|                        |                                                                          |
+| ---------------------- | ------------------------------------------------------------------------ |
+| **Action**             | `chat_user_added`                                                        |
 | **Webhook equivalent** | [`chat_user_added`](/management/configuration-api/v3.1/#chat_user_added) |
 
 #### Push payload
 
-| Object      | Notes                                |
-| ----------- | ------------------------------------ |
-| `user_type` | Possible values: `agent`, `customer` |
+| Object      | Notes                                          |
+| ----------- | ---------------------------------------------- |
+| `user_type` | Possible values: `agent`, `customer`           |
 | `thread_id` | Empty if a user was added to an inactive chat. |
 
 ### `chat_user_removed`
@@ -4351,16 +3911,16 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Specifics
 
-|                        |                                                                 |
-| ---------------------- | --------------------------------------------------------------- |
-| **Action**             | `chat_user_removed`                                             |
+|                        |                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| **Action**             | `chat_user_removed`                                                          |
 | **Webhook equivalent** | [`chat_user_removed`](/management/configuration-api/v3.1/#chat_user_removed) |
 
 #### Push payload
 
-| Object      | Notes                                |
-| ----------- | ------------------------------------ |
-| `user_type` | Possible values: `agent`, `customer` |
+| Object      | Notes                                              |
+| ----------- | -------------------------------------------------- |
+| `user_type` | Possible values: `agent`, `customer`               |
 | `thread_id` | Empty if a user was removed from an inactive chat. |
 
 ## Events
@@ -4396,9 +3956,9 @@ Informs about an incoming [event](#events) sent to a chat.
 
 #### Specifics
 
-|                        |                                                           |
-| ---------------------- | --------------------------------------------------------- |
-| **Action**             | `incoming_event`                                          |
+|                        |                                                                        |
+| ---------------------- | ---------------------------------------------------------------------- |
+| **Action**             | `incoming_event`                                                       |
 | **Webhook equivalent** | [`incoming_event`](/management/configuration-api/v3.1/#incoming_event) |
 
 ### `event_updated`
@@ -4420,9 +3980,9 @@ Informs that an [event](#events) was updated.
 
 #### Specifics
 
-|                        |                                                         |
-| ---------------------- | ------------------------------------------------------- |
-| **Action**             | `event_updated`                                         |
+|                        |                                                                      |
+| ---------------------- | -------------------------------------------------------------------- |
+| **Action**             | `event_updated`                                                      |
 | **Webhook equivalent** | [`event_updated`](/management/configuration-api/v3.1/#event_updated) |
 
 ### `incoming_rich_message_postback`
@@ -4447,9 +4007,9 @@ Informs about an incoming [rich message](#rich-message) postback. The push paylo
 
 #### Specifics
 
-|                        |                                                                                           |
-| ---------------------- | ----------------------------------------------------------------------------------------- |
-| **Action**             | `incoming_rich_message_postback`                                                          |
+|                        |                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Action**             | `incoming_rich_message_postback`                                                                       |
 | **Webhook equivalent** | [`incoming_rich_message_postback`](/management/configuration-api/v3.1/#incoming_rich_message_postback) |
 
 ## Properties
@@ -4480,9 +4040,9 @@ Informs about those chat properties that were updated.
 
 #### Specifics
 
-|                        |                                                                             |
-| ---------------------- | --------------------------------------------------------------------------- |
-| **Action**             | `chat_properties_updated`                                                   |
+|                        |                                                                                          |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| **Action**             | `chat_properties_updated`                                                                |
 | **Webhook equivalent** | [`chat_properties_updated`](/management/configuration-api/v3.1/#chat_properties_updated) |
 
 #### Push payload
@@ -4511,9 +4071,9 @@ Informs about those chat properties that were deleted.
 
 #### Specifics
 
-|                        |                                                                             |
-| ---------------------- | --------------------------------------------------------------------------- |
-| **Action**             | `chat_properties_deleted`                                                   |
+|                        |                                                                                          |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| **Action**             | `chat_properties_deleted`                                                                |
 | **Webhook equivalent** | [`chat_properties_deleted`](/management/configuration-api/v3.1/#chat_properties_deleted) |
 
 #### Push payload
@@ -4549,9 +4109,9 @@ Informs about those chat thread properties that were updated.
 
 #### Specifics
 
-|                        |                                                                                           |
-| ---------------------- | ----------------------------------------------------------------------------------------- |
-| **Action**             | `chat_thread_properties_updated`                                                          |
+|                        |                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Action**             | `chat_thread_properties_updated`                                                                       |
 | **Webhook equivalent** | [`chat_thread_properties_updated`](/management/configuration-api/v3.1/#chat_thread_properties_updated) |
 
 #### Push payload
@@ -4581,9 +4141,9 @@ Informs about those chat thread properties that were deleted.
 
 #### Specifics
 
-|                        |                                                                                           |
-| ---------------------- | ----------------------------------------------------------------------------------------- |
-| **Action**             | `chat_thread_properties_deleted`                                                          |
+|                        |                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Action**             | `chat_thread_properties_deleted`                                                                       |
 | **Webhook equivalent** | [`chat_thread_properties_deleted`](/management/configuration-api/v3.1/#chat_thread_properties_deleted) |
 
 #### Push payload
@@ -4616,9 +4176,9 @@ Informs about those event properties that were updated.
 
 #### Specifics
 
-|                        |                                                                               |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| **Action**             | `event_properties_updated`                                                    |
+|                        |                                                                                            |
+| ---------------------- | ------------------------------------------------------------------------------------------ |
+| **Action**             | `event_properties_updated`                                                                 |
 | **Webhook equivalent** | [`event_properties_updated`](/management/configuration-api/v3.1/#event_properties_updated) |
 
 #### Push payload
@@ -4649,9 +4209,9 @@ Informs about those event properties that were deleted.
 
 #### Specifics
 
-|                        |                                                                               |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| **Action**             | `event_properties_deleted`                                                    |
+|                        |                                                                                            |
+| ---------------------- | ------------------------------------------------------------------------------------------ |
+| **Action**             | `event_properties_deleted`                                                                 |
 | **Webhook equivalent** | [`event_properties_deleted`](/management/configuration-api/v3.1/#event_properties_deleted) |
 
 #### Push payload
@@ -4679,9 +4239,9 @@ Informs that a chat thread was tagged.
 
 #### Specifics
 
-|                        |                                                                   |
-| ---------------------- | ----------------------------------------------------------------- |
-| **Action**             | `chat_thread_tagged`                                              |
+|                        |                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| **Action**             | `chat_thread_tagged`                                                           |
 | **Webhook equivalent** | [`chat_thread_tagged`](/management/configuration-api/v3.1/#chat_thread_tagged) |
 
 ### `chat_thread_untagged`
@@ -4701,9 +4261,9 @@ Informs that a chat thread was untagged.
 
 #### Specifics
 
-|                        |                                                                       |
-| ---------------------- | --------------------------------------------------------------------- |
-| **Action**             | `chat_thread_untagged`                                                |
+|                        |                                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| **Action**             | `chat_thread_untagged`                                                             |
 | **Webhook equivalent** | [`chat_thread_untagged`](/management/configuration-api/v3.1/#chat_thread_untagged) |
 
 ## Customers
@@ -4765,9 +4325,9 @@ Informs that a new Customer registered.
 
 #### Specifics
 
-|                        |                                                               |
-| ---------------------- | ------------------------------------------------------------- |
-| **Action**             | `customer_created`                                            |
+|                        |                                                                            |
+| ---------------------- | -------------------------------------------------------------------------- |
+| **Action**             | `customer_created`                                                         |
 | **Webhook equivalent** | [`customer_created`](/management/configuration-api/v3.1/#customer_created) |
 
 ### `customer_updated`
@@ -4951,7 +4511,7 @@ Informs that one of the chat users is currently typing a message. The message ha
 {
   "chat_id": "PJ0MRSHTDG",
   "thread_id": "K600PKZON8",
-  "typing_indicator": {   
+  "typing_indicator": {
     "author_id": "d17cd570-11a9-45c0-45c0-1b020b7586dc",
     "recipients": "all",
     "timestamp": 1574245378,
@@ -4978,7 +4538,7 @@ Informs about the message a Customer is currently typing. The push payload conta
 {
   "chat_id": "PJ0MRSHTDG",
   "thread_id": "K600PKZON8",
-  "sneak_peek": {   
+  "sneak_peek": {
     "author_id": "d17cd570-11a9-45c0-45c0-1b020b7586dc",
     "recipients": "all",
     "text": "Hello",
@@ -5013,13 +4573,13 @@ Informs that a user has seen events up to a specific time.
 
 #### Specifics
 
-|                        |                                                                                     |
-| ---------------------- | ----------------------------------------------------------------------------------- |
-| **Action**             | `events_marked_as_seen`                                                       |
+|                        |                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------ |
+| **Action**             | `events_marked_as_seen`                                                              |
 | **Webhook equivalent** | [`events_marked_as_seen`](/management/configuration-api/v3.1/#events_marked_as_seen) |
 
 ### `incoming_multicast`
-Informs about messages sent via the `multicast` method or by the system. 
+Informs about messages sent via the `multicast` method or by the system.
 
 <CodeResponse title={'Sample push payload'}>
 
@@ -5046,11 +4606,11 @@ Informs about messages sent via the `multicast` method or by the system.
 
 #### Push payload
 
-| Object      | Required | Notes |
-| ----------- | -------- | ----- |
+| Object      | Required | Notes                                                                                            |
+| ----------- | -------- | ------------------------------------------------------------------------------------------------ |
 | `author_id` | No       | Present only if the push was generated by the **Multicast** method and not sent from the server. |
-| `content`   | Yes      |       |
-| `type`      | No       |       |
+| `content`   | Yes      |                                                                                                  |
+| `type`      | No       |                                                                                                  |
 
 # Errors
 

--- a/content/messaging/agent-chat-api/v3.1/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.1/rtm-reference/index.mdx
@@ -571,6 +571,7 @@ System message event is native system event sent in specific situations.
 | Field            | Req./Opt. |                                              Note |
 | ---------------- | :-------: | ------------------------------------------------: |
 | `routing_status` | optional  | Returned only if the Agent's currently logged in. |
+| `events_seen_up_to`| optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Agent—all the previous events are considered seen. |
 
 ### My profile
 
@@ -4063,14 +4064,14 @@ At least one `scopes` type (`agents.all`, `agents.ids`, `agents.groups`, `custom
 
 # Pushes
 
-Here's what you need to know about **pushes**: 
+Here's what you need to know about **pushes**:
 
 - They are generated primarily by RTM API actions, but also by Web API actions.
-- They notify you when specific events occur. 
-- Can be **delivered** only in the websocket transport. 
-- You don't need to register pushes to receive them. 
-- Their equivalents in Web API are [webhooks](/management/configuration-api/v3.1/#webhooks). 
-- Pushes and webhooks have similar payloads.
+- They notify you when specific events occur.
+- Can be **delivered** only in the websocket transport.
+- You don't need to register pushes to receive them.
+- Their equivalents in Web API are [webhooks](/management/configuration-api/v3.1/#webhooks). Pushes and webhooks have similar payloads.
+- There are no retries for pushes. To determine if a user has seen an event, compare the [event's](#response) `created_at` parameter with the [user's](#users) `events_seen_up_to` field.
 
 |                 |                                                                                                                                                                                                                                                                                                                                                                     |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -370,6 +370,7 @@ System message event is native system event sent in specific situations.
 | Field            | Req./Opt. |                                              Note |
 | ---------------- | :-------: | ------------------------------------------------: |
 | `routing_status` | optional  | Returned only if the Agent's currently logged in. |
+| `events_seen_up_to`| optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Agent—all the previous events are considered seen. |
 
 ### My profile
 
@@ -3427,8 +3428,8 @@ Here's what you need to know about **pushes**:
 - They notify you when specific events occur.
 - Can be **delivered** only in the websocket transport.
 - You don't need to register pushes to receive them.
-- Their equivalents in Web API are [webhooks](/management/configuration-api/#webhooks).
-- Pushes and webhooks have similar payloads.
+- Their equivalents in Web API are [webhooks](/management/configuration-api/#webhooks). Pushes and webhooks have similar payloads.
+- There are no retries for pushes. To determine if a user has seen an event, compare the [event's](#response) `created_at` parameter with the [user's](#users) `events_seen_up_to` field.
 
 |                 |                                                                                                                                                                                                                                                                                                                                                                     |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -102,32 +102,32 @@ The **File** event informs about an uploaded file.
 
 ### Request
 
-| Field              | Required | Data type | Notes                                                                                                                                     |
+| Field              | Required | Data type |                                                                                                                                     Notes |
 | ------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`        | no       | `string`  |                                                                                                                                           |
-| `type`             | yes      | `string`  | `file`                                                                                                                                    |
-| `recipients`       | yes      | `string`  | Possible values: `all` (default), `agents`                                                                                                |
-| `properties`       | no       | `object`  | [Properties](#properties)                                                                                                                 |
+| `type`             | yes      | `string`  |                                                                                                                                    `file` |
+| `recipients`       | yes      | `string`  |                                                                                                Possible values: `all` (default), `agents` |
+| `properties`       | no       | `object`  |                                                                                                                 [Properties](#properties) |
 | `url`              | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file). |
-| `alternative_text` | no       | `string`  | Only applicable to images                                                                                                                 |
+| `alternative_text` | no       | `string`  |                                                                                                                 Only applicable to images |
 
 ### Response
 
-| Field                               | Returned        | Notes                                                               |
-| ----------------------------------- | :-------------- | ------------------------------------------------------------------: |
-| `id`                                | always          |                                                                     |
-| `custom_id`                         | optionally      |                                                                     |
-| `created_at`                        | always          | Date & time format with a resolution of microseconds, `UTC string`. |
-| `type`                              | always          |                                                                     |
-| `author_id`                         | always          |                                                                     |
-| `recipients`                        | always          |                                                                     |
-| `properties`                        | optionally      |                                                                     |
-| `name`                              | always          |                                                                     |
-| `url`                               | always          |                                                                     |
-| `thumbnail_url`, `thumbnail2x_url`  | only for images |                                                                     |
-| `content_type`                      | always          |                                                                     |
-| `size`, `width`, `height`           | only for images |                                                                     |
-| `alternative_text`                  | only for images |                                                                     |
+| Field                              | Returned        |                                                               Notes |
+| ---------------------------------- | :-------------- | ------------------------------------------------------------------: |
+| `id`                               | always          |                                                                     |
+| `custom_id`                        | optionally      |                                                                     |
+| `created_at`                       | always          | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`                             | always          |                                                                     |
+| `author_id`                        | always          |                                                                     |
+| `recipients`                       | always          |                                                                     |
+| `properties`                       | optionally      |                                                                     |
+| `name`                             | always          |                                                                     |
+| `url`                              | always          |                                                                     |
+| `thumbnail_url`, `thumbnail2x_url` | only for images |                                                                     |
+| `content_type`                     | always          |                                                                     |
+| `size`, `width`, `height`          | only for images |                                                                     |
+| `alternative_text`                 | only for images |                                                                     |
 
 </Text>
 <Code>
@@ -144,28 +144,28 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 
 ### Request
 
-| Field                   | Required | Data type  |  Notes                                                                    |
-| ------------------------| -------- | -----------| ------------------------------------------------------------------------- |
-| `custom_id`             | no       | `string`   |                                                                           |
-| `type`                  | yes      | `string`   | `filled_form`                                                             |
-| `recipients`            | yes      | `string`   | Possible values: `all` (default), `agents`                                |
-| `properties`            | no       | `object`   | [Properties](#properties)                                                 |
-| `form_id`               | yes      | `string`   |                                                                           |
-| `fields`                | yes      | `array`    | The fields a form contains. See [form fields](#form-fields) for details.  |
+| Field        | Required | Data type | Notes                                                                    |
+| ------------ | -------- | --------- | ------------------------------------------------------------------------ |
+| `custom_id`  | no       | `string`  |                                                                          |
+| `type`       | yes      | `string`  | `filled_form`                                                            |
+| `recipients` | yes      | `string`  | Possible values: `all` (default), `agents`                               |
+| `properties` | no       | `object`  | [Properties](#properties)                                                |
+| `form_id`    | yes      | `string`  |                                                                          |
+| `fields`     | yes      | `array`   | The fields a form contains. See [form fields](#form-fields) for details. |
 
 ### Response
 
-| Field                   | Returned    | Notes |
-| ------------------------| ----------- | ----- |
-| `id`                    | always      |       |
-| `custom_id`             | optionally  |       |
-| `created_at`            | always      | Date & time format with a resolution of microseconds, `UTC string`. |
-| `type`                  | always      |       |
-| `author_id`             | always      |       |
-| `recipients`            | always      |       |
-| `properties`            | optionally  |       |
-| `form_id`               | always      |       |
-| `fields`                | always      | An array of [form fields](#form-fields) |
+| Field        | Returned   | Notes                                                               |
+| ------------ | ---------- | ------------------------------------------------------------------- |
+| `id`         | always     |                                                                     |
+| `custom_id`  | optionally |                                                                     |
+| `created_at` | always     | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`       | always     |                                                                     |
+| `author_id`  | always     |                                                                     |
+| `recipients` | always     |                                                                     |
+| `properties` | optionally |                                                                     |
+| `form_id`    | always     |                                                                     |
+| `fields`     | always     | An array of [form fields](#form-fields)                             |
 
 </Text>
 
@@ -183,38 +183,38 @@ The **Message** event contains text message to other chat users.
 
 ### Request
 
-| Field                 | Required| Data type | Notes                                                               |
-| --------------------- | ------- | --------- | ------------------------------------------------------------------  |
-| `custom_id`           | no      | `string`  |                                                                     |
-| `text`                | yes     | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
-| `type`                | yes     | `string`  | `message`                                                           |
-| `recipients`          | yes     | `string`  | Possible values: `all` (default), `agents`                          |
-| `properties`          | no      | `object`  | [Properties](#properties)                                           |
-| `postback`            | no      | `object`  | Indicates that the message event was generated in response to a rich message event. |
-| `postback.id`         | yes     | `string`  | ID of the postback from the rich message event.                     |
-| `postback.thread_id`  | yes     | `string`  | ID of the thread with the rich message event.                       |
-| `postback.event_id`   | yes     | `string`  | ID of the rich message event.                                       |
-| `postback.type`       | no      | `string`  | Should be used together with `postback.value` (when  one of them is present, the other is required).                      |
-| `postback.value`      | no      | `string`  | Should be used together with `postback.type` (when  one of them is present, the other is required).                       |
+| Field                | Required | Data type | Notes                                                                                                                        |
+| -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `custom_id`          | no       | `string`  |                                                                                                                              |
+| `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
+| `type`               | yes      | `string`  | `message`                                                                                                                    |
+| `recipients`         | yes      | `string`  | Possible values: `all` (default), `agents`                                                                                   |
+| `properties`         | no       | `object`  | [Properties](#properties)                                                                                                    |
+| `postback`           | no       | `object`  | Indicates that the message event was generated in response to a rich message event.                                          |
+| `postback.id`        | yes      | `string`  | ID of the postback from the rich message event.                                                                              |
+| `postback.thread_id` | yes      | `string`  | ID of the thread with the rich message event.                                                                                |
+| `postback.event_id`  | yes      | `string`  | ID of the rich message event.                                                                                                |
+| `postback.type`      | no       | `string`  | Should be used together with `postback.value` (when  one of them is present, the other is required).                         |
+| `postback.value`     | no       | `string`  | Should be used together with `postback.type` (when  one of them is present, the other is required).                          |
 
 ### Response
 
-| Field                   | Returned    | Notes                                                                 |
-| ------------------------| ----------- | ----------------------------------------------------------------------|
-| `id`                    | always      |                                                                       |
-| `custom_id`             | optionally  |                                                                       |
-| `created_at`            | always      | Date & time format with a resolution of microseconds, `UTC string`.   |
-| `type`                  | always      | `message`                                                             |
-| `author_id`             | always      |                                                                       |
-| `recipients`            | always      |                                                                       |
-| `text`                  | always      |                                                                       |
-| `postback`              | optionally  | Appears in a message only when triggered by a rich message.           |
-| `postback.id`           | always      |                                                                       |
-| `postback.thread_id`    | always      |                                                                       |
-| `postback.event_id`     | always      |                                                                       |
-| `postback.type`         | optionally  | Appears only if `postback.value` is present.                          |
-| `postback.value`        | optionally  | Appears only if `postback.type` is present.                           |
-| `properties`            | optionally  | [Properties](#properties)                                             |
+| Field                | Returned   | Notes                                                               |
+| -------------------- | ---------- | ------------------------------------------------------------------- |
+| `id`                 | always     |                                                                     |
+| `custom_id`          | optionally |                                                                     |
+| `created_at`         | always     | Date & time format with a resolution of microseconds, `UTC string`. |
+| `type`               | always     | `message`                                                           |
+| `author_id`          | always     |                                                                     |
+| `recipients`         | always     |                                                                     |
+| `text`               | always     |                                                                     |
+| `postback`           | optionally | Appears in a message only when triggered by a rich message.         |
+| `postback.id`        | always     |                                                                     |
+| `postback.thread_id` | always     |                                                                     |
+| `postback.event_id`  | always     |                                                                     |
+| `postback.type`      | optionally | Appears only if `postback.value` is present.                        |
+| `postback.value`     | optionally | Appears only if `postback.type` is present.                         |
+| `properties`         | optionally | [Properties](#properties)                                           |
 
 </Text>
 <Code>
@@ -231,50 +231,50 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 
 ### Request
 
-| Field                            | Required | Data type | Notes                                                                                             |
-| -------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------- |
-| `custom_id`                      | no       | `string`  | You can give your RM a custom ID.                                                                 |
-| `type`                           | yes      | `string`  | Event type: `rich_message`                                                                        |
-| `recipients`                     | yes      | `string`  | Those who can display the rich message: `all` (default) or `agents`                               |
-| `properties`                     | no       | `object`  | The [properties](#properties) data structure                                                      |
-| `template_id`                    | yes      | `string`  | Defines how every Rich Message will be presented. Values: `cards`, `sticker`, or `quick_replies`. |
-| `elements`                       | no       | `array`   | Can contain up to 10 `element` objects.                                                           |
-| `elements.title`                 | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.subtitle`              | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.image`                 | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`, `alternative_text`.|
-| `elements.buttons`               | no       | `array`   | Displays buttons. Can contain up to 13 `button` objects.                                          |
-| `elements.buttons.text`          | yes      | `string`  | Text displayed on a button.                                                                       |
-| `elements.buttons.type`          | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value` (when  one of them is present, the other is required). Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)  |
-| `elements.buttons.value`         | yes      | `string`  | Should be used together with `elements.buttons.type` (when  one of them is present, the other is required).                                             |
-| `elements.buttons.webview_height`| yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.         |
-| `elements.buttons.postback_id`   | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
-| `elements.buttons.user_ids`      | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.|
-| `elements.buttons.target`        | no       | `string`  | Should be used for the `url` button `type`. Specifies if the URL should open in the current or a new tab. Possible values: `new`, `current`.                    |
+| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                                                                                  |
+| --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                                                                      |
+| `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                                                                             |
+| `recipients`                      | yes      | `string`  | Those who can display the rich message: `all` (default) or `agents`                                                                                                                                                                                                                                    |
+| `properties`                      | no       | `object`  | The [properties](#properties) data structure                                                                                                                                                                                                                                                           |
+| `template_id`                     | yes      | `string`  | Defines how every Rich Message will be presented. Values: `cards`, `sticker`, or `quick_replies`.                                                                                                                                                                                                      |
+| `elements`                        | no       | `array`   | Can contain up to 10 `element` objects.                                                                                                                                                                                                                                                                |
+| `elements.title`                  | yes      | `string`  | Displays formatted text on RMs.                                                                                                                                                                                                                                                                        |
+| `elements.subtitle`               | yes      | `string`  | Displays formatted text on RMs.                                                                                                                                                                                                                                                                        |
+| `elements.image`                  | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`, `alternative_text`.                                                                                                                                                                 |
+| `elements.buttons`                | no       | `array`   | Displays buttons. Can contain up to 13 `button` objects.                                                                                                                                                                                                                                               |
+| `elements.buttons.text`           | yes      | `string`  | Text displayed on a button.                                                                                                                                                                                                                                                                            |
+| `elements.buttons.type`           | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value` (when  one of them is present, the other is required). Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
+| `elements.buttons.value`          | yes      | `string`  | Should be used together with `elements.buttons.type` (when  one of them is present, the other is required).                                                                                                                                                                                            |
+| `elements.buttons.webview_height` | yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.                                                                                                                                                                                                              |
+| `elements.buttons.postback_id`    | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)                                                                                                                            |
+| `elements.buttons.user_ids`       | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.                                                                                                                                                                                                                                         |
+| `elements.buttons.target`         | no       | `string`  | Should be used for the `url` button `type`. Specifies if the URL should open in the current or a new tab. Possible values: `new`, `current`.                                                                                                                                                           |
 
 ### Response
 
-| Field                            | Returned   | Notes                                                               |
-| -------------------------------- | ---------- | ------------------------------------------------------------------- |
-| `id`                             | always     | Generated server-side                                               |
-| `custom_id`                      | optionally |                                                                     |
-| `type`                           | always     |                                                                     |
-| `author_id`                      | always     | Generated server-side                                               |
-| `created_at`                     | always     | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
-| `recipients`                     | always     |                                                                     |
-| `properties`                     | optionally |                                                                     |
-| `template_id`                    | always     |                                                                     |
-| `elements`                       | optionally |                                                                     |
-| `elements.title`                 | always     |                                                                     |
-| `elements.subtitle`              | always     |                                                                     |
-| `elements.image`                 | always     |                                                                     |
-| `elements.buttons`               | optionally |                                                                     |
-| `elements.buttons.text`          | always     |                                                                     |
-| `elements.buttons.type`          | always     |                                                                     |
-| `elements.buttons.value`         | always     |                                                                     |
-| `elements.buttons.webview_height`| always     | Unless button `type` is different than `webview`.                   |
-| `elements.buttons.postback_id`   | always     |                                                                     |
-| `elements.buttons.user_ids`      | always     |                                                                     |
-| `elements.buttons.target`        | optionally |                                                                     |
+| Field                             | Returned   | Notes                                                                                      |
+| --------------------------------- | ---------- | ------------------------------------------------------------------------------------------ |
+| `id`                              | always     | Generated server-side                                                                      |
+| `custom_id`                       | optionally |                                                                                            |
+| `type`                            | always     |                                                                                            |
+| `author_id`                       | always     | Generated server-side                                                                      |
+| `created_at`                      | always     | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
+| `recipients`                      | always     |                                                                                            |
+| `properties`                      | optionally |                                                                                            |
+| `template_id`                     | always     |                                                                                            |
+| `elements`                        | optionally |                                                                                            |
+| `elements.title`                  | always     |                                                                                            |
+| `elements.subtitle`               | always     |                                                                                            |
+| `elements.image`                  | always     |                                                                                            |
+| `elements.buttons`                | optionally |                                                                                            |
+| `elements.buttons.text`           | always     |                                                                                            |
+| `elements.buttons.type`           | always     |                                                                                            |
+| `elements.buttons.value`          | always     |                                                                                            |
+| `elements.buttons.webview_height` | always     | Unless button `type` is different than `webview`.                                          |
+| `elements.buttons.postback_id`    | always     |                                                                                            |
+| `elements.buttons.user_ids`       | always     |                                                                                            |
+| `elements.buttons.target`         | optionally |                                                                                            |
 
 </Text>
 <Code>
@@ -291,7 +291,7 @@ Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                               |                                                                                   |
+| Field        | Required | Data type | Notes                                                               |  |
 | ------------ | -------- | --------- | ------------------------------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.                                 |
 | `type`       | yes      | `string`  | Event type: `custom`                                                |
@@ -327,14 +327,14 @@ System message event is native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required  | Data type | Notes                                                                                          |
-| --------------------- | --------- |---------- | --------------------------------------------------------------------------------------------- |
-| `custom_id`           | no        | `string`  | You can give the system message a custom ID.                                                   |
-| `type`                | yes       | `string`  | `system_message`                                                                               |
-| `text`                | no        | `string`  | Text displayed to recipients                                                                   |
-| `system_message_type` | yes       | `string`  | [System message type](/messaging/references/system-messages/)                                              |
-| `recipients`          | no        | `string`  | It can be specified when sending system messages via the [**Send Event**](#send-event) method. Possible values: `all`, `agents`.|
-| `text_vars`           | no        | `object`  | Variables used in the text                                                                     |
+| Field                 | Required | Data type | Notes                                                                                                                            |
+| --------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `custom_id`           | no       | `string`  | You can give the system message a custom ID.                                                                                     |
+| `type`                | yes      | `string`  | `system_message`                                                                                                                 |
+| `text`                | no       | `string`  | Text displayed to recipients                                                                                                     |
+| `system_message_type` | yes      | `string`  | [System message type](/messaging/references/system-messages/)                                                                    |
+| `recipients`          | no       | `string`  | It can be specified when sending system messages via the [**Send Event**](#send-event) method. Possible values: `all`, `agents`. |
+| `text_vars`           | no       | `object`  | Variables used in the text                                                                                                       |
 
 ### Response
 
@@ -367,18 +367,18 @@ System message event is native system event sent in specific situations.
 
 <CodeResponse version="v3.3" type="agent" title={'Sample Agent data structure'} json="agent"/>
 
-| Field            | Req./Opt. |                                              Note |
-| ---------------- | :-------: | ------------------------------------------------: |
-| `routing_status` | optional  | Returned only if the Agent's currently logged in. |
-| `events_seen_up_to`| optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Agent—all the previous events are considered seen. |
+| Field               | Req./Opt. |                                                                                                                            Note |
+| ------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------: |
+| `routing_status`    | optional  |                                                                               Returned only if the Agent's currently logged in. |
+| `events_seen_up_to` | optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Agent—all the previous events are considered seen. |
 
 ### My profile
 
 <CodeResponse version="v3.3" type="agent" title={'Sample My profile data structure'} json="myProfile"/>
 
-| Field                            | Req./Opt. | Notes                                                                                 |
-| -------------------------------- | --------- | ------------------------------------------------------------------------------------- |
-| `events_seen_up_to`              | optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Agent—all the previous events are considered seen. |
+| Field               | Req./Opt. | Notes                                                                                                                           |
+| ------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `events_seen_up_to` | optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Agent—all the previous events are considered seen. |
 
 ## Customer
 
@@ -438,16 +438,16 @@ A component of the [Filled form](#filled-form) event.
 
 <CodeResponse version="v3.3" type="agent" title={'Sample Form fields'} json="formFields"/>
 
-| Field                   | Required | Data type               |  Notes                                                                                                   |
-| ------------------------| -------- | ----------------------- | -------------------------------------------------------------------------------------------------------: |
-| `fields`                | yes      | `array of objects`      | The fields a form contains.                                                                              |
-| `type`                  | yes      | `string`                | Possible values: `checkbox`, `email`, `name`, `question`, `textarea`, `group_chooser`, `radio`, `select` |
-| `id`                    | yes      | `string`                | Field id, for all field types                                                                            |
-| `label`                 | yes      | `string`                | Field label; for all field types                                                                         |
-| `answer`                | yes      | `any`                   | For all field types                                                                                      |
-| `answer.id`             | yes      | `string`                | An identifier of each option a Customer can choose. For all field types.                           |
-| `answer.label`          | yes      | `string`                | Answer label; for all field types                                                                        |
-| `answer.group_id`       | yes      | `number`                | For `group_chooser`                                                                                      |
+| Field             | Required | Data type          |                                                                                                    Notes |
+| ----------------- | -------- | ------------------ | -------------------------------------------------------------------------------------------------------: |
+| `fields`          | yes      | `array of objects` |                                                                              The fields a form contains. |
+| `type`            | yes      | `string`           | Possible values: `checkbox`, `email`, `name`, `question`, `textarea`, `group_chooser`, `radio`, `select` |
+| `id`              | yes      | `string`           |                                                                            Field id, for all field types |
+| `label`           | yes      | `string`           |                                                                         Field label; for all field types |
+| `answer`          | yes      | `any`              |                                                                                      For all field types |
+| `answer.id`       | yes      | `string`           |                                 An identifier of each option a Customer can choose. For all field types. |
+| `answer.label`    | yes      | `string`           |                                                                        Answer label; for all field types |
+| `answer.group_id` | yes      | `number`           |                                                                                      For `group_chooser` |
 
 ## Properties
 
@@ -482,17 +482,17 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 
 ## Available methods
 
-|                 |                                                                                                                                                                                                                                                                                                                                                         |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                 |
-| **Chat access** | [`grant_chat_access`](#grant-chat-access) [`revoke_chat_access`](#revoke-chat-access) [`transfer_chat`](#transfer-chat)                                                                                                                                                                                                                           |
-| **Chat users**  | [`add_user_to_chat`](#add-user-to-chat) [`remove_user_from_chat`](#remove-user-from-chat)                                                                                                                                                                                                                                                               |
-| **Events**      | [`send_event`](#send-event) [`send_rich_message_postback`](#send-rich-message-postback)                                                                                                                                                                                                                                                                 |
+|                 |                                                                                                                                                                                                                                                                                                                                     |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                                           |
+| **Chat access** | [`grant_chat_access`](#grant-chat-access) [`revoke_chat_access`](#revoke-chat-access) [`transfer_chat`](#transfer-chat)                                                                                                                                                                                                             |
+| **Chat users**  | [`add_user_to_chat`](#add-user-to-chat) [`remove_user_from_chat`](#remove-user-from-chat)                                                                                                                                                                                                                                           |
+| **Events**      | [`send_event`](#send-event) [`send_rich_message_postback`](#send-rich-message-postback)                                                                                                                                                                                                                                             |
 | **Properties**  | [`update_chat_properties`](#update-chat-properties) [`delete_chat_properties`](#delete-chat-properties) [`update_thread_properties`](#update-thread-properties) [`delete_thread_properties`](#delete-thread-properties) [`update_event_properties`](#update-event-properties) [`delete_event_properties`](#delete-event-properties) |
 | **Thread tags** | [`tag_thread`](#tag-thread) [`untag_thread`](#untag-thread)                                                                                                                                                                                                                                                                         |
-| **Customers**   | [`get_customer`](#get-customer) [`list_customers`](#list-customers) [`create_customer`](#create-customer) [`update_customer`](#update-customer) [`ban_customer`](#ban-customer)                                                                                                                                                                           |
-| **Status**      | [`login`](#login) [`change_push_notifications`](#change-push-notifications) [`set_routing_status`](#set-routing-status) [`set_away_status`](#set-away-status) [`logout`](#logout)                                                                                                                                                                       |
-| **Other**       | [`mark_events_as_seen`](#mark-events-as-seen) [`send_typing_indicator`](#send-typing-indicator) [`multicast`](#multicast) [`list_agents_for_transfer`](#list-agents-for-transfer)                                                                                                                                                                         |
+| **Customers**   | [`get_customer`](#get-customer) [`list_customers`](#list-customers) [`create_customer`](#create-customer) [`update_customer`](#update-customer) [`ban_customer`](#ban-customer)                                                                                                                                                     |
+| **Status**      | [`login`](#login) [`change_push_notifications`](#change-push-notifications) [`set_routing_status`](#set-routing-status) [`set_away_status`](#set-away-status) [`logout`](#logout)                                                                                                                                                   |
+| **Other**       | [`mark_events_as_seen`](#mark-events-as-seen) [`send_typing_indicator`](#send-typing-indicator) [`multicast`](#multicast) [`list_agents_for_transfer`](#list-agents-for-transfer)                                                                                                                                                   |
 
 </Text>
 <Code>
@@ -540,7 +540,7 @@ It returns [summaries](#chat-summaries) of the chats an Agent has access to.
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
+| ---------------------- | ------------------------------------------------- |
 | **Action**             | `list_chats`                                      |
 | **Required scopes \*** | `chats--all:ro` `chats--access:ro` `chats--my:ro` |
 | **Web API equivalent** | [`list_chats`](../#list-chats)                    |
@@ -555,8 +555,8 @@ It returns [summaries](#chat-summaries) of the chats an Agent has access to.
 | `filters.include_chats_without_threads`               | No       | `bool`   | Defines if the returned chat summary includes chats without any threads; default: `true`.   |
 | `filters.group_ids`                                   | No       | `array`  | Array of group IDs. Max array size: 200                                                     |
 | `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`    |                                                                                             |
-| `sort_order`                                               | No       | `string` | Possible values: `asc` - oldest chats firstm `desc` - newest chats first (default)          |
-| `limit`                                               | No       | `number` | Default: 10, maximum: 100                                                                    |
+| `sort_order`                                          | No       | `string` | Possible values: `asc` - oldest chats firstm `desc` - newest chats first (default)          |
+| `limit`                                               | No       | `number` | Default: 10, maximum: 100                                                                   |
 | `page_id`                                             | No       | `string` |                                                                                             |
 
 `filter_type` can take the following values:
@@ -569,12 +569,12 @@ There's only one value allowed for a single property.
 
 #### Response
 
-| Parameter          | Data type   | Notes                                                                     |
-| ------------------ | ----------- | ------------------------------------------------------------------------- |
-| `chats_summary`    | `array`     | An array of [Chat summary](#chat-summaries) data structures |
-| `next_page_id`     | `string`    | In relation to `page_id` specified in the request. Appears in the response only when there's a next page. |
-| `previous_page_id` | `string`    | In relation to `page_id` specified in the request Appears in the response only when there's a previous page.|
-| `found_chats`      | `number`    | An estimated number. The real number of found chats can slightly differ. |
+| Parameter          | Data type | Notes                                                                                                        |
+| ------------------ | --------- | ------------------------------------------------------------------------------------------------------------ |
+| `chats_summary`    | `array`   | An array of [Chat summary](#chat-summaries) data structures                                                  |
+| `next_page_id`     | `string`  | In relation to `page_id` specified in the request. Appears in the response only when there's a next page.    |
+| `previous_page_id` | `string`  | In relation to `page_id` specified in the request Appears in the response only when there's a previous page. |
+| `found_chats`      | `number`  | An estimated number. The real number of found chats can slightly differ.                                     |
 
 </Text>
 <Code>
@@ -669,20 +669,20 @@ It returns threads that the current Agent has access to in a given chat.
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
-| **Action**             | `list_threads`                                      |
-| **Required scopes** | `chats--all:ro` `chats--access:ro` `chats--my:ro` |
-| **Web API equivalent** | [`list_threads`](../#list-threads)                    |
+| ---------------------- | ------------------------------------------------- |
+| **Action**             | `list_threads`                                    |
+| **Required scopes**    | `chats--all:ro` `chats--access:ro` `chats--my:ro` |
+| **Web API equivalent** | [`list_threads`](../#list-threads)                |
 | **Push message**       | -                                                 |
 
 #### Request
 
-| Parameter          | Required | Data type | Notes                                                                                      |
-| ------------------ | -------- | --------- | ------------------------------------------------------------------------------------------ |
-| `chat_id`          | Yes      | `string`  |                                                                                            |
-| `sort_order`       | No       | `string`  | Possible values: `asc` - oldest threads first and `desc` - newest threads first (default). |
-| `limit`            | No       | `number`  | Default: 3, maximum: 100                                                                   |
-| `page_id`          | No       | `string`  |                                                                                            |
+| Parameter          | Required | Data type | Notes                                                                                                                                                                                                                                                       |
+| ------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`          | Yes      | `string`  |                                                                                                                                                                                                                                                             |
+| `sort_order`       | No       | `string`  | Possible values: `asc` - oldest threads first and `desc` - newest threads first (default).                                                                                                                                                                  |
+| `limit`            | No       | `number`  | Default: 3, maximum: 100                                                                                                                                                                                                                                    |
+| `page_id`          | No       | `string`  |                                                                                                                                                                                                                                                             |
 | `min_events_count` | No       | `number`  | Range: 1-100; Specifies the minimum number of events to be returned in the response. It's the **total** number of events, so they can come from more than one thread. You'll get as many latest threads as needed to meet the `min_events_count` condition. |
 
 You cannot use both `limit` and `min_events_count` at the same time.
@@ -758,7 +758,7 @@ It returns a thread that the current Agent has access to in a given chat.
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
+| ---------------------- | ------------------------------------------------- |
 | **Action**             | `get_chat`                                        |
 | **Required scopes**    | `chats--all:ro` `chats--access:ro` `chats--my:ro` |
 | **Web API equivalent** | [`get_chat`](../#get-chat)                        |
@@ -767,7 +767,7 @@ It returns a thread that the current Agent has access to in a given chat.
 #### Request
 
 | Parameter   | Required | Data type | Notes                                  |
-|-------------|----------|-----------|----------------------------------------|
+| ----------- | -------- | --------- | -------------------------------------- |
 | `chat_id`   | Yes      | `string`  |                                        |
 | `thread_id` | No       | `string`  | Default: the latest thread (if exists) |
 
@@ -870,7 +870,7 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
+| ---------------------- | ------------------------------------------------- |
 | **Action**             | `list_archives`                                   |
 | **Required scopes**    | `chats--all:ro` `chats--access:ro` `chats--my:ro` |
 | **Web API equivalent** | [`list_archives`](../#list-archives)              |
@@ -878,26 +878,26 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 
 #### Request
 
-| Parameter                                             | Required | Data type | Notes                                                                                     |
-| ----------------------------------------------------- | -------- | --------- | ----------------------------------------------------------------------------------------- |
-| `filters`                                             | No       | `object`  |                                                                                           |
-| `filters.query`                                       | No       | `string`  |                                                                                           |
-| `filters.from`                                        | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.ssssssZHH:MM` |
-| `filters.to`                                           | No       | `string` | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.ssssssZHH:MM` |
-| `filters.group_ids`                                   | No       | `array`   | Array of group IDs. Max array size: 200                                                   |
-| `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     | **\* described below**                                                                    |
-| `filters.agents.<filter_type>`                        | No       | `any`     |  `exists` see to `false` will return unassigned chats; `true` will return the assigned ones.|
-| `filters.tags.<filter_type>`                          | No       | `any`     |                                                                                           |
-| `filters.sales.<filter_type>`                         | No       | `any`     |                                                                                           |
-| `filters.goals.<filter_type>`                         | No       | `any`     |                                                                                           |
-| `filters.surveys.<survey>`                            | No       | `array`   | **\*\*** **described below**                                                              |
-| `filters.events.types`                                | No       | `array`   | Array of [Event](#events) types. Duplicates are ignored.                                  |
-| `page_id`                                             | No       | `string`  |                                                                                           |
-| `sort_order` **\*\*\***                               | No       | `string`  |  Default: `desc`                                                                          |
-| `limit`                                               | No       | `number`  | Default: 10, min: 1, max: 100                                                             |
-| `highlights`                                          | No       | `object`  | Use it to highlight the match of `filters.query`. To enable highlights with default parameters, pass an empty object.|
-| `highlights.pre_tag`                                  | No       | `string`  | An HTML tag to use for highlighting the matched text; default: `<em>`. Use it together with `highlights.post_tag`.   |
-| `highlights.post_tag`                                 | No       | `string`  | An HTML tag to use for highlighting the matched text; default: `</em>`. Use it together with `highlights.pre_tag`.   |
+| Parameter                                             | Required | Data type | Notes                                                                                                                 |
+| ----------------------------------------------------- | -------- | --------- | --------------------------------------------------------------------------------------------------------------------- |
+| `filters`                                             | No       | `object`  |                                                                                                                       |
+| `filters.query`                                       | No       | `string`  |                                                                                                                       |
+| `filters.from`                                        | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.ssssssZHH:MM`                  |
+| `filters.to`                                          | No       | `string`  | Date & time format with a resolution of microseconds, UTC string, `YYYY-MM-DDTHH:MM:SS.ssssssZHH:MM`                  |
+| `filters.group_ids`                                   | No       | `array`   | Array of group IDs. Max array size: 200                                                                               |
+| `filters.properties.<namespace>.<name>.<filter_type>` | No       | `any`     | **\* described below**                                                                                                |
+| `filters.agents.<filter_type>`                        | No       | `any`     | `exists` see to `false` will return unassigned chats; `true` will return the assigned ones.                           |
+| `filters.tags.<filter_type>`                          | No       | `any`     |                                                                                                                       |
+| `filters.sales.<filter_type>`                         | No       | `any`     |                                                                                                                       |
+| `filters.goals.<filter_type>`                         | No       | `any`     |                                                                                                                       |
+| `filters.surveys.<survey>`                            | No       | `array`   | **\*\*** **described below**                                                                                          |
+| `filters.events.types`                                | No       | `array`   | Array of [Event](#events) types. Duplicates are ignored.                                                              |
+| `page_id`                                             | No       | `string`  |                                                                                                                       |
+| `sort_order` **\*\*\***                               | No       | `string`  | Default: `desc`                                                                                                       |
+| `limit`                                               | No       | `number`  | Default: 10, min: 1, max: 100                                                                                         |
+| `highlights`                                          | No       | `object`  | Use it to highlight the match of `filters.query`. To enable highlights with default parameters, pass an empty object. |
+| `highlights.pre_tag`                                  | No       | `string`  | An HTML tag to use for highlighting the matched text; default: `<em>`. Use it together with `highlights.post_tag`.    |
+| `highlights.post_tag`                                 | No       | `string`  | An HTML tag to use for highlighting the matched text; default: `</em>`. Use it together with `highlights.pre_tag`.    |
 
 **\*)**
 `<filter_type>` can take the following values:
@@ -1028,7 +1028,7 @@ Starts a chat.
 #### Specifics
 
 |                        |                                                                                          |
-|------------------------|------------------------------------------------------------------------------------------|
+| ---------------------- | ---------------------------------------------------------------------------------------- |
 | **Action**             | `start_chat`                                                                             |
 | **Required scopes \*** | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
 | **Web API equivalent** | [`start_chat`](../#start-chat)                                                           |
@@ -1043,25 +1043,25 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Request
 
-| Parameters               | Required | Data type | Notes                                                                   |
-| ------------------------ | -------- | --------- | ----------------------------------------------------------------------- |
-| `chat`                   | No       | `object`  |                                                                         |
-| `chat.properties`        | No       | `object`  |                                                                         |
-| `chat.access`            | No       | `object`  |                                                                         |
+| Parameters               | Required | Data type  | Notes                                                                                                    |
+| ------------------------ | -------- | ---------- | -------------------------------------------------------------------------------------------------------- |
+| `chat`                   | No       | `object`   |                                                                                                          |
+| `chat.properties`        | No       | `object`   |                                                                                                          |
+| `chat.access`            | No       | `object`   |                                                                                                          |
 | `chat.users`             | No       | `[]object` | The list of existing users. Up to 4 additional (other than the requester) agents and 1 customer allowed. |
-| `chat.users.id`          | Yes      | `string`  | User ID                                                               |
-| `chat.users.type`        | Yes      | `string`  | `agent` or `customer`.                                                  |
-| `chat.thread`            | No       | `object`  |                                                                         |
-| `chat.thread.events`     | No       | `array`   | The list of initial chat events                                         |
-| `chat.thread.properties` | No       | `object`  |                                                                         |
-| `continuous`             | No       | `bool`    | Starts chat as continuous (online group is not required); default: `false`. |
+| `chat.users.id`          | Yes      | `string`   | User ID                                                                                                  |
+| `chat.users.type`        | Yes      | `string`   | `agent` or `customer`.                                                                                   |
+| `chat.thread`            | No       | `object`   |                                                                                                          |
+| `chat.thread.events`     | No       | `array`    | The list of initial chat events                                                                          |
+| `chat.thread.properties` | No       | `object`   |                                                                                                          |
+| `continuous`             | No       | `bool`     | Starts chat as continuous (online group is not required); default: `false`.                              |
 
 #### Response
 
-| Parameter   | Data type  | Notes |
-| ----------- | ---------- | ----- |
-| `chat_id`   | `string`   |       |
-| `thread_id` | `string`   |       |
+| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`   | `string`   |                                                                                                                                                                         |
+| `thread_id` | `string`   |                                                                                                                                                                         |
 | `event_ids` | `[]string` | Returned only when the chat was started with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
 
 </Text>
@@ -1158,7 +1158,7 @@ Restarts an archived chat.
 | **Action**             | `activate_chat`                                                                          |
 | **Required scopes \*** | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
 | **Web API equivalent** | [`activate_chat`](../#activate-chat)                                                     |
-| **Push message**       | [`incoming_chat`](#incoming_chat)                                          |
+| **Push message**       | [`incoming_chat`](#incoming_chat)                                                        |
 
 **\*)**
 When `chat.users` is defined, one of following scopes is required:
@@ -1169,26 +1169,26 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Request
 
-| Request object           | Required | Type     | Notes                                                               |
-| ------------------------ | -------- | -------- | ------------------------------------------------------------------- |
-| `chat`                   | Yes      | `object` |                                                                     |
-| `chat.id`                | Yes      | `string` | The ID of the chat that will be activated.                          |
-| `chat.access`            | No       | `object` | Chat access to set, default: all agents.                            |
-| `chat.properties`        | No       | `object` | Initial chat properties                                             |
+| Request object           | Required | Type       | Notes                                                                                                    |
+| ------------------------ | -------- | ---------- | -------------------------------------------------------------------------------------------------------- |
+| `chat`                   | Yes      | `object`   |                                                                                                          |
+| `chat.id`                | Yes      | `string`   | The ID of the chat that will be activated.                                                               |
+| `chat.access`            | No       | `object`   | Chat access to set, default: all agents.                                                                 |
+| `chat.properties`        | No       | `object`   | Initial chat properties                                                                                  |
 | `chat.users`             | No       | `[]object` | The list of existing users. Up to 4 additional (other than the requester) agents and 1 customer allowed. |
-| `chat.users.id`          | Yes      | `string` | User ID                                                             |
-| `chat.users.type`        | Yes      | `string` | `agent` or `customer`                                               |
-| `chat.thread`            | No       | `object` |                                                                     |
-| `chat.thread.events`     | No       | `array`  | Initial chat events array                                           |
-| `chat.thread.properties` | No       | `object` | Initial thread properties                                      |
-| `continuous`             | No       | `bool`   | Sets a chat to the continuous mode. When unset, leaves the mode unchanged. |
+| `chat.users.id`          | Yes      | `string`   | User ID                                                                                                  |
+| `chat.users.type`        | Yes      | `string`   | `agent` or `customer`                                                                                    |
+| `chat.thread`            | No       | `object`   |                                                                                                          |
+| `chat.thread.events`     | No       | `array`    | Initial chat events array                                                                                |
+| `chat.thread.properties` | No       | `object`   | Initial thread properties                                                                                |
+| `continuous`             | No       | `bool`     | Sets a chat to the continuous mode. When unset, leaves the mode unchanged.                               |
 
 #### Response
 
-| Parameter   | Data type  | Notes |
-| ----------- | ---------- | ----- |
-| `thread_id` | `string`   |       |
-| `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array.|
+| Parameter   | Data type  | Notes                                                                                                                                                                     |
+| ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `thread_id` | `string`   |                                                                                                                                                                           |
+| `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
 
 </Text>
 <Code>
@@ -1276,7 +1276,7 @@ Deactivates a chat by closing the currently open thread. Sending messages to thi
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
+| ---------------------- | ------------------------------------------------- |
 | **Action**             | `deactivate_chat`                                 |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw` |
 | **Web API equivalent** | [`deactivate_chat`](../#deactivate-chat)          |
@@ -1284,9 +1284,9 @@ Deactivates a chat by closing the currently open thread. Sending messages to thi
 
 #### Request
 
-| Parameter | Required | Data type |  |
-| --------- | -------- | --------- | ----- |
-| `id`      | Yes      | `string`  |       |
+| Parameter | Required | Data type |     |
+| --------- | -------- | --------- | --- |
+| `id`      | Yes      | `string`  |     |
 
 </Text>
 <Code>
@@ -1331,7 +1331,7 @@ Marks a chat as followed. All changes to the chat will be sent to the requester 
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
+| ---------------------- | ------------------------------------------------- |
 | **Action**             | `follow_chat`                                     |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw` |
 | **Web API equivalent** | [`follow_chat`](../#follow-chat)                  |
@@ -1342,9 +1342,9 @@ It won't be sent when the requester already follows the chat or is the chat memb
 
 #### Request
 
-| Parameter | Required | Data type |  |
-| --------- | -------- | --------- | ----- |
-| `id`      | Yes      | `string`  |       |
+| Parameter | Required | Data type |     |
+| --------- | -------- | --------- | --- |
+| `id`      | Yes      | `string`  |     |
 
 </Text>
 <Code>
@@ -1454,12 +1454,12 @@ Grants access to a new chat without overwriting the existing ones.
 
 #### Request
 
-| Parameter     | Required | Data ype | Notes                |
-| ------------- | -------- | -------- | -------------------- |
-| `id`          | Yes      | `string` | Chat Id              |
-| `access`      | Yes      | `object` |                      |
-| `access.type` | Yes      | `string` | `group`              |
-| `access.id`   | Yes      | any      |                      |
+| Parameter     | Required | Data ype | Notes   |
+| ------------- | -------- | -------- | ------- |
+| `id`          | Yes      | `string` | Chat Id |
+| `access`      | Yes      | `object` |         |
+| `access.type` | Yes      | `string` | `group` |
+| `access.id`   | Yes      | any      |         |
 
 </Text>
 <Code>
@@ -1514,12 +1514,12 @@ Grants access to a new chat without overwriting the existing ones.
 
 #### Request
 
-| Parameter     | Required | Data type | Notes                |
-| ------------- | -------- | --------- | -------------------- |
-| `id`          | Yes      | `string`  | Chat Id              |
-| `access`      | Yes      | `object`  |                      |
-| `access.type` | Yes      | `string`  | `group` or `agent`   |
-| `access.id`   | Yes      | `number`  |                      |
+| Parameter     | Required | Data type | Notes              |
+| ------------- | -------- | --------- | ------------------ |
+| `id`          | Yes      | `string`  | Chat Id            |
+| `access`      | Yes      | `object`  |                    |
+| `access.type` | Yes      | `string`  | `group` or `agent` |
+| `access.id`   | Yes      | `number`  |                    |
 
 </Text>
 <Code>
@@ -1572,13 +1572,13 @@ Transfers a chat to an Agent or a group.
 | **Action**             | `transfer_chat`                                   |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw` |
 | **Web API equivalent** | [`transfer_chat`](../#transfer-chat)              |
-| **Push message**       | [`chat_transferred`](#chat_transferred)         |
+| **Push message**       | [`chat_transferred`](#chat_transferred)           |
 
 #### Request
 
 | Parameter     | Required | Data ype | Notes                                                                                                                           |
 | ------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `id`          | Yes      | `string` | Chat Id                                                                                                                     |
+| `id`          | Yes      | `string` | Chat Id                                                                                                                         |
 | `target`      | No       | `object` | If missing, the chat will be transferred within the current group.                                                              |
 | `target.type` | Yes      | `string` | `group` or `agent`                                                                                                              |
 | `target.ids`  | Yes      | `array`  | `group` or `agent` IDs array                                                                                                    |
@@ -1641,11 +1641,11 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 
 #### Request
 
-| Request object          | Required | Type     | Notes                                                                   |
-| ----------------------- | -------- | -------- | ----------------------------------------------------------------------- |
-| `chat_id`               | Yes      | `string` |                                                                         |
-| `user_id`               | Yes      | `string` |                                                                         |
-| `user_type`             | Yes      | `string` | Possible values: `agent` or `customer`                                  |
+| Request object          | Required | Type     | Notes                                                                                        |
+| ----------------------- | -------- | -------- | -------------------------------------------------------------------------------------------- |
+| `chat_id`               | Yes      | `string` |                                                                                              |
+| `user_id`               | Yes      | `string` |                                                                                              |
+| `user_type`             | Yes      | `string` | Possible values: `agent` or `customer`                                                       |
 | `require_active_thread` | No       | `bool`   | If `true`, it adds a user to a chat only if that chat has an active thread; default `false`. |
 
 </Text>
@@ -1757,11 +1757,11 @@ It's possible to write to a chat without joining it. The user sending an event w
 #### Specifics
 
 |                        |
-| ---------------------- | ----------------------------------------------------------------------------------------
-| **Action**             | `send_event`
-| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw`
-| **Web API equivalent** | [`send_event`](../#send-event)
-| **Push message**       | [`incoming_event`](#incoming_event)
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| **Action**             | `send_event`                                                                             |
+| **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
+| **Web API equivalent** | [`send_event`](../#send-event)                                                           |
+| **Push message**       | [`incoming_event`](#incoming_event)                                                      |
 
 #### Request
 
@@ -1893,10 +1893,10 @@ It's possible to write to a chat without joining it. The user sending an event w
 
 #### Request
 
-| Parameter    | Required | Data type | Notes                                     |
-| ------------ | -------- | --------- | ----------------------------------------- |
-| `id`         | Yes      | `string`  | Id of the chat you to set a property for. |
-| `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| Parameter    | Required | Data type | Notes                                                                                                                                                                        |
+| ------------ | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`         | Yes      | `string`  | Id of the chat you to set a property for.                                                                                                                                    |
+| `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_. |
 
 </Text>
 <Code>
@@ -1955,7 +1955,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 | Parameter    | Required | Data type | Notes                                           |
 | ------------ | -------- | --------- | ----------------------------------------------- |
 | `id`         | Yes      | `string`  | Id of the chat you want to delete property for. |
-| `properties` | Yes      | `object`  | Chat properties to delete. |
+| `properties` | Yes      | `object`  | Chat properties to delete.                      |
 
 </Text>
 <Code>
@@ -2003,7 +2003,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 #### Specifics
 
 |                        |                                                                                          |
-|------------------------|------------------------------------------------------------------------------------------|
+| ---------------------- | ---------------------------------------------------------------------------------------- |
 | **Action**             | `update_thread_properties`                                                               |
 | **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
 | **Web API equivalent** | [`update_thread_properties`](../#update-thread-properties)                               |
@@ -2011,11 +2011,11 @@ It's possible to write to a chat without joining it. The user sending an event w
 
 #### Request
 
-| Parameter    | Required | Data type | Notes                                            |
-| ------------ | -------- | --------- | ------------------------------------------------ |
-| `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.   |
-| `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for. |
-| `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| Parameter    | Required | Data type | Notes                                                                                                                                                                        |
+| ------------ | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.                                                                                                                               |
+| `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for.                                                                                                                             |
+| `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_. |
 
 </Text>
 <Code>
@@ -2064,7 +2064,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 #### Specifics
 
 |                        |                                                                                          |
-|------------------------|------------------------------------------------------------------------------------------|
+| ---------------------- | ---------------------------------------------------------------------------------------- |
 | **Action**             | `delete_thread_properties`                                                               |
 | **Required scopes**    | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
 | **Web API equivalent** | [`delete_thread_properties`](../#delete-thread-properties)                               |
@@ -2073,7 +2073,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 #### Request
 
 | Parameter    | Required | Data type | Notes                                             |
-|--------------|----------|-----------|---------------------------------------------------|
+| ------------ | -------- | --------- | ------------------------------------------------- |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete property for.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to delete property for. |
 | `properties` | Yes      | `object`  | Chat properties to delete.                        |
@@ -2138,7 +2138,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for. |
 | `event_id`   | Yes      | `string`  | Id of the event you want to set properties for.  |
-| `properties` | Yes      | `object`  | Chat properties to set. |
+| `properties` | Yes      | `object`  | Chat properties to set.                          |
 
 </Text>
 <Code>
@@ -2196,12 +2196,12 @@ It's possible to write to a chat without joining it. The user sending an event w
 
 #### Request
 
-| Parameter    | Required | Data type | Notes                                             |
-| ------------ | -------- | --------- | ------------------------------------------------- |
-| `chat_id`    | Yes      | `string`  | Id of the chat you want to delete the properties of.   |
-| `thread_id`  | Yes      | `string`  | Id of the thread you want to delete the properties of. |
-| `event_id`   | Yes      | `string`  | Id of the event you want to delete the properties of.  |
-| `properties` | Yes      | `object`  | Event properties to delete. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_.  |
+| Parameter    | Required | Data type | Notes                                                                                                                                                                            |
+| ------------ | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`    | Yes      | `string`  | Id of the chat you want to delete the properties of.                                                                                                                             |
+| `thread_id`  | Yes      | `string`  | Id of the thread you want to delete the properties of.                                                                                                                           |
+| `event_id`   | Yes      | `string`  | Id of the event you want to delete the properties of.                                                                                                                            |
+| `properties` | Yes      | `object`  | Event properties to delete. You should stick to the [general properties format](/management/configuration-api/#properties) and include _namespace_, _property name_ and _value_. |
 
 </Text>
 <Code>
@@ -2253,7 +2253,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
+| ---------------------- | ------------------------------------------------- |
 | **Action**             | `tag_thread`                                      |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw` |
 | **Web API equivalent** | [`tag_thread`](../#tag-thread)                    |
@@ -2310,7 +2310,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 #### Specifics
 
 |                        |                                                   |
-|------------------------|---------------------------------------------------|
+| ---------------------- | ------------------------------------------------- |
 | **Action**             | `untag_thread`                                    |
 | **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw` |
 | **Web API equivalent** | [`untag_thread`](../#untag-thread)                |
@@ -2379,9 +2379,9 @@ Returns the info about the Customer with a given `id`.
 
 #### Request
 
-| Parameter     | Required | Data type | Notes |
-| ------------- | -------- | --------- | ----- |
-| `id`          | Yes      | string    |       |
+| Parameter | Required | Data type | Notes |
+| --------- | -------- | --------- | ----- |
+| `id`      | Yes      | string    |       |
 
 #### Response
 
@@ -2488,7 +2488,7 @@ It returns the list of Customers.
 #### Specifics
 
 |                        |                                        |
-|------------------------|----------------------------------------|
+| ---------------------- | -------------------------------------- |
 | **Action**             | `list_customers`                       |
 | **Required scopes**    | `customers:ro`                         |
 | **Web API equivalent** | [`list_customers`](../#list-customers) |
@@ -2499,7 +2499,7 @@ It returns the list of Customers.
 All parameters are optional.
 
 | Parameter                                                                      | Data type | Notes                     |
-|--------------------------------------------------------------------------------|-----------|---------------------------|
+| ------------------------------------------------------------------------------ | --------- | ------------------------- |
 | `page_id`                                                                      | `string`  |                           |
 | `limit`                                                                        | `number`  | Default: 10, maximum: 100 |
 | `sort_order` **\***                                                            | `string`  | Default: `desc`           |
@@ -2555,10 +2555,10 @@ Dates are represented in ISO 8601 format with microseconds resolution, e.g. `201
 
 #### Response
 
-| Parameter         | Data type | Notes                                              |
-| ----------------- | --------- | -------------------------------------------------- |
-| `next_page_id`    | `string`  | In relation to `page_id` specified in the request. |
-| `previous_page_id`| `string`  | In relation to `page_id` specified in the request. |
+| Parameter          | Data type | Notes                                              |
+| ------------------ | --------- | -------------------------------------------------- |
+| `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
+| `previous_page_id` | `string`  | In relation to `page_id` specified in the request. |
 
 </Text>
 <Code>
@@ -2605,12 +2605,12 @@ Creates a new [Customer](#customer) user type.
 
 #### Specifics
 
-|                        |                                         |
-| ---------------------- | --------------------------------------- |
-| **Action**             | `create_customer`                       |
-| **Required scopes**    | `customers:rw`                          |
-| **Web API equivalent** | [`create_customer`](../#create-customer)  |
-| **Push message**       | [`customer_created`](#customer_created) |
+|                        |                                          |
+| ---------------------- | ---------------------------------------- |
+| **Action**             | `create_customer`                        |
+| **Required scopes**    | `customers:rw`                           |
+| **Web API equivalent** | [`create_customer`](../#create-customer) |
+| **Push message**       | [`customer_created`](#customer_created)  |
 
 #### Request
 
@@ -2747,11 +2747,11 @@ Bans the customer for a specific period of time. It immediately disconnects all 
 
 #### Request
 
-| Parameter     | Required | Data type |     |
-| ------------- | -------- | --------- | --- |
-| `id`          | Yes      | `string`  |     |
-| `ban`         | Yes      | `object`  |     |
-| `ban.days`    | Yes      | `number`  |     |
+| Parameter  | Required | Data type |     |
+| ---------- | -------- | --------- | --- |
+| `id`       | Yes      | `string`  |     |
+| `ban`      | Yes      | `object`  |     |
+| `ban.days` | Yes      | `number`  |     |
 
 </Text>
 <Code>
@@ -2801,7 +2801,7 @@ It returns the initial state of the current Agent.
 #### Specifics
 
 |                        |                                                                                        |
-|------------------------|----------------------------------------------------------------------------------------|
+| ---------------------- | -------------------------------------------------------------------------------------- |
 | **Action**             | `login`                                                                                |
 | **Required scopes**    | `chats--access:ro` `customers:ro` `multicast:ro` `agents--all:ro` `agents-bot--all:ro` |
 | **Web API equivalent** | -                                                                                      |
@@ -2820,17 +2820,17 @@ It returns the initial state of the current Agent.
 | `application`                       | No       | `object`  |                                                                                                                                  |
 | `application.name`                  | No       | `string`  | Application name                                                                                                                 |
 | `application.version`               | No       | `string`  | Application version                                                                                                              |
-| `away` __*__                        | No       | `bool`    | When `true`, the connection is set to the `away` state. Defaults to `false`.  |
+| `away` __*__                        | No       | `bool`    | When `true`, the connection is set to the `away` state. Defaults to `false`.                                                     |
 
 __*__ You can use the `away` param to **prevent assigning chats** to Agents **after random reconnections** when their status was set to `not_accepting_chats` by the auto-away feature. When an Agent logs in with `away: true`, the connection is immediately recognized
 as `away`. [Read more...](#set-away-status)
 
 #### Response
 
-| Parameter     | Data type | Notes |
-| ------------- | --------- | ----- |
-| `access`      | `object`  |       |
-| `properties`  | `object`  |       |
+| Parameter    | Data type | Notes |
+| ------------ | --------- | ----- |
+| `access`     | `object`  |       |
+| `properties` | `object`  |       |
 
 </Text>
 <Code>
@@ -3052,19 +3052,19 @@ Unlike [**Set Away Status**](#set-away-status), which is another mechanism of st
 
 #### Specifics
 
-|                        |                                                                            |
-| ---------------------- | -------------------------------------------------------------------------- |
-| **Action**             | `set_routing_status`                                                       |
-| **Required scopes**    | for Agents: `agents--my:rw` `agents--all:rw`; for Bot Agents: `agents-bot--my:rw` `agents-bot--all:rw`|
-| **Web API equivalent** | [`set_routing_status`](../#set-routing-status)                             |
-| **Push message**       | [`routing_status_set`](#routing_status_set)  |
+|                        |                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Action**             | `set_routing_status`                                                                                   |
+| **Required scopes**    | for Agents: `agents--my:rw` `agents--all:rw`; for Bot Agents: `agents-bot--my:rw` `agents-bot--all:rw` |
+| **Web API equivalent** | [`set_routing_status`](../#set-routing-status)                                                         |
+| **Push message**       | [`routing_status_set`](#routing_status_set)                                                            |
 
 #### Request
 
-| Parameter  | Required | Data type| Notes                                                            |
-| -----------| -------- | -------- | ---------------------------------------------------------------- |
-| `status`   |   Yes    | `string` | For Agents: `accepting_chats` or `not_accepting_chats`; for Bot Agents: `accepting_chats`, `not_accepting_chats`, or `offline` |
-| `agent_id` |   No     | `string` | If not specified, the requester's status will be updated.        |
+| Parameter  | Required | Data type | Notes                                                                                                                          |
+| ---------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `status`   | Yes      | `string`  | For Agents: `accepting_chats` or `not_accepting_chats`; for Bot Agents: `accepting_chats`, `not_accepting_chats`, or `offline` |
+| `agent_id` | No       | `string`  | If not specified, the requester's status will be updated.                                                                      |
 
 </Text>
 <Code>
@@ -3156,19 +3156,19 @@ Logs the Agent out.
 
 #### Specifics
 
-|                        |                                                               |
-| ---------------------- | ------------------------------------------------------------- |
-| **Action**             | `mark_events_as_seen`                                         |
-| **Required scopes**    | `chats--access:ro` `chats--all:ro`                            |
-| **Web API equivalent** | [`mark_events_as_seen`](../#mark-events-as-seen)              |
+|                        |                                                   |
+| ---------------------- | ------------------------------------------------- |
+| **Action**             | `mark_events_as_seen`                             |
+| **Required scopes**    | `chats--access:ro` `chats--all:ro`                |
+| **Web API equivalent** | [`mark_events_as_seen`](../#mark-events-as-seen)  |
 | **Push message**       | [`events_marked_as_seen`](#events_marked_as_seen) |
 
 #### Request
 
-| Parameter    | Required | Data type   | Notes |
-| ------------ | -------- | ----------- | ----- |
-| `chat_id`    | Yes      | `string`    |       |
-| `seen_up_to` | Yes      | `string`    | RFC 3339 date-time format |
+| Parameter    | Required | Data type | Notes                     |
+| ------------ | -------- | --------- | ------------------------- |
+| `chat_id`    | Yes      | `string`  |                           |
+| `seen_up_to` | Yes      | `string`  | RFC 3339 date-time format |
 
 </Text>
 <Code>
@@ -3281,7 +3281,7 @@ For example, it could be used in an app that sends notifications to Agents or Cu
 #### Request
 
 | Parameter    | Required | Data type | Notes                     |
-|--------------|----------|-----------|---------------------------|
+| ------------ | -------- | --------- | ------------------------- |
 | `recipients` | Yes      | `object`  | **\***                    |
 | `content`    | Yes      | `any`     | A JSON message to be sent |
 | `type`       | No       | `string`  | Multicast message type    |
@@ -3367,7 +3367,7 @@ It returns the Agents you can transfer a chat to. Agents are sorted ascendingly 
 #### Specifics
 
 |                        |                                                            |
-|------------------------|------------------------------------------------------------|
+| ---------------------- | ---------------------------------------------------------- |
 | **Action**             | `list_agents_for_transfer`                                 |
 | **Required scopes**    | -                                                          |
 | **Web API equivalent** | [`list_agents_for_transfer`](../#list-agents-for-transfer) |
@@ -3375,9 +3375,9 @@ It returns the Agents you can transfer a chat to. Agents are sorted ascendingly 
 
 #### Request
 
-| Parameter  | Required | Data type | Notes                                   |
-| ---------- | -------- | --------- | --------------------------------------- |
-| `chat_id`  | Yes      | `string`  | The ID of the chat you want to transfer |
+| Parameter | Required | Data type | Notes                                   |
+| --------- | -------- | --------- | --------------------------------------- |
+| `chat_id` | Yes      | `string`  | The ID of the chat you want to transfer |
 
 </Text>
 <Code>
@@ -3428,19 +3428,19 @@ Here's what you need to know about **pushes**:
 - They notify you when specific events occur.
 - Can be **delivered** only in the websocket transport.
 - You don't need to register pushes to receive them.
-- Their equivalents in Web API are [webhooks](/management/configuration-api/#webhooks). Pushes and webhooks have similar payloads.
+- Their equivalents in Web API are [webhooks](/management/configuration-api/v3.3/#webhooks). Pushes and webhooks have similar payloads.
 - There are no retries for pushes. To determine if a user has seen an event, compare the [event's](#response) `created_at` parameter with the [user's](#users) `events_seen_up_to` field.
 
-|                 |                                                                                                                                                                                                                                                                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                                   |
-| **Chat access** | [`chat_access_granted`](#chat_access_granted) [`chat_access_revoked`](#chat_access_revoked) [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                           |
+|                 |                                                                                                                                                                                                                                                                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                       |
+| **Chat access** | [`chat_access_granted`](#chat_access_granted) [`chat_access_revoked`](#chat_access_revoked) [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                             |
 | **Chat users**  | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                 |
-| **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                            |
+| **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                        |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
 | **Thread tags** | [`thread_tagged`](#thread_tagged) [`thread_untagged`](#thread_untagged)                                                                                                                                                                                                                                                                         |
-| **Customers**   | [`customer_visit_started`](#customer_visit_started) [`customer_created`](#customer_created) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_banned`](#customer_banned) [`customer_visit_ended`](#customer_visit_ended)                                                                                         |
-| **Status**      | [`routing_status_set`](#routing_status_set) [`agent_disconnected`](#agent_disconnected)                                                                                                                                                                                                                                                                             |
+| **Customers**   | [`customer_visit_started`](#customer_visit_started) [`customer_created`](#customer_created) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_banned`](#customer_banned) [`customer_visit_ended`](#customer_visit_ended)                                                                     |
+| **Status**      | [`routing_status_set`](#routing_status_set) [`agent_disconnected`](#agent_disconnected)                                                                                                                                                                                                                                                         |
 | **Other**       | [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_sneak_peek`](#incoming_sneak_peek) [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`chat_unfollowed`](#chat_unfollowed) [`queue_positions_updated`](#queue_positions_updated)                                               |
 
 </Text>
@@ -3504,7 +3504,7 @@ Informs about a chat coming with a new thread. The push payload contains the who
 #### Specifics
 
 |                        |                                                                 |
-|------------------------|-----------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------- |
 | **Action**             | `incoming_chat`                                                 |
 | **Webhook equivalent** | [`incoming_chat`](/management/configuration-api/#incoming_chat) |
 
@@ -3527,7 +3527,7 @@ Informs that a chat was deactivated by closing the currently open thread.
 #### Specifics
 
 |                        |                                                                       |
-|------------------------|-----------------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------------- |
 | **Action**             | `chat_deactivated`                                                    |
 | **Webhook equivalent** | [`chat_deactivated`](/management/configuration-api/#chat_deactivated) |
 
@@ -3558,16 +3558,16 @@ Informs that new, single access to a chat was granted. The existing access isn't
 
 #### Specifics
 
-|                        |                                                                             |
-| ---------------------- | --------------------------------------------------------------------------- |
-| **Action**             | `chat_access_granted`                                                       |
+|                        |                                                                                  |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| **Action**             | `chat_access_granted`                                                            |
 | **Webhook equivalent** | [`chat_access_granted`](/management/configuration-api/v3.3/#chat_access_granted) |
 
 #### Push payload
 
-| Object     | Notes         |
-| ---------- | ------------- |
-| `id`       | Chat id   |
+| Object | Notes   |
+| ------ | ------- |
+| `id`   | Chat id |
 
 ### `chat_access_revoked`
 
@@ -3588,16 +3588,16 @@ Informs that access to a certain chat was revoked.
 
 #### Specifics
 
-|                        |                                                                             |
-| ---------------------- | --------------------------------------------------------------------------- |
-| **Action**             | `chat_access_revoked`                                                       |
+|                        |                                                                                  |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| **Action**             | `chat_access_revoked`                                                            |
 | **Webhook equivalent** | [`chat_access_revoked`](/management/configuration-api/v3.3/#chat_access_revoked) |
 
 #### Push payload
 
-| Object     | Notes         |
-| ---------- | ------------- |
-| `id`       | Chat Id   |
+| Object | Notes   |
+| ------ | ------- |
+| `id`   | Chat Id |
 
 ### `chat_transferred`
 
@@ -3633,8 +3633,8 @@ Informs that a chat was transferred to a different group or to an Agent.
 
 #### Push payload
 
-| Object | Notes                        |
-| ------ | ---------------------------- |
+| Object           | Notes                                                |
+| ---------------- | ---------------------------------------------------- |
 | `thread_id`      | present if the chat is active                        |
 | `transferred_to` | IDs of groups and Agents the chat is now assigned to |
 | `queue`          | present if the chat is queued after the transfer     |
@@ -3665,15 +3665,15 @@ This push can be emitted with `user.present` set to `false` when a user writes t
 
 #### Specifics
 
-|                        |                                                             |
-| ---------------------- | ----------------------------------------------------------- |
+|                        |                                                                           |
+| ---------------------- | ------------------------------------------------------------------------- |
 | **Action**             | `user_added_to_chat`                                                      |
 | **Webhook equivalent** | [`user_added_to_chat`](/management/configuration-api/#user_added_to_chat) |
 
 #### Push payload
 
-| Object      | Notes                                |
-| ----------- | ------------------------------------ |
+| Object         | Notes                                            |
+| -------------- | ------------------------------------------------ |
 | `thread_id`    | Present when a user was added to an active chat. |
 | `reason`       | Why the user was added.                          |
 | `requester_id` | Present if the user was added by an agent.       |
@@ -3698,15 +3698,15 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Specifics
 
-|                        |                                                                 |
-| ---------------------- | --------------------------------------------------------------- |
+|                        |                                                                                   |
+| ---------------------- | --------------------------------------------------------------------------------- |
 | **Action**             | `user_removed_from_chat`                                                          |
 | **Webhook equivalent** | [`user_removed_from_chat`](/management/configuration-api/#user_removed_from_chat) |
 
 #### Push payload
 
-| Object      | Notes                                |
-| ----------- | ------------------------------------ |
+| Object         | Notes                                                |
+| -------------- | ---------------------------------------------------- |
 | `thread_id`    | Present when a user was removed from an active chat. |
 | `reason`       | Why the user was removed.                            |
 | `requester_id` | Present if the user was removed by an agent.         |
@@ -3743,9 +3743,9 @@ Informs about an incoming [event](#events) sent to a chat.
 
 #### Specifics
 
-|                        |                                                           |
-| ---------------------- | --------------------------------------------------------- |
-| **Action**             | `incoming_event`                                          |
+|                        |                                                                   |
+| ---------------------- | ----------------------------------------------------------------- |
+| **Action**             | `incoming_event`                                                  |
 | **Webhook equivalent** | [`incoming_event`](/management/configuration-api/#incoming_event) |
 
 ### `event_updated`
@@ -3768,9 +3768,9 @@ Informs that an [event](#events) was updated.
 
 #### Specifics
 
-|                        |                                                         |
-| ---------------------- | ------------------------------------------------------- |
-| **Action**             | `event_updated`                                         |
+|                        |                                                                 |
+| ---------------------- | --------------------------------------------------------------- |
+| **Action**             | `event_updated`                                                 |
 | **Webhook equivalent** | [`event_updated`](/management/configuration-api/#event_updated) |
 
 ### `incoming_rich_message_postback`
@@ -3796,9 +3796,9 @@ Informs about an incoming [rich message](#rich-message) postback. The push paylo
 
 #### Specifics
 
-|                        |                                                                                           |
-| ---------------------- | ----------------------------------------------------------------------------------------- |
-| **Action**             | `incoming_rich_message_postback`                                                          |
+|                        |                                                                                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------- |
+| **Action**             | `incoming_rich_message_postback`                                                                  |
 | **Webhook equivalent** | [`incoming_rich_message_postback`](/management/configuration-api/#incoming_rich_message_postback) |
 
 ## Properties
@@ -3826,9 +3826,9 @@ Informs about those chat properties that were updated.
 
 #### Specifics
 
-|                        |                                                                             |
-| ---------------------- | --------------------------------------------------------------------------- |
-| **Action**             | `chat_properties_updated`                                                   |
+|                        |                                                                                     |
+| ---------------------- | ----------------------------------------------------------------------------------- |
+| **Action**             | `chat_properties_updated`                                                           |
 | **Webhook equivalent** | [`chat_properties_updated`](/management/configuration-api/#chat_properties_updated) |
 
 #### Push payload
@@ -3857,9 +3857,9 @@ Informs about those chat properties that were deleted.
 
 #### Specifics
 
-|                        |                                                                             |
-| ---------------------- | --------------------------------------------------------------------------- |
-| **Action**             | `chat_properties_deleted`                                                   |
+|                        |                                                                                     |
+| ---------------------- | ----------------------------------------------------------------------------------- |
+| **Action**             | `chat_properties_deleted`                                                           |
 | **Webhook equivalent** | [`chat_properties_deleted`](/management/configuration-api/#chat_properties_deleted) |
 
 #### Push payload
@@ -3893,7 +3893,7 @@ Informs about those thread properties that were updated.
 #### Specifics
 
 |                        |                                                                                         |
-|------------------------|-----------------------------------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------------------------------- |
 | **Action**             | `thread_properties_updated`                                                             |
 | **Webhook equivalent** | [`thread_properties_updated`](/management/configuration-api/#thread_properties_updated) |
 
@@ -3926,7 +3926,7 @@ Informs about those thread properties that were deleted.
 #### Specifics
 
 |                        |                                                                                         |
-|------------------------|-----------------------------------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------------------------------- |
 | **Action**             | `thread_properties_deleted`                                                             |
 | **Webhook equivalent** | [`thread_properties_deleted`](/management/configuration-api/#thread_properties_deleted) |
 
@@ -3960,9 +3960,9 @@ Informs about those event properties that were updated.
 
 #### Specifics
 
-|                        |                                                                               |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| **Action**             | `event_properties_updated`                                                    |
+|                        |                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------- |
+| **Action**             | `event_properties_updated`                                                            |
 | **Webhook equivalent** | [`event_properties_updated`](/management/configuration-api/#event_properties_updated) |
 
 #### Push payload
@@ -3993,9 +3993,9 @@ Informs about those event properties that were deleted.
 
 #### Specifics
 
-|                        |                                                                               |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| **Action**             | `event_properties_deleted`                                                    |
+|                        |                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------- |
+| **Action**             | `event_properties_deleted`                                                            |
 | **Webhook equivalent** | [`event_properties_deleted`](/management/configuration-api/#event_properties_deleted) |
 
 #### Push payload
@@ -4025,7 +4025,7 @@ Informs that a chat thread was tagged.
 #### Specifics
 
 |                        |                                                                 |
-|------------------------|-----------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------- |
 | **Action**             | `thread_tagged`                                                 |
 | **Webhook equivalent** | [`thread_tagged`](/management/configuration-api/#thread_tagged) |
 
@@ -4048,7 +4048,7 @@ Informs that a chat thread was untagged.
 #### Specifics
 
 |                        |                                                                     |
-|------------------------|---------------------------------------------------------------------|
+| ---------------------- | ------------------------------------------------------------------- |
 | **Action**             | `thread_untagged`                                                   |
 | **Webhook equivalent** | [`thread_untagged`](/management/configuration-api/#thread_untagged) |
 
@@ -4116,9 +4116,9 @@ Informs that a new Customer registered.
 
 #### Specifics
 
-|                        |                                                               |
-| ---------------------- | ------------------------------------------------------------- |
-| **Action**             | `customer_created`                                            |
+|                        |                                                                       |
+| ---------------------- | --------------------------------------------------------------------- |
+| **Action**             | `customer_created`                                                    |
 | **Webhook equivalent** | [`customer_created`](/management/configuration-api/#customer_created) |
 
 ### `customer_updated`
@@ -4247,10 +4247,10 @@ Informs that an Agent's or Bot Agent's status was changed.
 
 #### Specifics
 
-|                        |                      |
-| ---------------------- | -------------------- |
-| **Action**             | `routing_status_set` |
-| **Webhook equivalent** | [`routing_status_set`](/management/configuration-api/v3.3/#routing_status_set)|
+|                        |                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| **Action**             | `routing_status_set`                                                           |
+| **Webhook equivalent** | [`routing_status_set`](/management/configuration-api/v3.3/#routing_status_set) |
 
 ### `agent_disconnected`
 
@@ -4375,9 +4375,9 @@ Informs that a user has seen events up to a specific time.
 
 #### Specifics
 
-|                        |                                                                                     |
-| ---------------------- | ----------------------------------------------------------------------------------- |
-| **Action**             | `events_marked_as_seen`                                                       |
+|                        |                                                                                 |
+| ---------------------- | ------------------------------------------------------------------------------- |
+| **Action**             | `events_marked_as_seen`                                                         |
 | **Webhook equivalent** | [`events_marked_as_seen`](/management/configuration-api/#events_marked_as_seen) |
 
 ### `incoming_multicast`
@@ -4409,11 +4409,11 @@ Informs about messages sent via the `multicast` method or by the system.
 
 #### Push payload
 
-| Object      | Required | Notes |
-| ----------- | -------- | ----- |
+| Object      | Required | Notes                                                                                            |
+| ----------- | -------- | ------------------------------------------------------------------------------------------------ |
 | `author_id` | No       | Present only if the push was generated by the **Multicast** method and not sent from the server. |
-| `content`   | Yes      |       |
-| `type`      | No       |       |
+| `content`   | Yes      |                                                                                                  |
+| `type`      | No       |                                                                                                  |
 
 ### `chat_unfollowed`
 
@@ -4465,7 +4465,7 @@ New positions and wait times for queued chats.
 #### Specifics
 
 |                        |                           |
-|------------------------|---------------------------|
+| ---------------------- | ------------------------- |
 | **Action**             | `queue_positions_updated` |
 | **Webhook equivalent** | -                         |
 

--- a/content/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -178,18 +178,18 @@ The **Message** event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                         |
-| -------------------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `custom_id`          | no       | `string`  |                                                                                                                               |
+| Field                | Required | Data type | Notes                                                                                                                        |
+| -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `custom_id`          | no       | `string`  |                                                                                                                              |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
-| `type`               | yes      | `string`  | `message`                                                                                                                     |
-| `properties`         | no       | `object`  | [Properties](#properties)                                                                                                     |
-| `postback`           | no       | `object`  | Indicates that the message event was generated in response to a rich message event.                                           |
-| `postback.id`        | yes      | `string`  | ID of the postback from the rich message event.                                                                               |
-| `postback.thread_id` | yes      | `string`  | ID of the thread with the rich message event.                                                                                 |
-| `postback.event_id`  | yes      | `string`  | ID of the rich message event.                                                                                                 |
-| `postback.type`      | no       | `string`  | Should be used together with `postback.value` (when  one of them is present, the other is required).                                                                                |
-| `postback.value`     | no       | `string`  | Should be used together with `postback.type` (when  one of them is present, the other is required).                                                                                 |
+| `type`               | yes      | `string`  | `message`                                                                                                                    |
+| `properties`         | no       | `object`  | [Properties](#properties)                                                                                                    |
+| `postback`           | no       | `object`  | Indicates that the message event was generated in response to a rich message event.                                          |
+| `postback.id`        | yes      | `string`  | ID of the postback from the rich message event.                                                                              |
+| `postback.thread_id` | yes      | `string`  | ID of the thread with the rich message event.                                                                                |
+| `postback.event_id`  | yes      | `string`  | ID of the rich message event.                                                                                                |
+| `postback.type`      | no       | `string`  | Should be used together with `postback.value` (when  one of them is present, the other is required).                         |
+| `postback.value`     | no       | `string`  | Should be used together with `postback.type` (when  one of them is present, the other is required).                          |
 
 ### Response
 
@@ -227,46 +227,46 @@ Rich message event contains rich message data structure. [Read more](/extending-
 
 ### Request
 
-| Field                            | Required | Data type | Notes                                                                                             |
-| -------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------- |
-| `custom_id`                      | no       | `string`  | You can give your RM a custom ID.                                                                 |
-| `type`                           | yes      | `string`  | Event type: `rich_message`                                                                        |
-| `properties`                     | no       | `object`  | The [properties](#properties) data structure                                                      |
-| `template_id`                    | yes      | `string`  | Defines how every Rich Message will be presented. Values: `cards`, `sticker`, or `quick_replies`. |
-| `elements`                       | no       | `array`   | Can contain up to 10 `element` objects.                                                           |
-| `elements.title`                 | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.subtitle`              | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.image`                 | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`.|
-| `elements.buttons`               | no       | `array`   | Displays buttons. Can contain up to 13 `button` objects.                                          |
-| `elements.buttons.text`          | yes      | `string`  | Text displayed on a button.                                                                       |
-| `elements.buttons.type`          | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value`. Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)  |
-| `elements.buttons.value`         | yes      | `string`  | Should be used together with `elements.buttons.type`.                                             |
-| `elements.buttons.webview_height`| yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.         |
-| `elements.buttons.postback_id`   | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
-| `elements.buttons.user_ids`      | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.|
+| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
+| --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                |
+| `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                       |
+| `properties`                      | no       | `object`  | The [properties](#properties) data structure                                                                                                                                                                                                     |
+| `template_id`                     | yes      | `string`  | Defines how every Rich Message will be presented. Values: `cards`, `sticker`, or `quick_replies`.                                                                                                                                                |
+| `elements`                        | no       | `array`   | Can contain up to 10 `element` objects.                                                                                                                                                                                                          |
+| `elements.title`                  | yes      | `string`  | Displays formatted text on RMs.                                                                                                                                                                                                                  |
+| `elements.subtitle`               | yes      | `string`  | Displays formatted text on RMs.                                                                                                                                                                                                                  |
+| `elements.image`                  | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`.                                                                                                                               |
+| `elements.buttons`                | no       | `array`   | Displays buttons. Can contain up to 13 `button` objects.                                                                                                                                                                                         |
+| `elements.buttons.text`           | yes      | `string`  | Text displayed on a button.                                                                                                                                                                                                                      |
+| `elements.buttons.type`           | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value`. Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
+| `elements.buttons.value`          | yes      | `string`  | Should be used together with `elements.buttons.type`.                                                                                                                                                                                            |
+| `elements.buttons.webview_height` | yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.                                                                                                                                                        |
+| `elements.buttons.postback_id`    | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)                                                                      |
+| `elements.buttons.user_ids`       | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.                                                                                                                                                                                   |
 
 ### Response
 
-| Field                            | Returned   | Notes                                                               |
-| -------------------------------- | ---------- | ------------------------------------------------------------------- |
-| `id`                             | always     | Generated server-side                                               |
-| `custom_id`                      | optionally |                                                                     |
-| `type`                           | always     |                                                                     |
-| `author_id`                      | always     | Generated server-side                                               |
-| `created_at`                     | always     | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
-| `properties`                     | optionally |                                                                     |
-| `template_id`                    | always     |                                                                     |
-| `elements`                       | optionally |                                                                     |
-| `elements.title`                 | always     |                                                                     |
-| `elements.subtitle`              | always     |                                                                     |
-| `elements.image`                 | always     |                                                                     |
-| `elements.buttons`               | optionally |                                                                     |
-| `elements.buttons.text`          | always     |                                                                     |
-| `elements.buttons.type`          | always     |                                                                     |
-| `elements.buttons.value`         | always     |                                                                     |
-| `elements.buttons.webview_height`| always     | Unless button `type` is different than `webview`.                   |
-| `elements.buttons.postback_id`   | always     |                                                                     |
-| `elements.buttons.user_ids`      | always     |                                                                     |
+| Field                             | Returned   | Notes                                                                                      |
+| --------------------------------- | ---------- | ------------------------------------------------------------------------------------------ |
+| `id`                              | always     | Generated server-side                                                                      |
+| `custom_id`                       | optionally |                                                                                            |
+| `type`                            | always     |                                                                                            |
+| `author_id`                       | always     | Generated server-side                                                                      |
+| `created_at`                      | always     | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
+| `properties`                      | optionally |                                                                                            |
+| `template_id`                     | always     |                                                                                            |
+| `elements`                        | optionally |                                                                                            |
+| `elements.title`                  | always     |                                                                                            |
+| `elements.subtitle`               | always     |                                                                                            |
+| `elements.image`                  | always     |                                                                                            |
+| `elements.buttons`                | optionally |                                                                                            |
+| `elements.buttons.text`           | always     |                                                                                            |
+| `elements.buttons.type`           | always     |                                                                                            |
+| `elements.buttons.value`          | always     |                                                                                            |
+| `elements.buttons.webview_height` | always     | Unless button `type` is different than `webview`.                                          |
+| `elements.buttons.postback_id`    | always     |                                                                                            |
+| `elements.buttons.user_ids`       | always     |                                                                                            |
 
 </Text>
 
@@ -285,12 +285,12 @@ Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                               |                                                                                   |
-| ------------ | -------- | --------- | ------------------------------------------------------------------- |
-| `custom_id`  | no       | `string`  | You can give the event a custom ID.                                 |
-| `type`       | yes      | `string`  | Event type: `custom`                                                |
-| `content`    | no       | `object`  | The content you define                                              |
-| `properties` | no       | `object`  | The [properties](#properties) data structure                        |
+| Field        | Required | Data type | Notes                                        |  |
+| ------------ | -------- | --------- | -------------------------------------------- |
+| `custom_id`  | no       | `string`  | You can give the event a custom ID.          |
+| `type`       | yes      | `string`  | Event type: `custom`                         |
+| `content`    | no       | `object`  | The content you define                       |
+| `properties` | no       | `object`  | The [properties](#properties) data structure |
 
 ### Response
 
@@ -321,13 +321,13 @@ System message event is a native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type |                                                                                                                            Notes |
-| --------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `custom_id`           | no       | `string`  |                                                                                     You can give the system message a custom ID. |
-| `type`                | yes      | `string`  |                                                                                                                 `system_message` |
-| `text`                | no       | `string`  |                                                                                                     Text displayed to recipients |
-| `system_message_type` | yes      | `string`  |                                                                                [System message type](/messaging/references/system-messages/) |
-| `text_vars`           | no       | `object`  |                                                                                                       Variables used in the text |
+| Field                 | Required | Data type | Notes                                                         |
+| --------------------- | -------- | --------- | ------------------------------------------------------------- |
+| `custom_id`           | no       | `string`  | You can give the system message a custom ID.                  |
+| `type`                | yes      | `string`  | `system_message`                                              |
+| `text`                | no       | `string`  | Text displayed to recipients                                  |
+| `system_message_type` | yes      | `string`  | [System message type](/messaging/references/system-messages/) |
+| `text_vars`           | no       | `object`  | Variables used in the text                                    |
 
 ### Response
 
@@ -364,6 +364,7 @@ System message event is a native system event sent in specific situations.
 | `email`          | optional  |                                                                                           |
 | `name`           | optional  |                                                                                           |
 | `session_fields` | optional  | An array of custom object-enclosed `key:value` pairs. Available for the session duration. |
+| `events_seen_up_to`| optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Customer—all the previous events are considered seen. |
 
 ## Agent
 
@@ -459,14 +460,14 @@ When connecting to the Customer Chat RTM API, clients have to send over the requ
 
 ## Available methods
 
-|                |                                                                                                                                                                                                                                                                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**      | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat)                                                                                                                 |
-| **Events**     | [`send_event`](#send-event) [`send_rich_message_postback`](#send-rich-message-postback) [`send_sneak_peek`](#send-sneak-peek)                                                                                                                                                                                                                           |
+|                |                                                                                                                                                                                                                                                                                                                                     |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Chats**      | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat)                                                                                                                                             |
+| **Events**     | [`send_event`](#send-event) [`send_rich_message_postback`](#send-rich-message-postback) [`send_sneak_peek`](#send-sneak-peek)                                                                                                                                                                                                       |
 | **Properties** | [`update_chat_properties`](#update-chat-properties) [`delete_chat_properties`](#delete-chat-properties) [`update_thread_properties`](#update-thread-properties) [`delete_thread_properties`](#delete-thread-properties) [`update_event_properties`](#update-event-properties) [`delete_event_properties`](#delete-event-properties) |
-| **Customers**  | [`update_customer`](#update-customer) [`update_customer_page`](#update-customer-page) [`set_customer_session_fields`](#set-customer-session-fields) [`get_customer`](#get-customer)                                                                                                                                                                     |
-| **Status**     | [`login`](#login) [`list_group_statuses`](#list-group-statuses)                                                                                                                                                                                                                                                                                             |
-| **Other**      | [`get_form`](#get-form) [`get_predicted_agent`](#get-predicted-agent) [`get_url_info`](#get-url-info) [`mark_events_as_seen`](#mark-events-as-seen) [`accept_greeting`](#accept-greeting) [`cancel_greeting`](#cancel-greeting)                                                                                                                   |
+| **Customers**  | [`update_customer`](#update-customer) [`update_customer_page`](#update-customer-page) [`set_customer_session_fields`](#set-customer-session-fields) [`get_customer`](#get-customer)                                                                                                                                                 |
+| **Status**     | [`login`](#login) [`list_group_statuses`](#list-group-statuses)                                                                                                                                                                                                                                                                     |
+| **Other**      | [`get_form`](#get-form) [`get_predicted_agent`](#get-predicted-agent) [`get_url_info`](#get-url-info) [`mark_events_as_seen`](#mark-events-as-seen) [`accept_greeting`](#accept-greeting) [`cancel_greeting`](#cancel-greeting)                                                                                                     |
 
 </Text>
 
@@ -519,7 +520,7 @@ It returns [summaries](#chat-summaries) of the chats a Customer participated in.
 #### Specifics
 
 |                        |                                |
-|------------------------|--------------------------------|
+| ---------------------- | ------------------------------ |
 | **Action**             | `list_chats`                   |
 | **Web API equivalent** | [`list_chats`](../#list-chats) |
 | **Push message**       | -                              |
@@ -623,20 +624,20 @@ It returns threads that the current Customer has access to in a given chat.
 
 #### Specifics
 
-|                        |                                                   |
-|------------------------|---------------------------------------------------|
-| **Action**             | `list_threads`                                      |
-| **Web API equivalent** | [`list_threads`](../#list-threads)                    |
-| **Push message**       | -                                                 |
+|                        |                                    |
+| ---------------------- | ---------------------------------- |
+| **Action**             | `list_threads`                     |
+| **Web API equivalent** | [`list_threads`](../#list-threads) |
+| **Push message**       | -                                  |
 
 #### Request
 
-| Parameter          | Required | Data type | Notes                                                                                      |
-| ------------------ | -------- | --------- | ------------------------------------------------------------------------------------------ |
-| `chat_id`          | Yes      | `string`  |                                                                                            |
-| `sort_order`       | No       | `string`  | Possible values: `asc` - oldest threads first and `desc` - newest threads first (default). |
-| `limit`            | No       | `number`  | Default: 3, maximum: 100                                                                   |
-| `page_id`          | No       | `string`  |                                                                                            |
+| Parameter          | Required | Data type | Notes                                                                                                                                                                                                                                                       |
+| ------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`          | Yes      | `string`  |                                                                                                                                                                                                                                                             |
+| `sort_order`       | No       | `string`  | Possible values: `asc` - oldest threads first and `desc` - newest threads first (default).                                                                                                                                                                  |
+| `limit`            | No       | `number`  | Default: 3, maximum: 100                                                                                                                                                                                                                                    |
+| `page_id`          | No       | `string`  |                                                                                                                                                                                                                                                             |
 | `min_events_count` | No       | `number`  | Range: 1-100; Specifies the minimum number of events to be returned in the response. It's the **total** number of events, so they can come from more than one thread. You'll get as many latest threads as needed to meet the `min_events_count` condition. |
 
 You cannot use both `limit` and `min_events_count` at the same time.
@@ -711,7 +712,7 @@ You cannot use both `limit` and `min_events_count` at the same time.
 #### Specifics
 
 |                        |                            |
-|------------------------|----------------------------|
+| ---------------------- | -------------------------- |
 | **Action**             | `get_chat`                 |
 | **Web API equivalent** | [`get_chat`](../#get-chat) |
 | **Push message**       | -                          |
@@ -719,7 +720,7 @@ You cannot use both `limit` and `min_events_count` at the same time.
 #### Request
 
 | Parameter   | Required | Data type |                                        |
-|-------------|----------|-----------|----------------------------------------|
+| ----------- | -------- | --------- | -------------------------------------- |
 | `chat_id`   | Yes      | `string`  |                                        |
 | `thread_id` | No       | `string`  | Default: the latest thread (if exists) |
 
@@ -818,7 +819,7 @@ Starts a chat.
 #### Specifics
 
 |                        |                                   |
-|------------------------|-----------------------------------|
+| ---------------------- | --------------------------------- |
 | **Action**             | `start_chat`                      |
 | **Web API equivalent** | [`start_chat`](../#start-chat)    |
 | **Push message**       | [`incoming_chat`](#incoming_chat) |
@@ -826,7 +827,7 @@ Starts a chat.
 #### Request
 
 | Parameters               | Required | Data type | Notes                                                                       |
-|--------------------------|----------|-----------|-----------------------------------------------------------------------------|
+| ------------------------ | -------- | --------- | --------------------------------------------------------------------------- |
 | `chat`                   | No       | `object`  |                                                                             |
 | `chat.properties`        | No       | `object`  | Initial chat properties                                                     |
 | `chat.access`            | No       | `object`  | Chat access to set, default: all agents.                                    |
@@ -929,7 +930,7 @@ Used to restart an archived chat.
 #### Specifics
 
 |                        |                                      |
-|------------------------|--------------------------------------|
+| ---------------------- | ------------------------------------ |
 | **Action**             | `activate_chat`                      |
 | **Web API equivalent** | [`activate_chat`](../#activate-chat) |
 | **Push message**       | [`incoming_chat`](#incoming_chat)    |
@@ -937,7 +938,7 @@ Used to restart an archived chat.
 #### Request
 
 | Request object           | Required | Type     | Notes                                                                      |
-|--------------------------|----------|----------|----------------------------------------------------------------------------|
+| ------------------------ | -------- | -------- | -------------------------------------------------------------------------- |
 | `chat`                   | Yes      | `object` |                                                                            |
 | `chat.id`                | Yes      | `string` | The ID of the chat that will be activated.                                 |
 | `chat.access`            | No       | `object` | Chat access to set, default: all agents.                                   |
@@ -1043,7 +1044,7 @@ Deactivates a chat by closing the currently open thread. Sending messages to thi
 #### Specifics
 
 |                        |                                                                                 |
-|------------------------|---------------------------------------------------------------------------------|
+| ---------------------- | ------------------------------------------------------------------------------- |
 | **Action**             | `deactivate_chat`                                                               |
 | **Web API equivalent** | [`deactivate_chat`](../#deactivate-chat)                                        |
 | **Push message**       | [`incoming_event`](#incoming_event) and [`chat_deactivated`](#chat_deactivated) |
@@ -1463,7 +1464,7 @@ Sends a sneak peek to a chat.
 #### Specifics
 
 |                        |                                                            |
-|------------------------|------------------------------------------------------------|
+| ---------------------- | ---------------------------------------------------------- |
 | **Action**             | `update_thread_properties`                                 |
 | **Web API equivalent** | [`update_thread_properties`](../#update-thread-properties) |
 | **Push message**       | [`thread_properties_updated`](#thread_properties_updated)  |
@@ -1528,7 +1529,7 @@ Sends a sneak peek to a chat.
 #### Specifics
 
 |                        |                                                            |
-|------------------------|------------------------------------------------------------|
+| ---------------------- | ---------------------------------------------------------- |
 | **Action**             | `delete_thread_properties`                                 |
 | **Web API equivalent** | [`delete_thread_properties`](../#delete-thread-properties) |
 | **Push message**       | [`thread_properties_deleted`](#thread_properties_deleted)  |
@@ -1536,7 +1537,7 @@ Sends a sneak peek to a chat.
 #### Request
 
 | Parameter    | Required | Data type | Notes                                                  |
-|--------------|----------|-----------|--------------------------------------------------------|
+| ------------ | -------- | --------- | ------------------------------------------------------ |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete the properties of.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to delete the properties of. |
 | `properties` | Yes      | `object`  | Thread properties to delete.                           |
@@ -2127,7 +2128,7 @@ It returns the initial state of the current Customer.
 #### Specifics
 
 |                        |                                                  |
-|------------------------|--------------------------------------------------|
+| ---------------------- | ------------------------------------------------ |
 | **Action**             | `list_group_statuses`                            |
 | **Web API equivalent** | [`list_group_statuses`](../#list-group-statuses) |
 | **Push message**       | -                                                |
@@ -2367,7 +2368,7 @@ It returns the info on a given URL.
 #### Specifics
 
 |                        |                                    |
-|------------------------|------------------------------------|
+| ---------------------- | ---------------------------------- |
 | **Action**             | `get_url_info`                     |
 | **Web API equivalent** | [`get_url_info`](../#get-url-info) |
 | **Push message**       | -                                  |
@@ -2613,18 +2614,18 @@ Here's what you need to know about **pushes**:
 - They notify you when specific events occur.
 - Can be **delivered** only in the websocket transport.
 - You don't need to register pushes to receive them.
-- Their equivalents in Web API are [webhooks](/management/configuration-api/#webhooks).
-- Pushes and webhooks have similar payloads.
+- Their equivalents in Web API are [webhooks](/management/configuration-api/#webhooks). Pushes and webhooks have similar payloads.
+- There are no retries for pushes. To determine if a customer has seen an event, compare the [event's](#response) `created_at` parameter with the [customer's](#customer) `events_seen_up_to` field.
 
-|                 |                                                                                                                                                                                                                                                                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                                   |
-| **Chat access** | [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                                                                                                                       |
+|                 |                                                                                                                                                                                                                                                                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                       |
+| **Chat access** | [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                                                                                                                         |
 | **Chat users**  | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                 |
-| **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                            |
+| **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                        |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
-| **Customers**   | [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                                         |
-| **Status**      | [`customer_disconnected`](#customer_disconnected)                                                                                                                                                                                                                                                                                                                   |
+| **Customers**   | [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                     |
+| **Status**      | [`customer_disconnected`](#customer_disconnected)                                                                                                                                                                                                                                                                                               |
 | **Other**       | [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_greeting`](#incoming_greeting) [`greeting_accepted`](#greeting_accepted) [`greeting_canceled`](#greeting_canceled) [`queue_position_updated`](#queue_position_updated)       |
 
 </Text>
@@ -2688,7 +2689,7 @@ Informs about a chat coming with a new thread. The push payload contains the who
 #### Specifics
 
 |                        |                                                                 |
-|------------------------|-----------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------- |
 | **Action**             | `incoming_chat`                                                 |
 | **Webhook equivalent** | [`incoming_chat`](/management/configuration-api/#incoming_chat) |
 
@@ -2711,7 +2712,7 @@ Informs that a chat was deactivated by closing the currently open thread.
 #### Specifics
 
 |                        |                                                                       |
-|------------------------|-----------------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------------- |
 | **Action**             | `chat_deactivated`                                                    |
 | **Webhook equivalent** | [`chat_deactivated`](/management/configuration-api/#chat_deactivated) |
 
@@ -2757,8 +2758,8 @@ Informs that a chat was transferred to a different group or to an Agent.
 
 #### Push payload
 
-| Object | Notes                                  |
-| ------ | -------------------------------------- |
+| Object           | Notes                                                  |
+| ---------------- | ------------------------------------------------------ |
 | `thread_id`      | Present if the chat is active                          |
 | `transferred_to` | IDs of groups and Agents the chat has been assigned to |
 | `queue`          | Present if the chat is queued after the transfer       |
@@ -2789,15 +2790,15 @@ This push can be emitted with `user.present` set to `false` when a user writes t
 
 #### Specifics
 
-|                        |                                                                     |
-| ---------------------- | ------------------------------------------------------------------- |
-| **Action**             | `user_added_to_chat`                                                   |
+|                        |                                                                           |
+| ---------------------- | ------------------------------------------------------------------------- |
+| **Action**             | `user_added_to_chat`                                                      |
 | **Webhook equivalent** | [`user_added_to_chat`](/management/configuration-api/#user_added_to_chat) |
 
 #### Push payload
 
-| Object      | Notes                                            |
-| ----------- | ------------------------------------------------ |
+| Object         | Notes                                            |
+| -------------- | ------------------------------------------------ |
 | `thread_id`    | Present when a user was added to an active chat. |
 | `reason`       | Why the user was added.                          |
 | `requester_id` | Present if the user was added by an agent.       |
@@ -2822,15 +2823,15 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Specifics
 
-|                        |                                                                         |
-| ---------------------- | ----------------------------------------------------------------------- |
-| **Action**             | `user_removed_from_chat`                                                     |
+|                        |                                                                                   |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| **Action**             | `user_removed_from_chat`                                                          |
 | **Webhook equivalent** | [`user_removed_from_chat`](/management/configuration-api/#user_removed_from_chat) |
 
 #### Push payload
 
-| Object      | Notes                                                |
-| ----------- | ---------------------------------------------------- |
+| Object         | Notes                                                |
+| -------------- | ---------------------------------------------------- |
 | `thread_id`    | Present when a user was removed from an active chat. |
 | `reason`       | Why the user was removed.                            |
 | `requester_id` | Present if the user was removed by an agent.         |
@@ -3015,7 +3016,7 @@ Informs about those thread properties that were updated.
 #### Specifics
 
 |                        |                                                                                         |
-|------------------------|-----------------------------------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------------------------------- |
 | **Action**             | `thread_properties_updated`                                                             |
 | **Webhook equivalent** | [`thread_properties_updated`](/management/configuration-api/#thread_properties_updated) |
 
@@ -3047,7 +3048,7 @@ Informs about those thread properties that were deleted.
 #### Specifics
 
 |                        |                                                                                         |
-|------------------------|-----------------------------------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------------------------------- |
 | **Action**             | `thread_properties_deleted`                                                             |
 | **Webhook equivalent** | [`thread_properties_deleted`](/management/configuration-api/#thread_properties_deleted) |
 
@@ -3385,14 +3386,14 @@ Informs about an incoming [greeting](https://www.livechatinc.com/help/why-should
 
 #### Push payload
 
-| Object                 | Notes                                                       |
-| ---------------------- | ----------------------------------------------------------- |
-| `id`                   | ID of the greeting configured within the license.           |
-| `unique_id`            | ID of the greeting that was generated, sent, and cancelled. |
-| `event`                | Greeting event ([Message](#message) or [Rich message](#rich-message))                    |
-| `displayed_first_time` | `true` if the greeting was generated for the first time.    |
-| `agent`                | Info about the Agent who sent the greeting.                 |
-| `addon`                | Additional greeting property                  |
+| Object                 | Notes                                                                 |
+| ---------------------- | --------------------------------------------------------------------- |
+| `id`                   | ID of the greeting configured within the license.                     |
+| `unique_id`            | ID of the greeting that was generated, sent, and cancelled.           |
+| `event`                | Greeting event ([Message](#message) or [Rich message](#rich-message)) |
+| `displayed_first_time` | `true` if the greeting was generated for the first time.              |
+| `agent`                | Info about the Agent who sent the greeting.                           |
+| `addon`                | Additional greeting property                                          |
 
 ### `greeting_accepted`
 

--- a/content/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -358,13 +358,13 @@ System message event is a native system event sent in specific situations.
 
 <CodeResponse version="v3.2" type="customer" title={'Sample Customer data structure'} json="customer"/>
 
-| Field            | Req./Opt. |                                                                                           |
-| ---------------- | --------- | ----------------------------------------------------------------------------------------- |
-| `avatar`         | optional  |                                                                                           |
-| `email`          | optional  |                                                                                           |
-| `name`           | optional  |                                                                                           |
-| `session_fields` | optional  | An array of custom object-enclosed `key:value` pairs. Available for the session duration. |
-| `events_seen_up_to`| optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Customer—all the previous events are considered seen. |
+| Field               | Req./Opt. |                                                                                                                                    |
+| ------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `avatar`            | optional  |                                                                                                                                    |
+| `email`             | optional  |                                                                                                                                    |
+| `name`              | optional  |                                                                                                                                    |
+| `session_fields`    | optional  | An array of custom object-enclosed `key:value` pairs. Available for the session duration.                                          |
+| `events_seen_up_to` | optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Customer—all the previous events are considered seen. |
 
 ## Agent
 

--- a/content/messaging/customer-chat-api/v3.1/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.1/rtm-reference/index.mdx
@@ -566,12 +566,13 @@ System message event is a native system event sent in specific situations.
 
 </CodeResponse>
 
-| Field    | Req./Opt. |      |
+| Field    | Req./Opt. | Notes|
 | -------- | :-------: | ---: |
 | `avatar` | optional  |      |
 | `email`  | optional  |      |
 | `name`   | optional  |      |
 | `fields` | optional  |      |
+| `events_seen_up_to`| optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Customer—all the previous events are considered seen. |
 
 ## Agent
 
@@ -2726,11 +2727,11 @@ No response payload (`200 OK`).
 Here's what you need to know about **pushes**:
 
 - They are generated primarily by RTM API actions, but also by Web API actions.
-- They notify you when specific events occur. 
-- Can be **delivered** only in the websocket transport. 
-- You don't need to register pushes to receive them. 
-- Their equivalents in Web API are [webhooks](/management/configuration-api/v3.1/#webhooks). 
-- Pushes and webhooks have similar payloads.
+- They notify you when specific events occur.
+- Can be **delivered** only in the websocket transport.
+- You don't need to register pushes to receive them.
+- Their equivalents in Web API are [webhooks](/management/configuration-api/v3.1/#webhooks). Pushes and webhooks have similar payloads.
+- There are no retries for pushes. To determine if a customer has seen an event, compare the [event's](#response) `created_at` parameter with the [customer's](#customer) `events_seen_up_to` field.
 
 |                 |                                                                                                                                                                                                                                                                                                                                                                     |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/content/messaging/customer-chat-api/v3.1/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.1/rtm-reference/index.mdx
@@ -96,11 +96,11 @@ File event informs about a file being uploaded.
 
 ### Request
  
-| Field        | Required | Data type |                                                                                                                                     Notes |
-| ------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
-| `custom_id`  | no       | `string`  |                                                                                                                                           |
-| `type`       | yes      | `string`  |                                                                                                                                    `file` |
-| `properties` | no       | `object`  |                                                                                                                 [Properties](#properties) |
+| Field        | Required | Data type |                                                                                                                                          Notes |
+| ------------ | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------: |
+| `custom_id`  | no       | `string`  |                                                                                                                                                |
+| `type`       | yes      | `string`  |                                                                                                                                         `file` |
+| `properties` | no       | `object`  |                                                                                                                      [Properties](#properties) |
 | `url`        | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/v3.1/#upload-file). |
 
 ### Response
@@ -257,18 +257,18 @@ Message event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                         |
-| -------------------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `custom_id`          | no       | `string`  |                                                                                                                               |
+| Field                | Required | Data type | Notes                                                                                                                        |
+| -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `custom_id`          | no       | `string`  |                                                                                                                              |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
-| `type`               | yes      | `string`  | `message`                                                                                                                     |
-| `properties`         | no       | `object`  | [Properties](#properties)                                                                                                     |
-| `postback`           | no       | `object`  | Indicates that the message event was generated in response to a rich message event.                                           |
-| `postback.id`        | yes      | `string`  | ID of the postback from the rich message event.                                                                               |
-| `postback.thread_id` | yes      | `string`  | ID of the thread with the rich message event.                                                                                 |
-| `postback.event_id`  | yes      | `string`  | ID of the rich message event.                                                                                                 |
-| `postback.type`      | no       | `string`  | Should be used together with `postback.value`(when  one of them is present, the other is required).                                                                                |
-| `postback.value`     | no       | `string`  | Should be used together with `postback.type`(when  one of them is present, the other is required).                                                                                 |
+| `type`               | yes      | `string`  | `message`                                                                                                                    |
+| `properties`         | no       | `object`  | [Properties](#properties)                                                                                                    |
+| `postback`           | no       | `object`  | Indicates that the message event was generated in response to a rich message event.                                          |
+| `postback.id`        | yes      | `string`  | ID of the postback from the rich message event.                                                                              |
+| `postback.thread_id` | yes      | `string`  | ID of the thread with the rich message event.                                                                                |
+| `postback.event_id`  | yes      | `string`  | ID of the rich message event.                                                                                                |
+| `postback.type`      | no       | `string`  | Should be used together with `postback.value`(when  one of them is present, the other is required).                          |
+| `postback.value`     | no       | `string`  | Should be used together with `postback.type`(when  one of them is present, the other is required).                           |
 
 ### Response
 
@@ -330,46 +330,46 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 
 ### Request
 
-| Field                            | Required | Data type | Notes                                                                                             |
-| -------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------- |
-| `custom_id`                      | no       | `string`  | You can give your RM a custom ID.                                                                 |
-| `type`                           | yes      | `string`  | Event type: `rich_message`                                                                        |
-| `properties`                     | no       | `object`  | The [properties](#properties) data structure                                                      |
-| `template_id`                    | yes      | `string`  | Defines how every Rich Message will be presented. Values: `cards`, `sticker`, or `quick_replies`. |
-| `elements`                       | no       | `array`   | Can contain up to 10 `element` objects.                                                           |
-| `elements.title`                 | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.subtitle`              | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.image`                 | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`.|
-| `elements.buttons`               | no       | `array`   | Displays buttons. Can contain up to 11 `button` objects.                                          |
-| `elements.buttons.text`          | yes      | `string`  | Text displayed on a button.                                                                       |
-| `elements.buttons.type`          | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value`. Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)  |
-| `elements.buttons.value`         | yes      | `string`  | Should be used together with `elements.buttons.type`.                                             |
-| `elements.buttons.webview_height`| yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.         |
-| `elements.buttons.postback_id`   | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
-| `elements.buttons.user_ids`      | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.|
+| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
+| --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                |
+| `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                       |
+| `properties`                      | no       | `object`  | The [properties](#properties) data structure                                                                                                                                                                                                     |
+| `template_id`                     | yes      | `string`  | Defines how every Rich Message will be presented. Values: `cards`, `sticker`, or `quick_replies`.                                                                                                                                                |
+| `elements`                        | no       | `array`   | Can contain up to 10 `element` objects.                                                                                                                                                                                                          |
+| `elements.title`                  | yes      | `string`  | Displays formatted text on RMs.                                                                                                                                                                                                                  |
+| `elements.subtitle`               | yes      | `string`  | Displays formatted text on RMs.                                                                                                                                                                                                                  |
+| `elements.image`                  | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`.                                                                                                                               |
+| `elements.buttons`                | no       | `array`   | Displays buttons. Can contain up to 11 `button` objects.                                                                                                                                                                                         |
+| `elements.buttons.text`           | yes      | `string`  | Text displayed on a button.                                                                                                                                                                                                                      |
+| `elements.buttons.type`           | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value`. Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
+| `elements.buttons.value`          | yes      | `string`  | Should be used together with `elements.buttons.type`.                                                                                                                                                                                            |
+| `elements.buttons.webview_height` | yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.                                                                                                                                                        |
+| `elements.buttons.postback_id`    | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)                                                                      |
+| `elements.buttons.user_ids`       | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.                                                                                                                                                                                   |
 
 ### Response
 
-| Field                            | Returned   | Notes                                                               |
-| -------------------------------- | ---------- | ------------------------------------------------------------------- |
-| `id`                             | always     | Generated server-side                                               |
-| `custom_id`                      | optionally |                                                                     |
-| `type`                           | always     |                                                                     |
-| `author_id`                      | always     | Generated server-side                                               |
-| `created_at`                     | always     | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
-| `properties`                     | optionally |                                                                     |
-| `template_id`                    | always     |                                                                     |
-| `elements`                       | optionally |                                                                     |
-| `elements.title`                 | always     |                                                                     |
-| `elements.subtitle`              | always     |                                                                     |
-| `elements.image`                 | always     |                                                                     |
-| `elements.buttons`               | optionally |                                                                     |
-| `elements.buttons.text`          | always     |                                                                     |
-| `elements.buttons.type`          | always     |                                                                     |
-| `elements.buttons.value`         | always     |                                                                     |
-| `elements.buttons.webview_height`| always     | Unless button `type` is different than `webview`.                   |
-| `elements.buttons.postback_id`   | always     |                                                                     |
-| `elements.buttons.user_ids`      | always     |                                                                     |
+| Field                             | Returned   | Notes                                                                                      |
+| --------------------------------- | ---------- | ------------------------------------------------------------------------------------------ |
+| `id`                              | always     | Generated server-side                                                                      |
+| `custom_id`                       | optionally |                                                                                            |
+| `type`                            | always     |                                                                                            |
+| `author_id`                       | always     | Generated server-side                                                                      |
+| `created_at`                      | always     | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
+| `properties`                      | optionally |                                                                                            |
+| `template_id`                     | always     |                                                                                            |
+| `elements`                        | optionally |                                                                                            |
+| `elements.title`                  | always     |                                                                                            |
+| `elements.subtitle`               | always     |                                                                                            |
+| `elements.image`                  | always     |                                                                                            |
+| `elements.buttons`                | optionally |                                                                                            |
+| `elements.buttons.text`           | always     |                                                                                            |
+| `elements.buttons.type`           | always     |                                                                                            |
+| `elements.buttons.value`          | always     |                                                                                            |
+| `elements.buttons.webview_height` | always     | Unless button `type` is different than `webview`.                                          |
+| `elements.buttons.postback_id`    | always     |                                                                                            |
+| `elements.buttons.user_ids`       | always     |                                                                                            |
 
 </Text>
 
@@ -440,12 +440,12 @@ The Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                               |                                                                                   |
-| ------------ | -------- | --------- | ------------------------------------------------------------------- |
-| `custom_id`  | no       | `string`  | You can give the event a custom ID.                                 |
-| `type`       | yes      | `string`  | Event type: `custom`                                                |
-| `content`    | no       | `object`  | The content you define                                              |
-| `properties` | no       | `object`  | The [properties](#properties) data structure                        |
+| Field        | Required | Data type | Notes                                        |  |
+| ------------ | -------- | --------- | -------------------------------------------- |
+| `custom_id`  | no       | `string`  | You can give the event a custom ID.          |
+| `type`       | yes      | `string`  | Event type: `custom`                         |
+| `content`    | no       | `object`  | The content you define                       |
+| `properties` | no       | `object`  | The [properties](#properties) data structure |
 
 ### Response
 
@@ -497,13 +497,13 @@ System message event is a native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type |                                                                                                                            Notes |
-| --------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `custom_id`           | no       | `string`  |                                                                                     You can give the system message a custom ID. |
-| `type`                | yes      | `string`  |                                                                                                                 `system_message` |
-| `text`                | no       | `string`  |                                                                                                     Text displayed to recipients |
-| `system_message_type` | yes      | `string`  |                                                                                [System message type](/messaging/references/system-messages/) |
-| `text_vars`           | no       | `object`  |                                                                                                       Variables used in the text |
+| Field                 | Required | Data type | Notes                                                         |
+| --------------------- | -------- | --------- | ------------------------------------------------------------- |
+| `custom_id`           | no       | `string`  | You can give the system message a custom ID.                  |
+| `type`                | yes      | `string`  | `system_message`                                              |
+| `text`                | no       | `string`  | Text displayed to recipients                                  |
+| `system_message_type` | yes      | `string`  | [System message type](/messaging/references/system-messages/) |
+| `text_vars`           | no       | `object`  | Variables used in the text                                    |
 
 ### Response
 
@@ -566,13 +566,13 @@ System message event is a native system event sent in specific situations.
 
 </CodeResponse>
 
-| Field    | Req./Opt. | Notes|
-| -------- | :-------: | ---: |
-| `avatar` | optional  |      |
-| `email`  | optional  |      |
-| `name`   | optional  |      |
-| `fields` | optional  |      |
-| `events_seen_up_to`| optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Customer—all the previous events are considered seen. |
+| Field               | Req./Opt. |                                                                                                                              Notes |
+| ------------------- | :-------: | ---------------------------------------------------------------------------------------------------------------------------------: |
+| `avatar`            | optional  |                                                                                                                                    |
+| `email`             | optional  |                                                                                                                                    |
+| `name`              | optional  |                                                                                                                                    |
+| `fields`            | optional  |                                                                                                                                    |
+| `events_seen_up_to` | optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Customer—all the previous events are considered seen. |
 
 ## Agent
 
@@ -830,12 +830,12 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 
 </CodeResponse>
 
-| Field               | Req./Opt. |                                                                                  Note |
-| ------------------- | :-------: | ------------------------------------------------------------------------------------: |
-| `access`            | optional  |                                                                                       |
-| `active`            | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active). |
-| `events`            | optional  |                                                                                       |
-| `properties`        | optional  |                                                                                       |
+| Field        | Req./Opt. |                                                                                  Note |
+| ------------ | :-------: | ------------------------------------------------------------------------------------: |
+| `access`     | optional  |                                                                                       |
+| `active`     | required  | Possible values: `true` (thread is still active) or `false`(thread no longer active). |
+| `events`     | optional  |                                                                                       |
+| `properties` | optional  |                                                                                       |
 
 # Methods
 In the websocket transport, actions generate [pushes](#pushes). RTM API actions can also trigger [webhooks](/management/configuration-api/v3.1/#webhooks), but they need to be registered first. 
@@ -1613,9 +1613,9 @@ Sends a sneak peek to a chat.
 
 #### Request
 
-| Parameter    | Required | Data type | Notes                                                                                                                                                                        |
-| ------------ | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `chat_id`    | Yes      | `string`  | Id of the chat you to set a property for.                                                                                                                                    |
+| Parameter    | Required | Data type | Notes                                                                                                                                                                             |
+| ------------ | -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`    | Yes      | `string`  | Id of the chat you to set a property for.                                                                                                                                         |
 | `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/v3.1/#properties) and include _namespace_, _property name_ and _value_. |
 
 </Text>
@@ -1738,10 +1738,10 @@ Sends a sneak peek to a chat.
 
 #### Request
 
-| Parameter    | Required | Data type | Notes                                                                                                                                                                        |
-| ------------ | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.                                                                                                                               |
-| `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for.                                                                                                                             |
+| Parameter    | Required | Data type | Notes                                                                                                                                                                             |
+| ------------ | -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.                                                                                                                                    |
+| `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for.                                                                                                                                  |
 | `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/v3.1/#properties) and include _namespace_, _property name_ and _value_. |
 
 </Text>
@@ -1867,11 +1867,11 @@ Sends a sneak peek to a chat.
 
 #### Request
 
-| Parameter    | Required | Data type | Notes                                                                                                                                                                        |
-| ------------ | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.                                                                                                                               |
-| `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for.                                                                                                                             |
-| `event_id`   | Yes      | `string`  | Id of the event you want to set properties for.                                                                                                                              |
+| Parameter    | Required | Data type | Notes                                                                                                                                                                             |
+| ------------ | -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`    | Yes      | `string`  | Id of the chat you want to set properties for.                                                                                                                                    |
+| `thread_id`  | Yes      | `string`  | Id of the thread you want to set properties for.                                                                                                                                  |
+| `event_id`   | Yes      | `string`  | Id of the event you want to set properties for.                                                                                                                                   |
 | `properties` | Yes      | `object`  | Chat properties to set. You should stick to the [general properties format](/management/configuration-api/v3.1/#properties) and include _namespace_, _property name_ and _value_. |
 
 </Text>
@@ -2800,9 +2800,9 @@ Informs about a new thread coming in the chat. The push payload contains not onl
 
 #### Specifics
 
-|                        |                                                                               |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| **Action**             | `incoming_chat_thread`                                                        |
+|                        |                                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| **Action**             | `incoming_chat_thread`                                                             |
 | **Webhook equivalent** | [`incoming_chat_thread`](/management/configuration-api/v3.1/#incoming_chat_thread) |
 
 ### `thread_closed`
@@ -2822,9 +2822,9 @@ Informs that a thread was closed.
 
 #### Specifics
 
-|                        |                                                                 |
-| ---------------------- | --------------------------------------------------------------- |
-| **Action**             | `thread_closed`                                                 |
+|                        |                                                                      |
+| ---------------------- | -------------------------------------------------------------------- |
+| **Action**             | `thread_closed`                                                      |
 | **Webhook equivalent** | [`thread_closed`](/management/configuration-api/v3.1/#thread_closed) |
 
 #### Push payload
@@ -2855,9 +2855,9 @@ Informs that new, single access to a resource was set. The existing access is ov
 
 #### Specifics
 
-|                        |                                                           |
-| ---------------------- | --------------------------------------------------------- |
-| **Action**             | `access_set`                                              |
+|                        |                                                                |
+| ---------------------- | -------------------------------------------------------------- |
+| **Action**             | `access_set`                                                   |
 | **Webhook equivalent** | [`access_set`](/management/configuration-api/v3.1/#access_set) |
 
 #### Push payload
@@ -2922,9 +2922,9 @@ This push can be emitted with `user.present` set to `false` when a user writes t
 
 #### Specifics
 
-|                        |                                                                     |
-| ---------------------- | ------------------------------------------------------------------- |
-| **Action**             | `chat_user_added`                                                   |
+|                        |                                                                          |
+| ---------------------- | ------------------------------------------------------------------------ |
+| **Action**             | `chat_user_added`                                                        |
 | **Webhook equivalent** | [`chat_user_added`](/management/configuration-api/v3.1/#chat_user_added) |
 
 #### Push payload
@@ -2952,9 +2952,9 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Specifics
 
-|                        |                                                                         |
-| ---------------------- | ----------------------------------------------------------------------- |
-| **Action**             | `chat_user_removed`                                                     |
+|                        |                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| **Action**             | `chat_user_removed`                                                          |
 | **Webhook equivalent** | [`chat_user_removed`](/management/configuration-api/v3.1/#chat_user_removed) |
 
 #### Push payload
@@ -2997,9 +2997,9 @@ Informs about an incoming [event](#events) sent to a chat.
 
 #### Specifics
 
-|                        |                                                                   |
-| ---------------------- | ----------------------------------------------------------------- |
-| **Action**             | `incoming_event`                                                  |
+|                        |                                                                        |
+| ---------------------- | ---------------------------------------------------------------------- |
+| **Action**             | `incoming_event`                                                       |
 | **Webhook equivalent** | [`incoming_event`](/management/configuration-api/v3.1/#incoming_event) |
 
 ### `event_updated`
@@ -3021,9 +3021,9 @@ Informs that an [event](#events) was updated.
 
 #### Specifics
 
-|                        |                                                                 |
-| ---------------------- | --------------------------------------------------------------- |
-| **Action**             | `event_updated`                                                 |
+|                        |                                                                      |
+| ---------------------- | -------------------------------------------------------------------- |
+| **Action**             | `event_updated`                                                      |
 | **Webhook equivalent** | [`event_updated`](/management/configuration-api/v3.1/#event_updated) |
 
 ### `incoming_rich_message_postback`
@@ -3048,9 +3048,9 @@ Informs about an incoming [rich message](#rich-message) postback. The push paylo
 
 #### Specifics
 
-|                        |                                                                                                   |
-| ---------------------- | ------------------------------------------------------------------------------------------------- |
-| **Action**             | `incoming_rich_message_postback`                                                                  |
+|                        |                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Action**             | `incoming_rich_message_postback`                                                                       |
 | **Webhook equivalent** | [`incoming_rich_message_postback`](/management/configuration-api/v3.1/#incoming_rich_message_postback) |
 
 ## Properties
@@ -3081,9 +3081,9 @@ Informs about those chat properties that were updated.
 
 #### Specifics
 
-|                        |                                                                                     |
-| ---------------------- | ----------------------------------------------------------------------------------- |
-| **Action**             | `chat_properties_updated`                                                           |
+|                        |                                                                                          |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| **Action**             | `chat_properties_updated`                                                                |
 | **Webhook equivalent** | [`chat_properties_updated`](/management/configuration-api/v3.1/#chat_properties_updated) |
 
 #### Push payload
@@ -3112,9 +3112,9 @@ Informs about those chat properties that were deleted.
 
 #### Specifics
 
-|                        |                                                                                     |
-| ---------------------- | ----------------------------------------------------------------------------------- |
-| **Action**             | `chat_properties_deleted`                                                           |
+|                        |                                                                                          |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| **Action**             | `chat_properties_deleted`                                                                |
 | **Webhook equivalent** | [`chat_properties_deleted`](/management/configuration-api/v3.1/#chat_properties_deleted) |
 
 #### Push payload
@@ -3150,9 +3150,9 @@ Informs about those chat thread properties that were updated.
 
 #### Specifics
 
-|                        |                                                                                                   |
-| ---------------------- | ------------------------------------------------------------------------------------------------- |
-| **Action**             | `chat_thread_properties_updated`                                                                  |
+|                        |                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Action**             | `chat_thread_properties_updated`                                                                       |
 | **Webhook equivalent** | [`chat_thread_properties_updated`](/management/configuration-api/v3.1/#chat_thread_properties_updated) |
 
 #### Push payload
@@ -3182,9 +3182,9 @@ Informs about those chat thread properties that were deleted.
 
 #### Specifics
 
-|                        |                                                                                                   |
-| ---------------------- | ------------------------------------------------------------------------------------------------- |
-| **Action**             | `chat_thread_properties_deleted`                                                                  |
+|                        |                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Action**             | `chat_thread_properties_deleted`                                                                       |
 | **Webhook equivalent** | [`chat_thread_properties_deleted`](/management/configuration-api/v3.1/#chat_thread_properties_deleted) |
 
 #### Push payload
@@ -3217,9 +3217,9 @@ Informs about those event properties that were updated.
 
 #### Specifics
 
-|                        |                                                                                       |
-| ---------------------- | ------------------------------------------------------------------------------------- |
-| **Action**             | `event_properties_updated`                                                            |
+|                        |                                                                                            |
+| ---------------------- | ------------------------------------------------------------------------------------------ |
+| **Action**             | `event_properties_updated`                                                                 |
 | **Webhook equivalent** | [`event_properties_updated`](/management/configuration-api/v3.1/#event_properties_updated) |
 
 #### Push payload
@@ -3250,9 +3250,9 @@ Informs about those event properties that were deleted.
 
 #### Specifics
 
-|                        |                                                                                       |
-| ---------------------- | ------------------------------------------------------------------------------------- |
-| **Action**             | `event_properties_deleted`                                                            |
+|                        |                                                                                            |
+| ---------------------- | ------------------------------------------------------------------------------------------ |
+| **Action**             | `event_properties_deleted`                                                                 |
 | **Webhook equivalent** | [`event_properties_deleted`](/management/configuration-api/v3.1/#event_properties_deleted) |
 
 #### Push payload
@@ -3468,9 +3468,9 @@ Informs that a user has seen events up to a specific time.
 
 #### Specifics
 
-|                        |                                                                                 |
-| ---------------------- | ------------------------------------------------------------------------------- |
-| **Action**             | `events_marked_as_seen`                                                         |
+|                        |                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------ |
+| **Action**             | `events_marked_as_seen`                                                              |
 | **Webhook equivalent** | [`events_marked_as_seen`](/management/configuration-api/v3.1/#events_marked_as_seen) |
 
 # Errors

--- a/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
@@ -368,6 +368,7 @@ System message event is a native system event sent in specific situations.
 | `email`          | optional  |                                                                                           |
 | `name`           | optional  |                                                                                           |
 | `session_fields` | optional  | An array of custom object-enclosed `key:value` pairs. Available for the session duration. |
+| `events_seen_up_to`| optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Customer—all the previous events are considered seen. |
 
 ## Agent
 
@@ -2617,8 +2618,8 @@ Here's what you need to know about **pushes**:
 - They notify you when specific events occur.
 - Can be **delivered** only in the websocket transport.
 - You don't need to register pushes to receive them.
-- Their equivalents in Web API are [webhooks](/management/configuration-api/#webhooks).
-- Pushes and webhooks have similar payloads.
+- Their equivalents in Web API are [webhooks](/management/configuration-api/v3.3/#webhooks). Pushes and webhooks have similar payloads.
+- There are no retries for pushes. To determine if a customer has seen an event, compare the [event's](#response) `created_at` parameter with the [customer's](#customer) `events_seen_up_to` field.
 
 |                 |                                                                                                                                                                                                                                                                                                                                                                     |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
@@ -102,7 +102,7 @@ The **File** event informs about an uploaded file.
 | `type`             | yes      | `string`  |                                                                                                                                    `file` |
 | `properties`       | no       | `object`  |                                                                                                                 [Properties](#properties) |
 | `url`              | yes      | `string`  | Has to point to the LiveChat CDN. It's recommended to use the URL returned by [`upload_file`](/messaging/customer-chat-api/#upload-file). |
-| `alternative_text` | no       | `string`  | Only applicable to images                                                                                                                 |
+| `alternative_text` | no       | `string`  |                                                                                                                 Only applicable to images |
 
 ### Response
 
@@ -180,18 +180,18 @@ The **Message** event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                         |
-| -------------------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `custom_id`          | no       | `string`  |                                                                                                                               |
+| Field                | Required | Data type | Notes                                                                                                                        |
+| -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `custom_id`          | no       | `string`  |                                                                                                                              |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
-| `type`               | yes      | `string`  | `message`                                                                                                                     |
-| `properties`         | no       | `object`  | [Properties](#properties)                                                                                                     |
-| `postback`           | no       | `object`  | Indicates that the message event was generated in response to a rich message event.                                           |
-| `postback.id`        | yes      | `string`  | ID of the postback from the rich message event.                                                                               |
-| `postback.thread_id` | yes      | `string`  | ID of the thread with the rich message event.                                                                                 |
-| `postback.event_id`  | yes      | `string`  | ID of the rich message event.                                                                                                 |
-| `postback.type`      | no       | `string`  | Should be used together with `postback.value` (when  one of them is present, the other is required).                                                                                |
-| `postback.value`     | no       | `string`  | Should be used together with `postback.type` (when  one of them is present, the other is required).                                                                                 |
+| `type`               | yes      | `string`  | `message`                                                                                                                    |
+| `properties`         | no       | `object`  | [Properties](#properties)                                                                                                    |
+| `postback`           | no       | `object`  | Indicates that the message event was generated in response to a rich message event.                                          |
+| `postback.id`        | yes      | `string`  | ID of the postback from the rich message event.                                                                              |
+| `postback.thread_id` | yes      | `string`  | ID of the thread with the rich message event.                                                                                |
+| `postback.event_id`  | yes      | `string`  | ID of the rich message event.                                                                                                |
+| `postback.type`      | no       | `string`  | Should be used together with `postback.value` (when  one of them is present, the other is required).                         |
+| `postback.value`     | no       | `string`  | Should be used together with `postback.type` (when  one of them is present, the other is required).                          |
 
 ### Response
 
@@ -229,48 +229,48 @@ Rich message event contains rich message data structure. [Read more](/extending-
 
 ### Request
 
-| Field                            | Required | Data type | Notes                                                                                             |
-| -------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------- |
-| `custom_id`                      | no       | `string`  | You can give your RM a custom ID.                                                                 |
-| `type`                           | yes      | `string`  | Event type: `rich_message`                                                                        |
-| `properties`                     | no       | `object`  | The [properties](#properties) data structure                                                      |
-| `template_id`                    | yes      | `string`  | Defines how every Rich Message will be presented. Values: `cards`, `sticker`, or `quick_replies`. |
-| `elements`                       | no       | `array`   | Can contain up to 10 `element` objects.                                                           |
-| `elements.title`                 | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.subtitle`              | yes      | `string`  | Displays formatted text on RMs.                                                                   |
-| `elements.image`                 | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`, `alternative_text`.|
-| `elements.buttons`               | no       | `array`   | Displays buttons. Can contain up to 13 `button` objects.                                          |
-| `elements.buttons.text`          | yes      | `string`  | Text displayed on a button.                                                                       |
-| `elements.buttons.type`          | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value`. Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)  |
-| `elements.buttons.value`         | yes      | `string`  | Should be used together with `elements.buttons.type`.                                             |
-| `elements.buttons.webview_height`| yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.         |
-| `elements.buttons.postback_id`   | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
-| `elements.buttons.user_ids`      | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.|
-| `elements.buttons.target`        | no       | `string`  | Should be used for the `url` button `type`. Specifies if the URL should open in the current or a new tab. Possible values: `new`, `current`.                    |
+| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
+| --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                |
+| `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                       |
+| `properties`                      | no       | `object`  | The [properties](#properties) data structure                                                                                                                                                                                                     |
+| `template_id`                     | yes      | `string`  | Defines how every Rich Message will be presented. Values: `cards`, `sticker`, or `quick_replies`.                                                                                                                                                |
+| `elements`                        | no       | `array`   | Can contain up to 10 `element` objects.                                                                                                                                                                                                          |
+| `elements.title`                  | yes      | `string`  | Displays formatted text on RMs.                                                                                                                                                                                                                  |
+| `elements.subtitle`               | yes      | `string`  | Displays formatted text on RMs.                                                                                                                                                                                                                  |
+| `elements.image`                  | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`, `alternative_text`.                                                                                                           |
+| `elements.buttons`                | no       | `array`   | Displays buttons. Can contain up to 13 `button` objects.                                                                                                                                                                                         |
+| `elements.buttons.text`           | yes      | `string`  | Text displayed on a button.                                                                                                                                                                                                                      |
+| `elements.buttons.type`           | yes      | `array`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value`. Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
+| `elements.buttons.value`          | yes      | `string`  | Should be used together with `elements.buttons.type`.                                                                                                                                                                                            |
+| `elements.buttons.webview_height` | yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.                                                                                                                                                        |
+| `elements.buttons.postback_id`    | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)                                                                      |
+| `elements.buttons.user_ids`       | yes      | `array`   | Describes users that sent the postback with `"toggled": true`.                                                                                                                                                                                   |
+| `elements.buttons.target`         | no       | `string`  | Should be used for the `url` button `type`. Specifies if the URL should open in the current or a new tab. Possible values: `new`, `current`.                                                                                                     |
 
 ### Response
 
-| Field                            | Returned   | Notes                                                               |
-| -------------------------------- | ---------- | ------------------------------------------------------------------- |
-| `id`                             | always     | Generated server-side                                               |
-| `custom_id`                      | optionally |                                                                     |
-| `type`                           | always     |                                                                     |
-| `author_id`                      | always     | Generated server-side                                               |
-| `created_at`                     | always     | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
-| `properties`                     | optionally |                                                                     |
-| `template_id`                    | always     |                                                                     |
-| `elements`                       | optionally |                                                                     |
-| `elements.title`                 | always     |                                                                     |
-| `elements.subtitle`              | always     |                                                                     |
-| `elements.image`                 | always     |                                                                     |
-| `elements.buttons`               | optionally |                                                                     |
-| `elements.buttons.text`          | always     |                                                                     |
-| `elements.buttons.type`          | always     |                                                                     |
-| `elements.buttons.value`         | always     |                                                                     |
-| `elements.buttons.webview_height`| always     | Unless button `type` is different than `webview`.                   |
-| `elements.buttons.postback_id`   | always     |                                                                     |
-| `elements.buttons.user_ids`      | always     |                                                                     |
-| `elements.buttons.target`        | optionally |                                                                     |
+| Field                             | Returned   | Notes                                                                                      |
+| --------------------------------- | ---------- | ------------------------------------------------------------------------------------------ |
+| `id`                              | always     | Generated server-side                                                                      |
+| `custom_id`                       | optionally |                                                                                            |
+| `type`                            | always     |                                                                                            |
+| `author_id`                       | always     | Generated server-side                                                                      |
+| `created_at`                      | always     | Date & time format with a resolution of microseconds, `UTC string`. Generated server-side. |
+| `properties`                      | optionally |                                                                                            |
+| `template_id`                     | always     |                                                                                            |
+| `elements`                        | optionally |                                                                                            |
+| `elements.title`                  | always     |                                                                                            |
+| `elements.subtitle`               | always     |                                                                                            |
+| `elements.image`                  | always     |                                                                                            |
+| `elements.buttons`                | optionally |                                                                                            |
+| `elements.buttons.text`           | always     |                                                                                            |
+| `elements.buttons.type`           | always     |                                                                                            |
+| `elements.buttons.value`          | always     |                                                                                            |
+| `elements.buttons.webview_height` | always     | Unless button `type` is different than `webview`.                                          |
+| `elements.buttons.postback_id`    | always     |                                                                                            |
+| `elements.buttons.user_ids`       | always     |                                                                                            |
+| `elements.buttons.target`         | optionally |                                                                                            |
 
 </Text>
 
@@ -289,12 +289,12 @@ Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                               |                                                                                   |
-| ------------ | -------- | --------- | ------------------------------------------------------------------- |
-| `custom_id`  | no       | `string`  | You can give the event a custom ID.                                 |
-| `type`       | yes      | `string`  | Event type: `custom`                                                |
-| `content`    | no       | `object`  | The content you define                                              |
-| `properties` | no       | `object`  | The [properties](#properties) data structure                        |
+| Field        | Required | Data type | Notes                                        |  |
+| ------------ | -------- | --------- | -------------------------------------------- |
+| `custom_id`  | no       | `string`  | You can give the event a custom ID.          |
+| `type`       | yes      | `string`  | Event type: `custom`                         |
+| `content`    | no       | `object`  | The content you define                       |
+| `properties` | no       | `object`  | The [properties](#properties) data structure |
 
 ### Response
 
@@ -325,13 +325,13 @@ System message event is a native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type |                                                                                                                            Notes |
-| --------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------: |
-| `custom_id`           | no       | `string`  |                                                                                     You can give the system message a custom ID. |
-| `type`                | yes      | `string`  |                                                                                                                 `system_message` |
-| `text`                | no       | `string`  |                                                                                                     Text displayed to recipients |
-| `system_message_type` | yes      | `string`  |                                                                                [System message type](/messaging/references/system-messages/) |
-| `text_vars`           | no       | `object`  |                                                                                                       Variables used in the text |
+| Field                 | Required | Data type |                                                         Notes |
+| --------------------- | -------- | --------- | ------------------------------------------------------------: |
+| `custom_id`           | no       | `string`  |                  You can give the system message a custom ID. |
+| `type`                | yes      | `string`  |                                              `system_message` |
+| `text`                | no       | `string`  |                                  Text displayed to recipients |
+| `system_message_type` | yes      | `string`  | [System message type](/messaging/references/system-messages/) |
+| `text_vars`           | no       | `object`  |                                    Variables used in the text |
 
 ### Response
 
@@ -362,13 +362,13 @@ System message event is a native system event sent in specific situations.
 
 <CodeResponse version="v3.3" type="customer" title={'Sample Customer data structure'} json="customer"/>
 
-| Field            | Req./Opt. |                                                                                           |
-| ---------------- | --------- | ----------------------------------------------------------------------------------------- |
-| `avatar`         | optional  |                                                                                           |
-| `email`          | optional  |                                                                                           |
-| `name`           | optional  |                                                                                           |
-| `session_fields` | optional  | An array of custom object-enclosed `key:value` pairs. Available for the session duration. |
-| `events_seen_up_to`| optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Customer—all the previous events are considered seen. |
+| Field               | Req./Opt. |                                                                                                                                    |
+| ------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `avatar`            | optional  |                                                                                                                                    |
+| `email`             | optional  |                                                                                                                                    |
+| `name`              | optional  |                                                                                                                                    |
+| `session_fields`    | optional  | An array of custom object-enclosed `key:value` pairs. Available for the session duration.                                          |
+| `events_seen_up_to` | optional  | RFC 3339 datetime string; the timestamp of the most recent event seen by the Customer—all the previous events are considered seen. |
 
 ## Agent
 
@@ -464,14 +464,14 @@ When connecting to the Customer Chat RTM API, clients have to send over the requ
 
 ## Available methods
 
-|                |                                                                                                                                                                                                                                                                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**      | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat)                                                                                                                 |
-| **Events**     | [`send_event`](#send-event) [`send_rich_message_postback`](#send-rich-message-postback) [`send_sneak_peek`](#send-sneak-peek)                                                                                                                                                                                                                           |
+|                |                                                                                                                                                                                                                                                                                                                                     |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Chats**      | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat)                                                                                                                                             |
+| **Events**     | [`send_event`](#send-event) [`send_rich_message_postback`](#send-rich-message-postback) [`send_sneak_peek`](#send-sneak-peek)                                                                                                                                                                                                       |
 | **Properties** | [`update_chat_properties`](#update-chat-properties) [`delete_chat_properties`](#delete-chat-properties) [`update_thread_properties`](#update-thread-properties) [`delete_thread_properties`](#delete-thread-properties) [`update_event_properties`](#update-event-properties) [`delete_event_properties`](#delete-event-properties) |
-| **Customers**  | [`update_customer`](#update-customer) [`update_customer_page`](#update-customer-page) [`set_customer_session_fields`](#set-customer-session-fields) [`get_customer`](#get-customer)                                                                                                                                                                     |
-| **Status**     | [`login`](#login) [`list_group_statuses`](#list-group-statuses)                                                                                                                                                                                                                                                                                             |
-| **Other**      | [`get_form`](#get-form) [`get_predicted_agent`](#get-predicted-agent) [`get_url_info`](#get-url-info) [`mark_events_as_seen`](#mark-events-as-seen) [`accept_greeting`](#accept-greeting) [`cancel_greeting`](#cancel-greeting)                                                                                                                   |
+| **Customers**  | [`update_customer`](#update-customer) [`update_customer_page`](#update-customer-page) [`set_customer_session_fields`](#set-customer-session-fields) [`get_customer`](#get-customer)                                                                                                                                                 |
+| **Status**     | [`login`](#login) [`list_group_statuses`](#list-group-statuses)                                                                                                                                                                                                                                                                     |
+| **Other**      | [`get_form`](#get-form) [`get_predicted_agent`](#get-predicted-agent) [`get_url_info`](#get-url-info) [`mark_events_as_seen`](#mark-events-as-seen) [`accept_greeting`](#accept-greeting) [`cancel_greeting`](#cancel-greeting)                                                                                                     |
 
 </Text>
 
@@ -524,7 +524,7 @@ It returns [summaries](#chat-summaries) of the chats a Customer participated in.
 #### Specifics
 
 |                        |                                |
-|------------------------|--------------------------------|
+| ---------------------- | ------------------------------ |
 | **Action**             | `list_chats`                   |
 | **Web API equivalent** | [`list_chats`](../#list-chats) |
 | **Push message**       | -                              |
@@ -628,20 +628,20 @@ It returns threads that the current Customer has access to in a given chat.
 
 #### Specifics
 
-|                        |                                                   |
-|------------------------|---------------------------------------------------|
-| **Action**             | `list_threads`                                      |
-| **Web API equivalent** | [`list_threads`](../#list-threads)                    |
-| **Push message**       | -                                                 |
+|                        |                                    |
+| ---------------------- | ---------------------------------- |
+| **Action**             | `list_threads`                     |
+| **Web API equivalent** | [`list_threads`](../#list-threads) |
+| **Push message**       | -                                  |
 
 #### Request
 
-| Parameter          | Required | Data type | Notes                                                                                      |
-| ------------------ | -------- | --------- | ------------------------------------------------------------------------------------------ |
-| `chat_id`          | Yes      | `string`  |                                                                                            |
-| `sort_order`       | No       | `string`  | Possible values: `asc` - oldest threads first and `desc` - newest threads first (default). |
-| `limit`            | No       | `number`  | Default: 3, maximum: 100                                                                   |
-| `page_id`          | No       | `string`  |                                                                                            |
+| Parameter          | Required | Data type | Notes                                                                                                                                                                                                                                                       |
+| ------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_id`          | Yes      | `string`  |                                                                                                                                                                                                                                                             |
+| `sort_order`       | No       | `string`  | Possible values: `asc` - oldest threads first and `desc` - newest threads first (default).                                                                                                                                                                  |
+| `limit`            | No       | `number`  | Default: 3, maximum: 100                                                                                                                                                                                                                                    |
+| `page_id`          | No       | `string`  |                                                                                                                                                                                                                                                             |
 | `min_events_count` | No       | `number`  | Range: 1-100; Specifies the minimum number of events to be returned in the response. It's the **total** number of events, so they can come from more than one thread. You'll get as many latest threads as needed to meet the `min_events_count` condition. |
 
 You cannot use both `limit` and `min_events_count` at the same time.
@@ -716,7 +716,7 @@ You cannot use both `limit` and `min_events_count` at the same time.
 #### Specifics
 
 |                        |                            |
-|------------------------|----------------------------|
+| ---------------------- | -------------------------- |
 | **Action**             | `get_chat`                 |
 | **Web API equivalent** | [`get_chat`](../#get-chat) |
 | **Push message**       | -                          |
@@ -724,7 +724,7 @@ You cannot use both `limit` and `min_events_count` at the same time.
 #### Request
 
 | Parameter   | Required | Data type |                                        |
-|-------------|----------|-----------|----------------------------------------|
+| ----------- | -------- | --------- | -------------------------------------- |
 | `chat_id`   | Yes      | `string`  |                                        |
 | `thread_id` | No       | `string`  | Default: the latest thread (if exists) |
 
@@ -823,7 +823,7 @@ Starts a chat.
 #### Specifics
 
 |                        |                                   |
-|------------------------|-----------------------------------|
+| ---------------------- | --------------------------------- |
 | **Action**             | `start_chat`                      |
 | **Web API equivalent** | [`start_chat`](../#start-chat)    |
 | **Push message**       | [`incoming_chat`](#incoming_chat) |
@@ -831,7 +831,7 @@ Starts a chat.
 #### Request
 
 | Parameters               | Required | Data type | Notes                                                                       |
-|--------------------------|----------|-----------|-----------------------------------------------------------------------------|
+| ------------------------ | -------- | --------- | --------------------------------------------------------------------------- |
 | `chat`                   | No       | `object`  |                                                                             |
 | `chat.properties`        | No       | `object`  | Initial chat properties                                                     |
 | `chat.access`            | No       | `object`  | Chat access to set, default: all agents.                                    |
@@ -934,7 +934,7 @@ Used to restart an archived chat.
 #### Specifics
 
 |                        |                                      |
-|------------------------|--------------------------------------|
+| ---------------------- | ------------------------------------ |
 | **Action**             | `activate_chat`                      |
 | **Web API equivalent** | [`activate_chat`](../#activate-chat) |
 | **Push message**       | [`incoming_chat`](#incoming_chat)    |
@@ -942,7 +942,7 @@ Used to restart an archived chat.
 #### Request
 
 | Request object           | Required | Type     | Notes                                                                      |
-|--------------------------|----------|----------|----------------------------------------------------------------------------|
+| ------------------------ | -------- | -------- | -------------------------------------------------------------------------- |
 | `chat`                   | Yes      | `object` |                                                                            |
 | `chat.id`                | Yes      | `string` | The ID of the chat that will be activated.                                 |
 | `chat.access`            | No       | `object` | Chat access to set, default: all agents.                                   |
@@ -1048,7 +1048,7 @@ Deactivates a chat by closing the currently open thread. Sending messages to thi
 #### Specifics
 
 |                        |                                                                                 |
-|------------------------|---------------------------------------------------------------------------------|
+| ---------------------- | ------------------------------------------------------------------------------- |
 | **Action**             | `deactivate_chat`                                                               |
 | **Web API equivalent** | [`deactivate_chat`](../#deactivate-chat)                                        |
 | **Push message**       | [`incoming_event`](#incoming_event) and [`chat_deactivated`](#chat_deactivated) |
@@ -1468,7 +1468,7 @@ Sends a sneak peek to a chat.
 #### Specifics
 
 |                        |                                                            |
-|------------------------|------------------------------------------------------------|
+| ---------------------- | ---------------------------------------------------------- |
 | **Action**             | `update_thread_properties`                                 |
 | **Web API equivalent** | [`update_thread_properties`](../#update-thread-properties) |
 | **Push message**       | [`thread_properties_updated`](#thread_properties_updated)  |
@@ -1533,7 +1533,7 @@ Sends a sneak peek to a chat.
 #### Specifics
 
 |                        |                                                            |
-|------------------------|------------------------------------------------------------|
+| ---------------------- | ---------------------------------------------------------- |
 | **Action**             | `delete_thread_properties`                                 |
 | **Web API equivalent** | [`delete_thread_properties`](../#delete-thread-properties) |
 | **Push message**       | [`thread_properties_deleted`](#thread_properties_deleted)  |
@@ -1541,7 +1541,7 @@ Sends a sneak peek to a chat.
 #### Request
 
 | Parameter    | Required | Data type | Notes                                                  |
-|--------------|----------|-----------|--------------------------------------------------------|
+| ------------ | -------- | --------- | ------------------------------------------------------ |
 | `chat_id`    | Yes      | `string`  | Id of the chat you want to delete the properties of.   |
 | `thread_id`  | Yes      | `string`  | Id of the thread you want to delete the properties of. |
 | `properties` | Yes      | `object`  | Thread properties to delete.                           |
@@ -2132,7 +2132,7 @@ It returns the initial state of the current Customer.
 #### Specifics
 
 |                        |                                                  |
-|------------------------|--------------------------------------------------|
+| ---------------------- | ------------------------------------------------ |
 | **Action**             | `list_group_statuses`                            |
 | **Web API equivalent** | [`list_group_statuses`](../#list-group-statuses) |
 | **Push message**       | -                                                |
@@ -2372,7 +2372,7 @@ It returns the info on a given URL.
 #### Specifics
 
 |                        |                                    |
-|------------------------|------------------------------------|
+| ---------------------- | ---------------------------------- |
 | **Action**             | `get_url_info`                     |
 | **Web API equivalent** | [`get_url_info`](../#get-url-info) |
 | **Push message**       | -                                  |
@@ -2621,15 +2621,15 @@ Here's what you need to know about **pushes**:
 - Their equivalents in Web API are [webhooks](/management/configuration-api/v3.3/#webhooks). Pushes and webhooks have similar payloads.
 - There are no retries for pushes. To determine if a customer has seen an event, compare the [event's](#response) `created_at` parameter with the [customer's](#customer) `events_seen_up_to` field.
 
-|                 |                                                                                                                                                                                                                                                                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                                   |
-| **Chat access** | [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                                                                                                                       |
+|                 |                                                                                                                                                                                                                                                                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                       |
+| **Chat access** | [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                                                                                                                         |
 | **Chat users**  | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                 |
-| **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                            |
+| **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                        |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
-| **Customers**   | [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                                         |
-| **Status**      | [`customer_disconnected`](#customer_disconnected)                                                                                                                                                                                                                                                                                                                   |
+| **Customers**   | [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                     |
+| **Status**      | [`customer_disconnected`](#customer_disconnected)                                                                                                                                                                                                                                                                                               |
 | **Other**       | [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_greeting`](#incoming_greeting) [`greeting_accepted`](#greeting_accepted) [`greeting_canceled`](#greeting_canceled) [`queue_position_updated`](#queue_position_updated)       |
 
 </Text>
@@ -2693,7 +2693,7 @@ Informs about a chat coming with a new thread. The push payload contains the who
 #### Specifics
 
 |                        |                                                                 |
-|------------------------|-----------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------- |
 | **Action**             | `incoming_chat`                                                 |
 | **Webhook equivalent** | [`incoming_chat`](/management/configuration-api/#incoming_chat) |
 
@@ -2716,7 +2716,7 @@ Informs that a chat was deactivated by closing the currently open thread.
 #### Specifics
 
 |                        |                                                                       |
-|------------------------|-----------------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------------- |
 | **Action**             | `chat_deactivated`                                                    |
 | **Webhook equivalent** | [`chat_deactivated`](/management/configuration-api/#chat_deactivated) |
 
@@ -2762,8 +2762,8 @@ Informs that a chat was transferred to a different group or to an Agent.
 
 #### Push payload
 
-| Object | Notes                                  |
-| ------ | -------------------------------------- |
+| Object           | Notes                                                  |
+| ---------------- | ------------------------------------------------------ |
 | `thread_id`      | Present if the chat is active                          |
 | `transferred_to` | IDs of groups and Agents the chat has been assigned to |
 | `queue`          | Present if the chat is queued after the transfer       |
@@ -2794,15 +2794,15 @@ This push can be emitted with `user.present` set to `false` when a user writes t
 
 #### Specifics
 
-|                        |                                                                     |
-| ---------------------- | ------------------------------------------------------------------- |
-| **Action**             | `user_added_to_chat`                                                   |
+|                        |                                                                           |
+| ---------------------- | ------------------------------------------------------------------------- |
+| **Action**             | `user_added_to_chat`                                                      |
 | **Webhook equivalent** | [`user_added_to_chat`](/management/configuration-api/#user_added_to_chat) |
 
 #### Push payload
 
-| Object      | Notes                                            |
-| ----------- | ------------------------------------------------ |
+| Object         | Notes                                            |
+| -------------- | ------------------------------------------------ |
 | `thread_id`    | Present when a user was added to an active chat. |
 | `reason`       | Why the user was added.                          |
 | `requester_id` | Present if the user was added by an agent.       |
@@ -2827,15 +2827,15 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Specifics
 
-|                        |                                                                         |
-| ---------------------- | ----------------------------------------------------------------------- |
-| **Action**             | `user_removed_from_chat`                                                     |
+|                        |                                                                                   |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| **Action**             | `user_removed_from_chat`                                                          |
 | **Webhook equivalent** | [`user_removed_from_chat`](/management/configuration-api/#user_removed_from_chat) |
 
 #### Push payload
 
-| Object      | Notes                                                |
-| ----------- | ---------------------------------------------------- |
+| Object         | Notes                                                |
+| -------------- | ---------------------------------------------------- |
 | `thread_id`    | Present when a user was removed from an active chat. |
 | `reason`       | Why the user was removed.                            |
 | `requester_id` | Present if the user was removed by an agent.         |
@@ -3020,7 +3020,7 @@ Informs about those thread properties that were updated.
 #### Specifics
 
 |                        |                                                                                         |
-|------------------------|-----------------------------------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------------------------------- |
 | **Action**             | `thread_properties_updated`                                                             |
 | **Webhook equivalent** | [`thread_properties_updated`](/management/configuration-api/#thread_properties_updated) |
 
@@ -3052,7 +3052,7 @@ Informs about those thread properties that were deleted.
 #### Specifics
 
 |                        |                                                                                         |
-|------------------------|-----------------------------------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------------------------------- |
 | **Action**             | `thread_properties_deleted`                                                             |
 | **Webhook equivalent** | [`thread_properties_deleted`](/management/configuration-api/#thread_properties_deleted) |
 
@@ -3390,14 +3390,14 @@ Informs about an incoming [greeting](https://www.livechatinc.com/help/why-should
 
 #### Push payload
 
-| Object                 | Notes                                                       |
-| ---------------------- | ----------------------------------------------------------- |
-| `id`                   | ID of the greeting configured within the license.           |
-| `unique_id`            | ID of the greeting that was generated, sent, and cancelled. |
-| `event`                | Greeting event ([Message](#message) or [Rich message](#rich-message))                    |
-| `displayed_first_time` | `true` if the greeting was generated for the first time.    |
-| `agent`                | Info about the Agent who sent the greeting.                 |
-| `addon`                | Additional greeting property                  |
+| Object                 | Notes                                                                 |
+| ---------------------- | --------------------------------------------------------------------- |
+| `id`                   | ID of the greeting configured within the license.                     |
+| `unique_id`            | ID of the greeting that was generated, sent, and cancelled.           |
+| `event`                | Greeting event ([Message](#message) or [Rich message](#rich-message)) |
+| `displayed_first_time` | `true` if the greeting was generated for the first time.              |
+| `agent`                | Info about the Agent who sent the greeting.                           |
+| `addon`                | Additional greeting property                                          |
 
 ### `greeting_accepted`
 


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/retries-for-pushes)

## 📓 Description
Clarify there're no retries for pushes.

## ✅ Checklist (for API docs)

Agent & Customer RTM Chat API, all versions

## 👷 Type of change (remove not needed)

### Content

- Proofreading/content fixes

