### PR TITLE
API-7272 added ended_at to last_visit for customer

### DIFF
--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -21,12 +21,13 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 
 - The **Transfer Chat** ([Web](/messaging/agent-chat-api/v3.3/#transfer-chat) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#transfer-chat)) method had the `chat_id` parameter renamed to `id`.
 
-### Events
+### Events, users & data structures
 
 - The **File** ([Web](/messaging/agent-chat-api/v3.3/#file) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#file)) event has a new parameter for images, `alternative_text`.
 - The **Rich Message** ([Web](/messaging/agent-chat-api/v3.3/#rich-message) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#rich-message)) data structure:
   - has a new parameter for images, `alternative_text`,
   - has a new property for buttons, `target`.
+- The **Customer** ([Web](/messaging/agent-chat-api/v3.3/#customer) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#customer)) data structure has a new property for visits, `ended_at`.
 
 ### Properties
 
@@ -38,7 +39,6 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - The **Get Customer** ([Web](/messaging/agent-chat-api/v3.3/#get-customer) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#get-customer)) method had the `customer_id` parameter renamed to `id`.
 - The **Update Customer** ([Web](/messaging/agent-chat-api/v3.3/#update-customer) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#update-customer)) method had the `customer_id` parameter renamed to `id`.
 - The **Ban Customer** ([Web](/messaging/agent-chat-api/v3.3/#ban-customer) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#ban-customer)) method had the `customer_id` parameter renamed to `id`.
-- The [**Customer**](/messaging/agent-chat-api/v3.3/#customer) data structure has a new property for visits, `ended_at`.
 
 ## [v3.2] - 2020-06-18
 

--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -38,6 +38,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - The **Get Customer** ([Web](/messaging/agent-chat-api/v3.3/#get-customer) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#get-customer)) method had the `customer_id` parameter renamed to `id`.
 - The **Update Customer** ([Web](/messaging/agent-chat-api/v3.3/#update-customer) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#update-customer)) method had the `customer_id` parameter renamed to `id`.
 - The **Ban Customer** ([Web](/messaging/agent-chat-api/v3.3/#ban-customer) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#ban-customer)) method had the `customer_id` parameter renamed to `id`.
+- The [**Customer**](/messaging/agent-chat-api/v3.3/#customer) data structure has a new property for visits, `ended_at`.
 
 ## [v3.2] - 2020-06-18
 

--- a/content/messaging/agent-chat-api/v3.3/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/index.mdx
@@ -2127,12 +2127,13 @@ https://api.livechatinc.com/v3.3/agent/action/get_customer \
   "email": "t.anderson@example.com",
   "avatar": "example.com/avatars/1.jpg",
   "session_fields": [{
-  "custom_key": "custom_value"
+    "custom_key": "custom_value"
   }, {
-  "another_custom_key": "another_custom_value"
+    "another_custom_key": "another_custom_value"
   }],
   "last_visit": {
     "started_at": "2017-10-12T15:19:21.010200Z",
+    "ended_at": "2017-10-12T15:20:22.010200Z",
     "referrer": "http://www.google.com/",
     "ip": "<customer_ip>",
     "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 Safari/537.36",

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -2434,6 +2434,7 @@ Returns the info about the Customer with a given `id`.
     }],
     "last_visit": {
       "started_at": "2017-10-12T15:19:21.010200Z",
+      "ended_at": "2017-10-12T15:20:22.010200Z",
       "referrer": "http://www.google.com/",
       "ip": "<customer_ip>",
       "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 Safari/537.36",

--- a/payloads/messaging/v3.3/agent-chat-api/other-structures/chat.json
+++ b/payloads/messaging/v3.3/agent-chat-api/other-structures/chat.json
@@ -62,6 +62,7 @@
       "created_at": "2019-11-02T19:19:50.625101Z",
       "last_visit": {
         "started_at": "2020-05-12T11:32:03.497479Z",
+        "ended_at": "2020-05-12T11:33:33.497000Z",
         "ip": "<customer_ip>",
         "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36",
         "geolocation": {

--- a/payloads/messaging/v3.3/agent-chat-api/other-structures/chatSummary.json
+++ b/payloads/messaging/v3.3/agent-chat-api/other-structures/chatSummary.json
@@ -34,6 +34,7 @@
       "created_at": "2019-11-02T19:19:50.625101Z",
       "last_visit": {
         "started_at": "2020-05-12T11:32:03.497479Z",
+        "ended_at": "2020-05-12T11:33:33.497000Z",
         "ip": "<customer_ip>",
         "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36",
         "geolocation": {

--- a/payloads/messaging/v3.3/agent-chat-api/users/customer.json
+++ b/payloads/messaging/v3.3/agent-chat-api/users/customer.json
@@ -6,6 +6,7 @@
   "avatar": "example.com/avatars/1.png",
   "last_visit": {
     "started_at": "2017-10-12T15:19:21.010200Z",
+    "ended_at": "2017-10-12T15:21:01.000000Z",
     "referrer": "http://www.google.com/",
     "ip": "<customer_ip>",
     "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 Safari/537.36",


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-7272)
- [Jira](https://livechatinc.atlassian.net/browse/API-7272)

## 📓 Description
Extended the customer object's `last_visit` with `ended_at` date (to match `started_at`)

## ✅ Checklist (for API docs)

- Changelog
- API versions
- Web & RTM
- **Table:** Available methods/webhooks/pushes
- **Table:** Specifics

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)

### Content

- New content