### PR TITLE
Fix hide example to use proper callback in old JS API docs

### DIFF
--- a/content/extending-chat-widget/javascript-api/v1.0/index.mdx
+++ b/content/extending-chat-widget/javascript-api/v1.0/index.mdx
@@ -193,7 +193,7 @@ Use this snippet if you want to hide chat window on particular page(s).
 var LC_API = LC_API || {};
 var livechat_chat_started = false;
 
-LC_API.on_before_load = function() {
+LC_API.on_after_load = function() {
   // don't hide the chat window only if visitor
   // is currently chatting with an agent
   if (LC_API.visitor_engaged() === false && livechat_chat_started === false) {


### PR DESCRIPTION
## 📓 Description
Fix the old JS API example, so it uses the proper callback