### PR TITLE
API-7617: v3.1: remove supervisor from possible default_group_priorit…

### DIFF
--- a/content/management/configuration-api/index.mdx
+++ b/content/management/configuration-api/index.mdx
@@ -731,6 +731,7 @@ Creates a new Bot.
 | `name`                                 | Yes      | `string`   | Display name                                                                                                                           |
 | `avatar`                               | No       | `string`   | Avatar URL                                                                                                                             |
 | `max_chats_count`                      | No       | `int`      | Max. number of incoming chats that can be routed to the Bot; default: 6.                                                               |
+| `default_group_priority` __*****__     | No       | `string`   | The default routing priority for a group without defined priority.                                                                     |
 | `groups`                               | No       | `object[]` | Groups the Bot belongs to.                                                                                                             |
 | `groups[].id`                          | No       | `int`      | Group ID; required only when `group`'s included.                                                                                       |
 | `groups[].priority` __*__              | Yes      | `string`   | Bot's priority in a group; required only when `group`'s included.                                                                      |
@@ -768,6 +769,14 @@ __****__ `<work_scheduler>` contains the following fields:
 
 - `start` (`string`) - the time when the Bot starts accepting chats, in the format: `HH:MM`
 - `end` (`string`) - the time when the Bot finishes accepting chats, in the format: `HH:MM`
+
+__*****__ The table below presents the possible values for the `default_group_priority` parameter:
+
+| Possible values |  Notes        |
+| --------------- |:-------------:|
+| `first`         | The highest chat routing priority. Agents with the `first` priority get chats before others from the same group, e.g. Bots can get chats before regular Agents.  |
+| `normal`        | The medium chat routing priority. Agents with the `normal` priority get chats before those with the `last` priority, when there are no Agents with the `first` priority available with free slots in the group. |
+| `last`          | The lowest chat routing priority. Agents with the `last` priority get chats when there are no Agents with the `first` or `normal` priority available with free slots in the group.   |
 
 </Text>
 

--- a/content/management/configuration-api/index.mdx
+++ b/content/management/configuration-api/index.mdx
@@ -731,7 +731,7 @@ Creates a new Bot.
 | `name`                                 | Yes      | `string`   | Display name                                                                                                                           |
 | `avatar`                               | No       | `string`   | Avatar URL                                                                                                                             |
 | `max_chats_count`                      | No       | `int`      | Max. number of incoming chats that can be routed to the Bot; default: 6.                                                               |
-| `default_group_priority` __*****__     | No       | `string`   | The default routing priority for a group without defined priority.                                                                     |
+| `default_group_priority` __\*\*\*\*\*__| No       | `string`   | The default routing priority for a group without defined priority.                                                                     |
 | `groups`                               | No       | `object[]` | Groups the Bot belongs to.                                                                                                             |
 | `groups[].id`                          | No       | `int`      | Group ID; required only when `group`'s included.                                                                                       |
 | `groups[].priority` __*__              | Yes      | `string`   | Bot's priority in a group; required only when `group`'s included.                                                                      |
@@ -770,7 +770,7 @@ __****__ `<work_scheduler>` contains the following fields:
 - `start` (`string`) - the time when the Bot starts accepting chats, in the format: `HH:MM`
 - `end` (`string`) - the time when the Bot finishes accepting chats, in the format: `HH:MM`
 
-__*****__ The table below presents the possible values for the `default_group_priority` parameter:
+__\*\*\*\*\*__ The table below presents the possible values for the `default_group_priority` parameter:
 
 | Possible values |  Notes        |
 | --------------- |:-------------:|

--- a/content/management/configuration-api/v3.1/index.mdx
+++ b/content/management/configuration-api/v3.1/index.mdx
@@ -115,7 +115,6 @@ __***__ The table below presents the possible values for the `default_group_prio
 | `first`         | The highest chat routing priority. Agents with the `first` priority get chats before others from the same group, e.g. Bots can get chats before regular Agents.  |
 | `normal`        | The medium chat routing priority. Agents with the `normal` priority get chats before those with the `last` priority, when there are no Agents with the `first` priority available with free slots in the group. |
 | `last`          | The lowest chat routing priority. Agents with the `last` priority get chats when there are no Agents with the `first` or `normal` priority available with free slots in the group.   |
-| `supervisor`    | Bot works as `supervisor` so it will not be assigned to any chats.   |
 
 
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -1009,6 +1009,7 @@ Creates a new Bot.
 | `name`                                 | Yes      | `string`   | Display name                                                                                                                           |
 | `avatar`                               | No       | `string`   | Avatar URL                                                                                                                             |
 | `max_chats_count`                      | No       | `int`      | Max. number of incoming chats that can be routed to the Bot; default: 6.                                                               |
+| `default_group_priority` __****__      | No       | `string`   | The default routing priority for a group without defined priority.                                                                     |
 | `groups`                               | No       | `object[]` | Groups the Bot belongs to.                                                                                                             |
 | `groups[].id`                          | No       | `int`      | Group ID; required only when `group`'s included.                                                                                       |
 | `groups[].priority` __*__              | Yes      | `string`   | Bot's priority in a group; required only when `group`'s included.                                                                      |
@@ -1045,6 +1046,14 @@ __***__ `<work_scheduler>` contains the following fields:
 
 - `start` (`string`) - the time when the Bot starts accepting chats, in the format: `HH:MM`
 - `end` (`string`) - the time when the Bot finishes accepting chats, in the format: `HH:MM`
+
+__****__ The table below presents the possible values for the `default_group_priority` parameter:
+
+| Possible values |  Notes        |
+| --------------- |:-------------:|
+| `first`         | The highest chat routing priority. Agents with the `first` priority get chats before others from the same group, e.g. Bots can get chats before regular Agents.  |
+| `normal`        | The medium chat routing priority. Agents with the `normal` priority get chats before those with the `last` priority, when there are no Agents with the `first` priority available with free slots in the group. |
+| `last`          | The lowest chat routing priority. Agents with the `last` priority get chats when there are no Agents with the `first` or `normal` priority available with free slots in the group.   |
 
 </Text>
 


### PR DESCRIPTION
…y params

v3.2 & v3.3: add default_group_priority

## 🚀 Links

- [Feature branch] https://developers.labs.livechat.com/docs/feature/API-7617-default_group_priority_for_CreateBot
- [Jira] https://livechatinc.atlassian.net/browse/API-7329
## 📓 Description


## ✅ Checklist (for API docs)

- Changelog
- API versions
- Web & RTM
- **Table:** Available methods/webhooks/pushes
- **Table:** Specifics

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)

### Content

- New content
- Proofreading/content fixes
  
### Features (for the website)

- New feature
- Bug fix
- Breaking change
