### PR TITLE
Fix typo `chata` -> `chat`

### DIFF
--- a/content/extending-chat-widget/javascript-api/index.mdx
+++ b/content/extending-chat-widget/javascript-api/index.mdx
@@ -24,7 +24,7 @@ This API works only with the [new Chat Widget](https://developers.livechatinc.co
 
 The API is accessed through the `LiveChatWidget` object.
 It is being initialized within the LiveChat tracking code, which is used to install our Chat Widget on your site.
-If you haven't installed the code yet, you can  either find it directly in the [LiveChat app](https://my.livechatinc.com/settings/code) or copy it from here (remember to replace `<LICENSE_NUMBER>` with your license number):
+If you haven't installed the code yet, you can either find it directly in the [LiveChat app](https://my.livechatinc.com/settings/code) or copy it from here (remember to replace `<LICENSE_NUMBER>` with your license number):
 
 ```html
 <!-- Start of LiveChat (www.livechatinc.com) code -->
@@ -177,7 +177,7 @@ LiveChatWidget.get('customer_data')
 
 ## Get chat data
 
-It returns chata data which contains current chat and thread ids.
+It returns chat data which contains current chat and thread ids.
 
 #### Example
 


### PR DESCRIPTION
## 📓 Description
Just a small typo fix.