### PR TITLE
API-7592: activate -> resume chat

### DIFF
--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -16,6 +16,8 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - The **Deactivate Chat** ([Web](/messaging/agent-chat-api/v3.3/#deactivate-chat) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#deactivate-chat)) method had the `chat_id` parameter renamed to `id`.
 - The **Follow Chat** ([Web](/messaging/agent-chat-api/v3.3/#follow-chat) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#follow-chat)) method had the `chat_id` parameter renamed to `id`.
 - The **Unfollow Chat** ([Web](/messaging/agent-chat-api/v3.3/#unfollow-chat) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#unfollow-chat)) method had the `chat_id` parameter renamed to `id`.
+- The **Activate Chat** method was renamed to **Resume Chat** ([Web](/messaging/agent-chat-api/v3.3/#resume-chat) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#resume-chat)).
+- The **Start Chat** ([Web](/messaging/agent-chat-api/v3.3/#start-chat) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#start-chat)) and **Resume Chat** ([Web](/messaging/agent-chat-api/v3.3/#resume-chat) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#resume-chat)) methods have a new optional parameter, `active`.
 
 ### Chat access
 

--- a/content/messaging/agent-chat-api/v3.3/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/index.mdx
@@ -481,7 +481,7 @@ curl -X POST \
 
 |                 |                                                                                                                                                                                                                                                                                                                                                         |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                 |
+| **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`resume_chat`](#resume-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                 |
 | **Chat access** | [`grant_chat_access`](#grant-chat-access) [`revoke_chat_access`](#revoke-chat-access) [`transfer_chat`](#transfer-chat)                                                                                                                                                                                           |
 | **Chat users**  | [`add_user_to_chat`](#add-user-to-chat) [`remove_user_from_chat`](#remove-user-from-chat)                                                                                                                                                                                                                                                               |
 | **Events**      | [`send_event`](#send-event) [`upload_file`](#upload-file) [`send_rich_message_postback`](#send-rich-message-postback)                                                                                                                                                                                                                                   |
@@ -996,6 +996,7 @@ When `chat.users` is defined, one of following scopes is required:
 | `chat.thread`            | No       | `object`   |                                                                                                          |
 | `chat.thread.events`     | No       | `array`    | The list of initial chat events.                                                                         |
 | `chat.thread.properties` | No       | `object`   |                                                                                                          |
+| `active`                 | No       | `bool`     | When set to `false`, creates an inactive thread; default: `true`.                                         |
 | `continuous`             | No       | `bool`     | Starts chat as continuous (online group is not required); default: `false`.                              |
 
 #### Response
@@ -1035,7 +1036,7 @@ curl -X POST \
 <Section>
 <Text>
 
-### Activate Chat
+### Resume Chat
 
 Restarts an archived chat.
 
@@ -1043,9 +1044,9 @@ Restarts an archived chat.
 
 |                        |                                                                                          |
 |------------------------|------------------------------------------------------------------------------------------|
-| **Method URL**         | `https://api.livechatinc.com/v3.3/agent/action/activate_chat`                            |
+| **Method URL**         | `https://api.livechatinc.com/v3.3/agent/action/resume_chat`                            |
 | **Required scopes \*** | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
-| **RTM API equivalent** | [`activate_chat`](rtm-reference/#activate-chat)                                          |
+| **RTM API equivalent** | [`resume_chat`](rtm-reference/#resume-chat)                                          |
 | **Webhook**            | [`incoming_chat`](/management/configuration-api/#incoming-chat-thread)                   |
 
 **\*)**
@@ -1060,7 +1061,7 @@ When `chat.users` is defined, one of following scopes is required:
 | Parameter                | Required | Data type  | Notes                                                                                                    |
 | ------------------------ | -------- | ---------- | -------------------------------------------------------------------------------------------------------- |
 | `chat`                   | Yes      | `object`   |                                                                                                          |
-| `chat.id`                | Yes      | `string`   | ID of the chat that will be activated.                                                                   |
+| `chat.id`                | Yes      | `string`   | ID of the chat that will be resumed.                                                                     |
 | `chat.access`            | No       | `object`   | Chat access to set, default: all agents.                                                                 |
 | `chat.properties`        | No       | `object`   | Initial chat properties                                                                                  |
 | `chat.users`             | No       | `[]object` | The list of existing users. Up to 4 additional (other than the requester) agents and 1 customer allowed. |
@@ -1068,7 +1069,8 @@ When `chat.users` is defined, one of following scopes is required:
 | `chat.users.type`        | Yes      | `string`   | `agent` or `customer`                                                                                    |
 | `chat.thread`            | No       | `object`   |                                                                                                          |
 | `chat.thread.events`     | No       | `array`    | Initial chat events array                                                                                |
-| `chat.thread.properties` | No       | `object`   | Initial thread properties                                                                           |
+| `chat.thread.properties` | No       | `object`   | Initial thread properties                                                                                |
+| `active`                 | No       | `bool`     | When set to `false`, creates an inactive thread; default: `true`.                                         |
 | `continuous`             | No       | `bool`     | Sets a chat to the continuous mode. When unset, leaves the mode unchanged.                               |
 
 #### Response
@@ -1076,7 +1078,7 @@ When `chat.users` is defined, one of following scopes is required:
 | Parameter   | Data type  | Notes                                                                                                                                                                     |
 | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                           |
-| `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
+| `event_ids` | `[]string` | Returned only when the chat was resumed with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
 
 </Text>
 <Code>
@@ -1084,7 +1086,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 ```shell
 curl -X POST \
-  https://api.livechatinc.com/v3.3/agent/action/activate_chat \
+  https://api.livechatinc.com/v3.3/agent/action/resume_chat \
   -H 'Authorization: Bearer <your_access_token>' \
   -H 'Content-Type: application/json' \
   -d '{

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -491,7 +491,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 
 |                 |                                                                                                                                                                                                                                                                                                                                     |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                                           |
+| **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`resume_chat`](#resume-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                                           |
 | **Chat access** | [`grant_chat_access`](#grant-chat-access) [`revoke_chat_access`](#revoke-chat-access) [`transfer_chat`](#transfer-chat)                                                                                                                                                                                                             |
 | **Chat users**  | [`add_user_to_chat`](#add-user-to-chat) [`remove_user_from_chat`](#remove-user-from-chat)                                                                                                                                                                                                                                           |
 | **Events**      | [`send_event`](#send-event) [`send_rich_message_postback`](#send-rich-message-postback)                                                                                                                                                                                                                                             |
@@ -1061,6 +1061,7 @@ When `chat.users` is defined, one of following scopes is required:
 | `chat.thread`            | No       | `object`   |                                                                                                          |
 | `chat.thread.events`     | No       | `array`    | The list of initial chat events                                                                          |
 | `chat.thread.properties` | No       | `object`   |                                                                                                          |
+| `active`                 | No       | `bool`     | When set to `false`, creates an inactive thread; default: `true`.                                         |
 | `continuous`             | No       | `bool`     | Starts chat as continuous (online group is not required); default: `false`.                              |
 
 #### Response
@@ -1154,7 +1155,7 @@ When `chat.users` is defined, one of following scopes is required:
 <Section>
 <Text>
 
-### Activate Chat
+### Resume Chat
 
 Restarts an archived chat.
 
@@ -1162,9 +1163,9 @@ Restarts an archived chat.
 
 |                        |                                                                                          |
 | ---------------------- | ---------------------------------------------------------------------------------------- |
-| **Action**             | `activate_chat`                                                                          |
+| **Action**             | `resume_chat`                                                                          |
 | **Required scopes \*** | `chats.conversation--all:rw` `chats.conversation--access:rw` `chats.conversation--my:rw` |
-| **Web API equivalent** | [`activate_chat`](../#activate-chat)                                                     |
+| **Web API equivalent** | [`resume_chat`](../#resume-chat)                                                     |
 | **Push message**       | [`incoming_chat`](#incoming_chat)                                                        |
 
 **\*)**
@@ -1179,7 +1180,7 @@ When `chat.users` is defined, one of following scopes is required:
 | Request object           | Required | Type       | Notes                                                                                                    |
 | ------------------------ | -------- | ---------- | -------------------------------------------------------------------------------------------------------- |
 | `chat`                   | Yes      | `object`   |                                                                                                          |
-| `chat.id`                | Yes      | `string`   | The ID of the chat that will be activated.                                                               |
+| `chat.id`                | Yes      | `string`   | The ID of the chat that will be resumed.                                                                 |
 | `chat.access`            | No       | `object`   | Chat access to set, default: all agents.                                                                 |
 | `chat.properties`        | No       | `object`   | Initial chat properties                                                                                  |
 | `chat.users`             | No       | `[]object` | The list of existing users. Up to 4 additional (other than the requester) agents and 1 customer allowed. |
@@ -1188,6 +1189,7 @@ When `chat.users` is defined, one of following scopes is required:
 | `chat.thread`            | No       | `object`   |                                                                                                          |
 | `chat.thread.events`     | No       | `array`    | Initial chat events array                                                                                |
 | `chat.thread.properties` | No       | `object`   | Initial thread properties                                                                                |
+| `active`                 | No       | `bool`     | When set to `false`, creates an inactive thread. Default `true`.                                          |
 | `continuous`             | No       | `bool`     | Sets a chat to the continuous mode. When unset, leaves the mode unchanged.                               |
 
 #### Response
@@ -1195,7 +1197,7 @@ When `chat.users` is defined, one of following scopes is required:
 | Parameter   | Data type  | Notes                                                                                                                                                                     |
 | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                           |
-| `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
+| `event_ids` | `[]string` | Returned only when the chat was resumed with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
 
 </Text>
 <Code>
@@ -1203,7 +1205,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 ```json
 {
-  "action": "activate_chat",
+  "action": "resume_chat",
   "payload": {
   "chat": {
     "id": "PWJ8Y4THAV"
@@ -1213,47 +1215,6 @@ When `chat.users` is defined, one of following scopes is required:
 ```
 
 </CodeSample>
-
-<!-- > **`activate_chat`** sample **request** with optional params
-
-```json
-{
-  "request_id": "7676",
-  "action": "activate_chat",
-  "payload": {
-  "chat": {
-    "id": "PJ0MRSHTDG",
-    "access": {
-      "group_ids": [1]
-    },
-    "properties": {
-      "source": {
-        "type": "facebook"
-      }
-    },
-    "thread": {
-      "events": [{
-        "type": "message",
-        "custom_id": "31-0C-1C-07-DB-16",
-        "text": "hello there"
-      }, {
-        "type": "system_message",
-        "custom_id": "31-0C-1C-07-DB-16",
-        "text": "hello there"
-      }],
-      "properties": {
-        "source": {
-          "type": "facebook"
-        },
-        // ...
-      },
-      "tags": ["bug_report"]
-      }
-    }
-  },
-  "author_id": "<author_id>" // optional, applies only to bots
-}
-``` -->
 
 <CodeResponse>
 

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -14,6 +14,8 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 ### Chats
 
 - In the **Deactivate Chat** ([Web](/messaging/customer-chat-api/v3.3/#deactivate-chat) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#deactivate-chat)) method, the `chat_id` parameter was renamed to `id`.
+- The **Activate Chat** method was renamed to **Resume Chat** ([Web](/messaging/customer-chat-api/v3.3/#resume-chat) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#resume-chat)).
+- The **Start Chat** ([Web](/messaging/agent-chat-api/v3.3/#start-chat) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#start-chat)) and **Resume Chat** ([Web](/messaging/customer-chat-api/v3.3/#resume-chat) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#resume-chat)) methods have a new optional parameter, `active`.
 
 ### Config
 

--- a/content/messaging/customer-chat-api/v3.3/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/index.mdx
@@ -483,7 +483,7 @@ curl -X POST \
 
 |                  |                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**        | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat)                                                                                                                                                                                                                                                                     |
+| **Chats**        | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`start_chat`](#start-chat) [`resume_chat`](#resume-chat) [`deactivate_chat`](#deactivate-chat)                                                                                                                                                                                                                                                                     |
 | **Configuration** | [`get_dynamic_configuration`](#get-dynamic-configuration) [`get_configuration`](#get-configuration)                                                                                                                                                                                                                                                                                                                                                                                                     |
 | **Events**       | [`send_event`](#send-event) [`upload_file`](#upload-file) [`send_rich_message_postback`](#send-rich-message-postback) [`send_sneak_peek`](#send-sneak-peek)                                                                                                                                                                                                                                                                                                 |
 | **Localization** | [`get_localization`](#get-localization)                                                                                                                                                                                                                                                                                                                                                                                                               |
@@ -804,6 +804,7 @@ Starts a chat.
 | `chat.thread`            | No       | `object`  |                                                                             |
 | `chat.thread.events`     | No       | `array`   | Initial chat events array                                                   |
 | `chat.thread.properties` | No       | `object`  | Initial thread properties                                                   |
+| `active`                 | No       | `bool`    | When set to `false`, creates an inactive thread; default: `true`.            |
 | `continuous`             | No       | `bool`    | Starts chat as continuous (online group is not required); default: `false`. |
 
 #### Response
@@ -849,7 +850,7 @@ curl -X POST \
 
 <Text>
 
-### Activate Chat
+### Resume Chat
 
 Used to restart an archived chat.
 
@@ -857,8 +858,8 @@ Used to restart an archived chat.
 
 |                        |                                                                  |
 |------------------------|------------------------------------------------------------------|
-| **Method URL**         | `https://api.livechatinc.com/v3.3/customer/action/activate_chat` |
-| **RTM API equivalent** | [`activate_chat`](rtm-reference/#activate-chat)                  |
+| **Method URL**         | `https://api.livechatinc.com/v3.3/customer/action/resume_chat` |
+| **RTM API equivalent** | [`resume_chat`](rtm-reference/#resume-chat)                  |
 | **Webhook**            | [`incoming_chat`](/management/configuration-api/#incoming_chat)  |
 
 #### Request
@@ -866,12 +867,13 @@ Used to restart an archived chat.
 | Parameter                | Required | Data type| Notes                                                                      |
 |--------------------------|----------|----------|----------------------------------------------------------------------------|
 | `chat`                   | Yes      | `object` |                                                                            |
-| `chat.id`                | Yes      | `string` | ID of the chat that will be activated.                                     |
+| `chat.id`                | Yes      | `string` | ID of the chat that will be resumed.                                       |
 | `chat.access`            | No       | `object` | Chat access to set; default: all agents.                                   |
 | `chat.properties`        | No       | `object` | Initial chat properties                                                    |
 | `chat.thread`            | No       | `object` |                                                                            |
 | `chat.thread.events`     | No       | `array`  | Initial chat events array                                                  |
 | `chat.thread.properties` | No       | `object` | Initial thread properties                                                  |
+| `active`                 | No       | `bool`   | When set to `false`, creates an inactive thread; default: `true`.           |
 | `continuous`             | No       | `bool`   | Sets a chat to the continuous mode. When unset, leaves the mode unchanged. |
 
 #### Response
@@ -879,7 +881,7 @@ Used to restart an archived chat.
 | Field       | Data type  | Notes                                                                                                                                                                     |
 | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                           |
-| `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
+| `event_ids` | `[]string` | Returned only when the chat was resumed with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
 
 </Text>
 
@@ -889,7 +891,7 @@ Used to restart an archived chat.
 
 ```shell
 curl -X POST \
-  https://api.livechatinc.com/v3.3/customer/action/activate_chat?license_id=<license_id> \
+  https://api.livechatinc.com/v3.3/customer/action/resume_chat?license_id=<license_id> \
   -H 'Content-Type: <content-type>' \
   -H 'Authorization: Bearer <customer_access_token>' \
   -d '{

--- a/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
@@ -486,7 +486,7 @@ When connecting to the Customer Chat RTM API, clients have to send over the requ
 
 |                |                                                                                                                                                                                                                                                                                                                                     |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**      | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`start_chat`](#start-chat) [`activate_chat`](#activate-chat) [`deactivate_chat`](#deactivate-chat)                                                                                                                                             |
+| **Chats**      | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`start_chat`](#start-chat) [`resume_chat`](#resume-chat) [`deactivate_chat`](#deactivate-chat)                                                                                                                                             |
 | **Events**     | [`send_event`](#send-event) [`send_rich_message_postback`](#send-rich-message-postback) [`send_sneak_peek`](#send-sneak-peek)                                                                                                                                                                                                       |
 | **Properties** | [`update_chat_properties`](#update-chat-properties) [`delete_chat_properties`](#delete-chat-properties) [`update_thread_properties`](#update-thread-properties) [`delete_thread_properties`](#delete-thread-properties) [`update_event_properties`](#update-event-properties) [`delete_event_properties`](#delete-event-properties) |
 | **Customers**  | [`update_customer`](#update-customer) [`update_customer_page`](#update-customer-page) [`set_customer_session_fields`](#set-customer-session-fields) [`get_customer`](#get-customer)                                                                                                                                                 |
@@ -859,6 +859,7 @@ Starts a chat.
 | `chat.thread`            | No       | `object`  |                                                                             |
 | `chat.thread.events`     | No       | `array`   | Initial chat events array                                                   |
 | `chat.thread.properties` | No       | `object`  | Initial thread properties                                                   |
+| `active`                 | No       | `bool`    | When set to `false`, creates an inactive thread; default: `true`.            |
 | `continuous`             | No       | `bool`    | Starts chat as continuous (online group is not required); default: `false`. |
 
 #### Response
@@ -905,49 +906,11 @@ Starts a chat.
 
 </Section>
 
-<!-- > **`start_chat`** sample **request** with optional params
-
-```json
-{
-  "action": "start_chat",
-  "payload": {
-  "chat": {
-    "access": {
-      "group_ids": [1]
-    },
-    "properties": {
-      "source": {
-        "type": "facebook"
-      }
-    },
-    "thread": {
-      "events": [{
-        "type": "message",
-        "custom_id": "31-0C-1C-07-DB-16",
-        "text": "hello there"
-      }, {
-        "type": "system_message",
-        "custom_id": "31-0C-1C-07-DB-16",
-        "text": "hello there"
-      }],
-      "properties": {
-        "source": {
-          "type": "facebook"
-        },
-        // ...
-      }
-    }
-  },
-  "continuous": true
-  }
-}
-``` -->
-
 <Section>
 
 <Text>
 
-### Activate Chat
+### Resume Chat
 
 Used to restart an archived chat.
 
@@ -955,8 +918,8 @@ Used to restart an archived chat.
 
 |                        |                                      |
 | ---------------------- | ------------------------------------ |
-| **Action**             | `activate_chat`                      |
-| **Web API equivalent** | [`activate_chat`](../#activate-chat) |
+| **Action**             | `resume_chat`                      |
+| **Web API equivalent** | [`resume_chat`](../#resume-chat) |
 | **Push message**       | [`incoming_chat`](#incoming_chat)    |
 
 #### Request
@@ -964,12 +927,13 @@ Used to restart an archived chat.
 | Request object           | Required | Type     | Notes                                                                      |
 | ------------------------ | -------- | -------- | -------------------------------------------------------------------------- |
 | `chat`                   | Yes      | `object` |                                                                            |
-| `chat.id`                | Yes      | `string` | The ID of the chat that will be activated.                                 |
+| `chat.id`                | Yes      | `string` | The ID of the chat that will be resumed.                                   |
 | `chat.access`            | No       | `object` | Chat access to set, default: all agents.                                   |
 | `chat.properties`        | No       | `object` | Initial chat properties                                                    |
 | `chat.thread`            | No       | `object` |                                                                            |
 | `chat.thread.events`     | No       | `array`  | Initial chat events array                                                  |
 | `chat.thread.properties` | No       | `object` | Initial thread properties                                                  |
+| `active`                 | No       | `bool`   | When set to `false`, creates an inactive thread; default: `true`.           |
 | `continuous`             | No       | `bool`   | Sets a chat to the continuous mode. When unset, leaves the mode unchanged. |
 
 #### Response
@@ -977,7 +941,7 @@ Used to restart an archived chat.
 | Parameter   | Data type  | Notes                                                                                                                                                                     |
 | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                           |
-| `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
+| `event_ids` | `[]string` | Returned only when the chat was resumed with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
 
 </Text>
 
@@ -987,7 +951,7 @@ Used to restart an archived chat.
 
 ```json
 {
-  "action": "activate_chat",
+  "action": "resume_chat",
   "payload": {
   "chat": {
     "id": "PWJ8Y4THAV"
@@ -1003,7 +967,7 @@ Used to restart an archived chat.
 ```json
 {
   "request_id": "<request_id>", // optional
-  "action": "activate_chat",
+  "action": "resume_chat",
   "type": "response",
   "success": true,
   "payload": {
@@ -1017,45 +981,6 @@ Used to restart an archived chat.
 </Code>
 
 </Section>
-
-<!-- > **`activate_chat`** sample **request** with optional params
-
-```json
-{
-  "request_id": "7676",
-  "action": "activate_chat",
-  "payload": {
-  "chat": {
-    "id": "PJ0MRSHTDG",
-    "access": {
-      "group_ids": [1]
-    },
-    "properties": {
-      "source": {
-        "type": "facebook"
-      }
-    },
-    "thread": {
-      "events": [{
-        "type": "message",
-        "custom_id": "31-0C-1C-07-DB-16",
-        "text": "hello there"
-      }, {
-        "type": "system_message",
-        "custom_id": "31-0C-1C-07-DB-16",
-        "text": "hello there"
-      }],
-      "properties": {
-        "source": {
-          "type": "facebook"
-        },
-        // ...
-        }
-      }
-    }
-  }
-}
-``` -->
 
 <Section>
 


### PR DESCRIPTION
start/resume_chat: `active`

## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-7592-resume-and-offline-thread)
- [Jira](https://livechatinc.atlassian.net/browse/API-7592)

## 📓 Description


## ✅ Checklist (for API docs)

- Changelog
- API versions
- Web & RTM
- **Table:** Available methods/webhooks/pushes
- **Table:** Specifics

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)

### Content

- New content
- Proofreading/content fixes
  
### Features (for the website)

- New feature
- Bug fix
- Breaking change
