### PR TITLE
Additional info about user's EventsSeenUpTo in Start/ResumeChat and S…

### DIFF
--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -18,6 +18,7 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 - The **Unfollow Chat** ([Web](/messaging/agent-chat-api/v3.3/#unfollow-chat) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#unfollow-chat)) method had the `chat_id` parameter renamed to `id`.
 - The **Activate Chat** method was renamed to **Resume Chat** ([Web](/messaging/agent-chat-api/v3.3/#resume-chat) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#resume-chat)).
 - The **Start Chat** ([Web](/messaging/agent-chat-api/v3.3/#start-chat) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#start-chat)) and **Resume Chat** ([Web](/messaging/agent-chat-api/v3.3/#resume-chat) & [RTM](/messaging/agent-chat-api/v3.3/rtm-reference/#resume-chat)) methods have a new optional parameter, `active`.
+- The **Start Chat** and **Activate Chat** methods now update the requester's `events_seen_up_to` as if all chat events were already seen by the requester. A subsequent call to **Mark Events As Seen** can be skipped in such cases.
 
 ### Chat access
 

--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -1506,9 +1506,11 @@ https://api.livechatinc.com/v3.2/agent/action/remove_user_from_chat \
 
 ### Send Event
 
-Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request.
+Sends an [Event](#events) object. Use this method to send a message by specifying the [Message](#message) event type in the request.
 
 It's possible to write to a chat without joining it. The user sending an event will be automatically added to the chat with the `present` parameter set to `false` (see [`user_added_to_chat`](/messaging/agent-chat-api/rtm-reference/#user_added_to_chat)). **Sample use case:** a Bot Agent that sends messages visible to all chat participants without actually joining the chat.
+
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
 #### Specifics
 

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -1747,9 +1747,11 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 
 ### Send Event
 
-Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request.
+Sends an [Event](#events) object. Use this method to send a message by specifying the [Message](#message) event type in the request.
 
 It's possible to write to a chat without joining it. The user sending an event will be automatically added to the chat with the `present` parameter set to `false` (see [`user_added_to_chat`](#user_added_to_chat)). **Sample use case:** a Bot Agent that sends messages visible to all chat participants without actually joining the chat.
+
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
 #### Specifics
 

--- a/content/messaging/agent-chat-api/v3.3/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/index.mdx
@@ -970,6 +970,8 @@ curl -X POST \
 
 Starts a chat.
 
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
+
 #### Specifics
 
 |                        |                                                                                          |
@@ -1042,6 +1044,8 @@ curl -X POST \
 ### Resume Chat
 
 Restarts an archived chat.
+
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
 #### Specifics
 
@@ -1507,9 +1511,11 @@ https://api.livechatinc.com/v3.3/agent/action/remove_user_from_chat \
 
 ### Send Event
 
-Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request.
+Sends an [Event](#events) object. Use this method to send a message by specifying the [Message](#message) event type in the request.
 
 It's possible to write to a chat without joining it. The user sending an event will be automatically added to the chat with the `present` parameter set to `false` (see [`user_added_to_chat`](/messaging/agent-chat-api/rtm-reference/#user_added_to_chat)). **Sample use case:** a Bot Agent that sends messages visible to all chat participants without actually joining the chat.
+
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
 #### Specifics
 

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -1036,6 +1036,8 @@ There's only one value allowed for a single property.
 
 Starts a chat.
 
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
+
 #### Specifics
 
 |                        |                                                                                          |
@@ -1162,6 +1164,8 @@ When `chat.users` is defined, one of following scopes is required:
 ### Resume Chat
 
 Restarts an archived chat.
+
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
 #### Specifics
 
@@ -1722,9 +1726,11 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 
 ### Send Event
 
-Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request.
+Sends an [Event](#events) object. Use this method to send a message by specifying the [Message](#message) event type in the request.
 
 It's possible to write to a chat without joining it. The user sending an event will be automatically added to the chat with the `present` parameter set to `false` (see [`user_added_to_chat`](#user_added_to_chat)). **Sample use case:** a Bot Agent that sends messages visible to all chat participants without actually joining the chat.
+
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
 #### Specifics
 

--- a/content/messaging/customer-chat-api/changelog/index.mdx
+++ b/content/messaging/customer-chat-api/changelog/index.mdx
@@ -16,6 +16,7 @@ This document is the record of all the changes in the **Customer Chat API**, Web
 - In the **Deactivate Chat** ([Web](/messaging/customer-chat-api/v3.3/#deactivate-chat) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#deactivate-chat)) method, the `chat_id` parameter was renamed to `id`.
 - The **Activate Chat** method was renamed to **Resume Chat** ([Web](/messaging/customer-chat-api/v3.3/#resume-chat) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#resume-chat)).
 - The **Start Chat** ([Web](/messaging/agent-chat-api/v3.3/#start-chat) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#start-chat)) and **Resume Chat** ([Web](/messaging/customer-chat-api/v3.3/#resume-chat) & [RTM](/messaging/customer-chat-api/v3.3/rtm-reference/#resume-chat)) methods have a new optional parameter, `active`.
+- The **Start Chat** and **Activate Chat** methods now update the requester's `events_seen_up_to` as if all chat events were already seen by the requester. A subsequent call to **Mark Events As Seen** can be skipped in such cases.
 
 ### Config
 

--- a/content/messaging/customer-chat-api/index.mdx
+++ b/content/messaging/customer-chat-api/index.mdx
@@ -953,7 +953,9 @@ curl -X POST \
 
 ### Send Event
 
-Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request.
+Sends an [Event](#events) object. Use this method to send a message by specifying the [Message](#message) event type in the request.
+
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
 #### Specifics
 

--- a/content/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -1100,7 +1100,9 @@ Deactivates a chat by closing the currently open thread. Sending messages to thi
 
 ### Send Event
 
-Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request.
+Sends an [Event](#events) object. Use this method to send a message by specifying the [Message](#message) event type in the request.
+
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
 #### Specifics
 

--- a/content/messaging/customer-chat-api/v3.3/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/index.mdx
@@ -786,6 +786,8 @@ curl -X POST \
 
 Starts a chat.
 
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
+
 #### Specifics
 
 |                        |                                                                 |
@@ -852,7 +854,9 @@ curl -X POST \
 
 ### Resume Chat
 
-Used to restart an archived chat.
+Restarts an archived chat.
+
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
 #### Specifics
 
@@ -1125,7 +1129,9 @@ curl -X GET \
 
 ### Send Event
 
-Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request.
+Sends an [Event](#events) object. Use this method to send a message by specifying the [Message](#message) event type in the request.
+
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
 #### Specifics
 

--- a/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
@@ -840,6 +840,8 @@ You cannot use both `limit` and `min_events_count` at the same time.
 
 Starts a chat.
 
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
+
 #### Specifics
 
 |                        |                                   |
@@ -912,7 +914,9 @@ Starts a chat.
 
 ### Resume Chat
 
-Used to restart an archived chat.
+Restarts an archived chat.
+
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
 #### Specifics
 
@@ -1049,7 +1053,9 @@ Deactivates a chat by closing the currently open thread. Sending messages to thi
 
 ### Send Event
 
-Sends an [Event](#events) object. Use this method to send a message by specifing the [Message](#message) event type in the request.
+Sends an [Event](#events) object. Use this method to send a message by specifying the [Message](#message) event type in the request.
+
+The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
 #### Specifics
 


### PR DESCRIPTION
…endEvent.

## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-7061-activate-chat-seen-events)
- [Jira](https://livechatinc.atlassian.net/browse/API-6987)

## 📓 Description

Start/ResumeChat - describes new behavior in v3.3
SendEvent - adds missing info

## 👷 Type of change (remove not needed)

### Content

- New content
- Proofreading/content fixes