### PR TITLE
API-8104 webhooks 3.3: new field and methods renamed

### DIFF
--- a/content/management/changelog/index.mdx
+++ b/content/management/changelog/index.mdx
@@ -77,11 +77,11 @@ Since the migration is still ongoing, different parts will be successively moved
   - The [**Register Webhook**](/management/configuration-api/v3.3/#register-webhook) method:
     - had the `webhook_id` field in response renamed to `id`.
     - had the required scope changed to `webhooks.configuration:rw`.
-    - has a new mandatory parameter, `owner_client_id`.
+    - has two new mandatory parameters, `owner_client_id` and `type` ("bot" or "license").
   - There are new methods for managing webhooks:
-    - [**Enable Webhooks**](/management/configuration-api/v3.3/#enable-webhooks)
-    - [**Disable Webhooks**](/management/configuration-api/v3.3/#disable-webhooks)
-    - [**Get Webhooks State**](/management/configuration-api/v3.3/#get-webhooks-state)
+    - [**Enable License Webhooks**](/management/configuration-api/v3.3/#enable-license-webhooks)
+    - [**Disable License Webhooks**](/management/configuration-api/v3.3/#disable-license-webhooks)
+    - [**Get License Webhooks State**](/management/configuration-api/v3.3/#get-license-webhooks-state)
 
 ## [v3.2] - 2020-06-18
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -3611,7 +3611,7 @@ Informs that a user has seen events up to a specific time.
 
 ### Register Webhook
 
-Registers a webhook for the Client ID (application) provided in the request. Later on, registered webhooks can be [enabled](#enable-webhooks) for a given license.
+Registers a webhook for the Client ID (application) provided in the request. Later on, registered webhooks can be [enabled](#enable-license-webhooks) for a given license.
 
 #### Specifics
 
@@ -3634,6 +3634,7 @@ Registers a webhook for the Client ID (application) provided in the request. Lat
 | `filters.chat_member_ids.agents_any`     | no       | `[]string` | Array of Agents' ids; if any specified Agent is in the chat, the webhook will be triggered.                                                               |
 | `filters.chat_member_ids.agents_exclude` | no       | `[]string` | Array of Agents' ids; If any specified Agent is in the chat, the webhook will not be triggered.                                                           |
 | `owner_client_id`                        | yes      | `string`   | The Client ID for which the webhook will be registered.                                                                                                   |
+| `type`                                   | yes      | `string`   | `bot` or `license`                                                                                                                                        |
 
 #### Triggering actions
 
@@ -3679,7 +3680,9 @@ curl -X POST \
         "url": "http://myservice.com/webhooks",
         "description": "Test webhook",
         "action": "chat_deactivated",
-        "secret_key": "laudla991lamda0pnoaa0"
+        "secret_key": "laudla991lamda0pnoaa0",
+        "owner_client_id": "asXdesldiAJSq9padj",
+        "type": "license"
       }'
 ```
 
@@ -3831,16 +3834,16 @@ curl -X POST \
 
 <Text>
 
-### Enable Webhooks
+### Enable License Webhooks
 
 Enables the webhooks [registered](#register-webhook) for a given **Client Id** (application) for the license associated with the access token used in the request.
 
 #### Specifics
 
-|                 |                                                                         |
-| --------------- | ----------------------------------------------------------------------- |
-| Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/enable_webhooks` |
-| Required scopes | `webhooks.state:rw`                                                     |
+|                 |                                                                                 |
+| --------------- | ------------------------------------------------------------------------------- |
+| Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/enable_license_webhooks` |
+| Required scopes | `webhooks.state:rw`                                                             |
 
 #### Request
 
@@ -3860,7 +3863,7 @@ No response payload (`200 OK`).
 
 ```shell
 curl -X POST \
-  https://api.livechatinc.com/v3.3/configuration/action/enable_webhooks \
+  https://api.livechatinc.com/v3.3/configuration/action/enable_license_webhooks \
   -H 'Content-Type: application/json' \
   -d '{}'
 ```
@@ -3875,16 +3878,16 @@ curl -X POST \
 
 <Text>
 
-### Disable Webhooks
+### Disable license Webhooks
 
-Disables the [enabled webhooks](#enable-webhooks).
+Disables the [enabled webhooks](#enable-license-webhooks).
 
 #### Specifics
 
-|                 |                                                                          |
-| --------------- | ------------------------------------------------------------------------ |
-| Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/disable_webhooks` |
-| Required scopes | `webhooks.state:rw`                                                      |
+|                 |                                                                                  |
+| --------------- | -------------------------------------------------------------------------------- |
+| Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/disable_license_webhooks` |
+| Required scopes | `webhooks.state:rw`                                                              |
 
 #### Request
 
@@ -3904,7 +3907,7 @@ No response payload (`200 OK`).
 
 ```shell
 curl -X POST \
-  https://api.livechatinc.com/v3.3/configuration/action/disable_webhooks \
+  https://api.livechatinc.com/v3.3/configuration/action/disable_license_webhooks \
   -H 'Content-Type: application/json' \
   -d '{}'
 ```
@@ -3919,16 +3922,16 @@ curl -X POST \
 
 <Text>
 
-### Get Webhooks State
+### Get License Webhooks State
 
 Gets the state of the webhooks registered for a given **Client Id** (application) on the license associated with the access token used in the request.
 
 #### Specifics
 
-|                 |                                                                            |
-| --------------- | -------------------------------------------------------------------------- |
-| Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/get_webhooks_state` |
-| Required scopes | `webhooks.state:ro`                                                        |
+|                 |                                                                                    |
+| --------------- | ---------------------------------------------------------------------------------- |
+| Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/get_license_webhooks_state` |
+| Required scopes | `webhooks.state:ro`                                                                |
 
 #### Request
 
@@ -3944,7 +3947,7 @@ Gets the state of the webhooks registered for a given **Client Id** (application
 
 ```shell
 curl -X POST \
-  https://api.livechatinc.com/v3.3/configuration/action/get_webhooks_state \
+  https://api.livechatinc.com/v3.3/configuration/action/get_license_webhooks_state \
   -H 'Content-Type: application/json' \
   -d '{}'
 ```

--- a/payloads/management/v3.3/configuration-api/responses/webhooks/getWebhooksState.json
+++ b/payloads/management/v3.3/configuration-api/responses/webhooks/getWebhooksState.json
@@ -1,3 +1,3 @@
 {
-    "webhooks_enabled": true
+    "license_webhooks_enabled": true
 }

--- a/payloads/management/v3.3/configuration-api/responses/webhooks/listWebhooks.json
+++ b/payloads/management/v3.3/configuration-api/responses/webhooks/listWebhooks.json
@@ -11,6 +11,7 @@
         ]
       }
     },
-    "owner_client_id": "asXdesldiAJSq9padj"
+    "owner_client_id": "asXdesldiAJSq9padj",
+    "type": "license"
   }
 ]


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-8104-type-in-webhooks-3.3)
- [Jira](https://livechatinc.atlassian.net/browse/API-8104)

## 📓 Description
Changes in v3.3 only:
- New field `type` in webhooks (used in register-webhook and list-webhooks)
- 3 webhook management method renamed to better reflect their responsibilities

## ✅ Checklist (for API docs)

- Changelog
- API versions
- Web & RTM
- **Table:** Available methods/webhooks/pushes
- **Table:** Specifics

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)

### Features

- Development of existing features in API v3.3
