### PR TITLE
add info about timezone in get-bot and list-bots methods

### DIFF
--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -1022,7 +1022,7 @@ Creates a new Bot.
 | `webhooks.actions[].additional_data`   | No       | `string[]` | Additional data that will arrive with webhooks.                                                                                        |
 | `work_scheduler`                       | No       | `object`   | Work scheduler options to set for the new Bot.                                                                                         |
 | `work_scheduler.**.<work_scheduler>`   | No       | `object`   | `<work_scheduler>` values __***__.                                                                                                     |
-| `timezone`                             | No       | `string`   | The time zone in which the Bot's work scheduler should operate. Required if `work_scheduler` is provided.                                       |
+| `timezone`                             | Yes      | `string`   | The time zone in which the Bot's work scheduler should operate. Required only if `work_scheduler` is provided.                                       |
 
 __*__ Possible values for the `groups[].priority` parameter:
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -1250,12 +1250,13 @@ __*__ **Calling List Bots with `all:false`**
 
 __**__ Possible values for the `fields[]` parameter:
 
-| Possible value        | Notes                                                     |
-| --------------------- | --------------------------------------------------------- |
-| `groups`              | Groups a Bot belongs to                                |
-| `work_scheduler`      | Work scheduler object for a Bot                        |
-| `job_title`           | Bot's job title                                         |
-| `max_chats_count`     | Bot's maximum number of concurrent chats                |
+| Possible value    | Notes                                                    |
+|-------------------|----------------------------------------------------------|
+| `groups`          | Groups a Bot belongs to                                  |
+| `work_scheduler`  | Work scheduler object for a Bot                          |
+| `job_title`       | Bot's job title                                          |
+| `max_chats_count` | Bot's maximum number of concurrent chats                 |
+| `timezone`        | The time zone in which the Bot's work scheduler operates |
 
 </Text>
 
@@ -1303,12 +1304,13 @@ curl -X POST \
 
 __*__ Possible values for the `fields[]` parameter:
 
-| Possible value        | Notes                                                     |
-| --------------------- | --------------------------------------------------------- |
-| `work_scheduler`      | Work scheduler object for a Bot                        |
-| `groups`              | Groups a Bot belongs to                                |
-| `job_title`           | Bot's job title                                         |
-| `max_chats_count`     | Bot's maximum number of concurrent chats                |
+| Possible value    | Notes                                                    |
+|-------------------|----------------------------------------------------------|
+| `work_scheduler`  | Work scheduler object for a Bot                          |
+| `groups`          | Groups a Bot belongs to                                  |
+| `job_title`       | Bot's job title                                          |
+| `max_chats_count` | Bot's maximum number of concurrent chats                 |
+| `timezone`        | The time zone in which the Bot's work scheduler operates |
 
 </Text>
 


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/bot-timezone)

## 📓 Description

One of possible values in `fields` (`list_bot` / `get_bot`) is not documented.