### PR TITLE
Remove information about filters object which is no longer required i…

### DIFF
--- a/content/messaging/agent-chat-api/v3.3/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/index.mdx
@@ -511,7 +511,7 @@ It returns [summaries](#chat-summaries) of the chats an Agent has access to.
 
 | Parameter                                             | Required | Type     | Notes                                                                                       |
 | ----------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------- |
-| `filters`                                             | No       | `object` | Mustn't change between requests for subsequent pages. Otherwise, the behavior is undefined. |
+| `filters`                                             | No       | `object` |                                                                                             |
 | `filters.include_active`                              | No       | `bool`   | Defines if the returned chat summary includes active chats; default: `true`.                |
 | `filters.include_chats_without_threads`               | No       | `bool`   | Defines if the returned chat summary includes chats without any threads; default: `true`.   |
 | `filters.group_ids`                                   | No       | `array`  | Array of group IDs. Max array size: 200                                                     |

--- a/content/messaging/agent-chat-api/v3.3/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/index.mdx
@@ -511,7 +511,7 @@ It returns [summaries](#chat-summaries) of the chats an Agent has access to.
 
 | Parameter                                             | Required | Type     | Notes                                                                                       |
 | ----------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------- |
-| `filters`                                             | No       | `object` |                                                                                             |
+| `filters`                                             | No       | `object` | When paginating, `filters` provided in the first request are remembered and automatically used for the subsequent requests. Providing a new `filters` object will result in a `validation` error.  To reset the filters, start paginating with a new set of filters.|
 | `filters.include_active`                              | No       | `bool`   | Defines if the returned chat summary includes active chats; default: `true`.                |
 | `filters.include_chats_without_threads`               | No       | `bool`   | Defines if the returned chat summary includes chats without any threads; default: `true`.   |
 | `filters.group_ids`                                   | No       | `array`  | Array of group IDs. Max array size: 200                                                     |

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -558,7 +558,7 @@ It returns [summaries](#chat-summaries) of the chats an Agent has access to.
 
 | Request object                                        | Required | Type     | Notes                                                                                       |
 | ----------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------- |
-| `filters`                                             | No       | `object` |                                                                                             |
+| `filters`                                             | No       | `object` | When paginating, `filters` provided in the first request are remembered and automatically used for the subsequent requests. Providing a new `filters` object will result in a `validation` error. To reset the filters, start paginating with a new set of filters.|
 | `filters.include_active`                              | No       | `bool`   | Defines if the returned chat summary includes active chats; default: `true`.                |
 | `filters.include_chats_without_threads`               | No       | `bool`   | Defines if the returned chat summary includes chats without any threads; default: `true`.   |
 | `filters.group_ids`                                   | No       | `array`  | Array of group IDs. Max array size: 200                                                     |

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -558,7 +558,7 @@ It returns [summaries](#chat-summaries) of the chats an Agent has access to.
 
 | Request object                                        | Required | Type     | Notes                                                                                       |
 | ----------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------- |
-| `filters`                                             | No       | `object` | Mustn't change between requests for subsequent pages. Otherwise, the behavior is undefined. |
+| `filters`                                             | No       | `object` |                                                                                             |
 | `filters.include_active`                              | No       | `bool`   | Defines if the returned chat summary includes active chats; default: `true`.                |
 | `filters.include_chats_without_threads`               | No       | `bool`   | Defines if the returned chat summary includes chats without any threads; default: `true`.   |
 | `filters.group_ids`                                   | No       | `array`  | Array of group IDs. Max array size: 200                                                     |


### PR DESCRIPTION
…n v3.3 when providing a page ID.
FB: https://developers.labs.livechat.com/docs/feature/Remove-filters-info-in-3-3-for-pagination/

## 📓 Description
In v3.3, filters requested on first page are remembered when paginating. Providing `filters` object in the request with `page_id` would result in validation error. note: I'm not sure if this should be included in the changelog, as this has been in place for a while, probably someone just overseen this detail.

## ✅ Checklist (for API docs)

- Changelog
- API versions
- Web & RTM
- **Table:** Available methods/webhooks/pushes
- **Table:** Specifics

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)

### Content

- Proofreading/content fixes
 
