### PR TITLE
[DPS-2587] Refactor parameter/field in Messaging + Configuration API nomenclature

### DIFF
--- a/content/management/configuration-api/index.mdx
+++ b/content/management/configuration-api/index.mdx
@@ -204,7 +204,7 @@ It returns the info about an Agent specified by `id`.
 
 #### Request
 
-| Request object | Type       | Required | Notes                         |
+| Parameter | Type       | Required | Notes                         |
 | -------------- | ---------- | -------- | ----------------------------- |
 | `id`           | `string`   | Yes      | Agent ID                      |
 | `fields`__*__  | `string[]` | No       | Additional fields to include. |
@@ -1072,7 +1072,7 @@ Creates a new group.
 
 #### Request
 
-| Request object          | Data type | Required | Notes                                                                                                                            |
+| Parameter          | Data type | Required | Notes                                                                                                                            |
 | ----------------------- | --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `name`                  | `string`  | Yes      | Group name (up to 180 chars)                                                                                                     |
 | `language_code`         | `string`  | No       | The code of the group languange                                                                                                  |
@@ -1132,7 +1132,7 @@ Updates an existing group.
 
 #### Request
 
-| Request object          | Data type | Required | Notes                                                                        |
+| Parameter          | Data type | Required | Notes                                                                        |
 | ----------------------- | --------- | -------- | ---------------------------------------------------------------------------- |
 | `id`                    | `int`     | Yes      | Group ID                                                                     |
 | `name`                  | `string`  | No       | Group name (up to 180 chars)                                                 |
@@ -1196,7 +1196,7 @@ Deletes an existing group.
 
 #### Request
 
-| Request object | Data type | Required | Notes    |
+| Parameter | Data type | Required | Notes    |
 | -------------- | --------- | -------- | -------- |
 | `id`           | `int`     | Yes      | Group ID |
 
@@ -1243,7 +1243,7 @@ Lists all the exisiting groups.
 
 #### Request
 
-| Request object | Data type  | Required | Notes                         |
+| Parameter | Data type  | Required | Notes                         |
 | -------------- | ---------- | -------- | ----------------------------- |
 | `fields`__*__  | `string[]` | No       | Additional fields to include. |
 
@@ -1293,7 +1293,7 @@ Returns details about a group specified by its `id`.
 
 #### Request
 
-| Request object | Data type  | Required | Notes                         |
+| Parameter | Data type  | Required | Notes                         |
 | -------------- | ---------- | -------- | ----------------------------- |
 | `id`           | `int`      | Yes      | Group ID                      |
 | `fields`__*__  | `string[]` | No       | Additional fields to include. |
@@ -1947,7 +1947,7 @@ Informs about a chat coming with a new thread. The webhook payload contains the 
 
 #### Webhook payload
 
-| Object | Notes                                                   |
+| Field | Notes                                                   |
 | ------ | ------------------------------------------------------- |
 | `chat` | [Chat data structure](/messaging/agent-chat-api/#chats) |
 
@@ -2008,7 +2008,7 @@ Informs that a chat was deactivated by closing the currently open thread.
 
 #### Webhook payload
 
-| Object    | Notes                                         |
+| Field    | Notes                                         |
 | --------- | --------------------------------------------- |
 | `user_id` | Missing if a thread was closed by the router. |
 
@@ -2062,7 +2062,7 @@ Informs that new, single access to a chat was granted. The existing access isn't
 
 #### Webhook payload
 
-| Object | Notes   |
+| Field | Notes   |
 | ------ | ------- |
 | `id`   | Chat id |
 
@@ -2115,7 +2115,7 @@ Informs that access to a certain chat was revoked.
 
 #### Webhook payload
 
-| Object | Notes   |
+| Field | Notes   |
 | ------ | ------- |
 | `id`   | Chat Id |
 
@@ -2170,7 +2170,7 @@ Informs that a user (Customer or Agent) was added to a chat.
 
 #### Webhook payload
 
-| Object      | Notes                                |
+| Field      | Notes                                |
 | ----------- | ------------------------------------ |
 | `user_type` | Possible values: `agent`, `customer` |
 
@@ -2226,7 +2226,7 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Webhook payload
 
-| Object      | Notes                                |
+| Field      | Notes                                |
 | ----------- | ------------------------------------ |
 | `user_type` | Possible values: `agent`, `customer` |
 
@@ -2431,7 +2431,7 @@ Informs about those chat properties that were updated.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -2486,7 +2486,7 @@ Informs about those chat properties that were deleted.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -2541,7 +2541,7 @@ Informs about those thread properties that were updated.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -2597,7 +2597,7 @@ Informs about those thread properties that were deleted.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -2653,7 +2653,7 @@ Informs about those event properties that were updated.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                           |
+| Field       | Notes                                                                                                           |
 | ------------ | --------------------------------------------------------------------------------------------------------------- |
 | `properties` | This is not a full `properties` object. This webhook shows only the properties that have been recently updated. |
 
@@ -2710,7 +2710,7 @@ Informs about those event properties that were deleted.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                           |
+| Field       | Notes                                                                                                           |
 | ------------ | --------------------------------------------------------------------------------------------------------------- |
 | `properties` | This is not a full `properties` object. This webhook shows only the properties that have been recently updated. |
 
@@ -2863,7 +2863,7 @@ Informs that an Agent's or Bot's status has changed.
 
 #### Webhook payload
 
-| Object   | Notes                                                                                |
+| Field   | Notes                                                                                |
 | -------- | ------------------------------------------------------------------------------------ |
 | `status` | Possible values: `accepting chats`, `not accepting chats`, `offline` (for Bots only) |
 
@@ -3062,7 +3062,7 @@ Informs that a user has seen events up to a specific time.
 | Method URL      | `https://api.livechatinc.com/v3.2/configuration/action/register_webhook` |
 | Required scopes | `webhooks--my:rw`                                                        |
 
-| Request object                           | Required | Data type  | Notes                                                                                                                                                    |
+| Parameter                          | Required | Data type  | Notes                                                                                                                                                    |
 | ---------------------------------------- | -------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `action`__*__                            | yes      | `string`   | The [action](#triggering-actions) that triggers sending a webhook.                                                                                       |
 | `secret_key`                             | yes      | `string`   | The secret key sent in webhooks to verify the source of a webhook.                                                                                       |

--- a/content/management/configuration-api/v2.0/index.mdx
+++ b/content/management/configuration-api/v2.0/index.mdx
@@ -189,9 +189,9 @@ Or, `agents_read` if you use the old LiveChat protocol.
 
 💡 Not sure which protocol you use? You use the old one if you don't see the [new scopes](/authorization/scopes/#agent-scopes) in {{DEVELOPER_CONSOLE_URL}}.
 
-### Optional properties
+### Optional parameters
 
-| Property          | Description                                                                                                                                                 |
+| Parameter          | Description                                                                                                                                                 |
 | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `status`       | returns the agents with one of the following statuses: `accepting chats`, `not accepting chats` or `offline`|
 
@@ -245,9 +245,9 @@ Or, `agents_read` if you use the old LiveChat protocol.
 
 💡 Not sure which protocol you use? You use the old one if you don't see the [new scopes](/authorization/scopes/#agent-scopes) in {{DEVELOPER_CONSOLE_URL}}.
 
-### Properties
+### Parameters
 
-| Property          | Description                                                                                                              |
+| Parameter          | Description                                                                                                              |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `login`           | the agent's e-mail address                                                                                               |
 | `name`            | the agent's name                                                                                                         |
@@ -329,16 +329,16 @@ Or, `agents_write` if you use the old LiveChat protocol.
 
 💡 Not sure which protocol you use? You use the old one if you don't see the [new scopes](/authorization/scopes/#agent-scopes) in {{DEVELOPER_CONSOLE_URL}}.
 
-### Required properties
+### Required parameters
 
-| Property | Description                      |
+| Parameter | Description                      |
 | -------- | -------------------------------- |
 | `login`  | must be a correct e-mail address |
 | `name`   | string                           |
 
-### Optional properties
+### Optional parameters
 
-| Property          | Description                                                                                                                                                 |
+| Parameter          | Description                                                                                                                                                 |
 | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `job_title`       | defaults to: `Support Agent`                                                                                                                                |
 | `login_status`    | possible values: `accepting chats`, `not accepting chats`; defines the default status for an agent right after the login                                    |
@@ -437,9 +437,9 @@ Or, `agents_write` if you use the old LiveChat protocol.
 
 💡 Not sure which protocol you use? You use the old one if you don't see the [new scopes](/authorization/scopes/#agent-scopes) in {{DEVELOPER_CONSOLE_URL}}.
 
-### Optional properties
+### Optional parameters
 
-| Property           | Description                                                                                                                  |
+| Parameter           | Description                                                                                                                  |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
 | `job_title`        |                                                                                                                              |
 | `name`             |                                                                                                                              |
@@ -1088,7 +1088,7 @@ This method updates the tags assigned to a chat.
 
 - `archives_write`
 
-### Required parameter
+### Required parameters
 
 | Parameter | Description        |
 | --------- | ------------------ |
@@ -1273,7 +1273,7 @@ tag[]=feedback"
 
 - `archives_read`
 
-### Required parameter
+### Required parameters
 
 | Parameter | Description               |
 | --------- | ------------------------- |
@@ -1413,9 +1413,9 @@ curl "https://api.livechatinc.com/canned_responses?group=1" \
 
 - `canned_responses_read`
 
-### Attributes
+### Parameters
 
-| Attribute       | Description                                         |
+| Parameter       | Description                                         |
 | --------------- | --------------------------------------------------- |
 | `id`            | id of the canned response                           |
 | `group`         | id of the group that canned response is assigned to |
@@ -1473,16 +1473,16 @@ Creates a new canned response.
 
 - `canned_responses_write`
 
-### Required properties
+### Required parameters
 
-| Property | Description             |
+| Parameter | Description             |
 | -------- | ----------------------- |
 | `text`   | response text           |
 | `tags`   | array of strings (tags) |
 
-### Optional properties
+### Optional parameters
 
-| Property | Description   |
+| Parameter | Description   |
 | -------- | ------------- |
 | `group`  | defaults to 0 |
 
@@ -1553,9 +1553,9 @@ Updates the specified canned response by setting the values of the parameters pa
 
 - `canned_responses_write`
 
-### Optional properties
+### Optional parameters
 
-| Property | Description             |
+| Parameter | Description             |
 | -------- | ----------------------- |
 | `text`   | response text           |
 | `tags`   | array of strings (tags) |
@@ -1745,9 +1745,9 @@ Returns the goal details for the given `GOAL_ID`.
 
 - `goals_read`
 
-### Attributes
+### Parameters
 
-| Attribute | Description                        |
+| Parameter | Description                        |
 | --------- | ---------------------------------- |
 | `id`      | id of the goal                     |
 | `name`    | goal name                          |
@@ -2112,9 +2112,9 @@ Returns the list of all greetings.
 
 - `greetings_read`
 
-### Optional properties
+### Optional parameters
 
-| Property | Description                                                                                                         |
+| Parameter | Description                                                                                                         |
 | -------- | ------------------------------------------------------------------------------------------------------------------- |
 | `group`  | Group number can be specified to get greetings from a given group. If not specified, all greetings will be returned |
 
@@ -2257,16 +2257,16 @@ Use this function to create a new greeting.
 
 - `greetings_write`
 
-### Required properties
+### Required parameters
 
-| Property | Description                                                                                                                      |
+| Parameter | Description                                                                                                                      |
 | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `name`   | greeting name displayed in the LiveChat settings (not visible to your website's visitors)                                        |
 | `rules`  | an array of conditions that must be met for the greeting to be displayed. Greeting rules are [documented below](#greeting-rules) |
 
-### Optional properties
+### Optional parameters
 
-| Property  | Description                                                                                                                                                                                    |
+| Parameter  | Description                                                                                                                                                                                    |
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `group`   | creates a greeting displayed in a particular group only. Defaults to `0`                                                                                                                       |
 | `active`  | creates a greeting, which is active or inactive. Defaults to `1`                                                                                                                               |
@@ -3024,9 +3024,9 @@ Or, `groups_read` if you use the old LiveChat protocol.
 
 💡 Not sure which protocol you use? You use the old one if you don't see the [new scopes](/authorization/scopes/#group-scopes) in {{DEVELOPER_CONSOLE_URL}}.
 
-### Attributes
+### Parameters
 
-| Attribute  | Description                                                                                                                                                        |
+| Parameter  | Description                                                                                                                                                        |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `id`       | id of the group                                                                                                                                                    |
 | `name`     | group name                                                                                                                                                         |
@@ -3094,16 +3094,16 @@ Or, `groups_write` if you use the old LiveChat protocol.
 
 💡 Not sure which protocol you use? You use the old one if you don't see the [new scopes](/authorization/scopes/#group-scopes) in {{DEVELOPER_CONSOLE_URL}}.
 
-### Required properties
+### Required parameters
 
-| Property | Description                                  |
+| Parameter | Description                                  |
 | -------- | -------------------------------------------- |
 | `name`   | group name                                   |
 | `agents` | an array of LiveChat users' logins (e-mails) |
 
-### Optional properties
+### Optional parameters
 
-| Property   | Description                                                                                                                                                        |
+| Parameter   | Description                                                                                                                                                        |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `language` | group language (defaults to English). See the [list of supported languages](http://www.livechatinc.com/kb/how-to-modify-chat-window-language/#supported-languages) |
 
@@ -3178,9 +3178,9 @@ Or, `groups_write` if you use the old LiveChat protocol.
 
 💡 Not sure which protocol you use? You use the old one if you don't see the [new scopes](/authorization/scopes/#group-scopes) in {{DEVELOPER_CONSOLE_URL}}.
 
-### Optional properties
+### Optional parameters
 
-| Property   | Description                                                                                                                  |
+| Parameter   | Description                                                                                                                  |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `name`     | group name                                                                                                                   |
 | `language` | see the [list of supported languages](http://www.livechatinc.com/kb/how-to-modify-chat-window-language/#supported-languages) |
@@ -3520,9 +3520,9 @@ Deletes a tag from the chosen group. The agents will no longer be able to tag ch
 
 - `tags_write`
 
-### Required properties
+### Required parameters
 
-| Property | Description                                 |
+| Parameter | Description                                 |
 | -------- | ------------------------------------------- |
 | `tag`    | tag name                                    |
 | `group`  | id of the group that the tag is assigned to |
@@ -4239,9 +4239,9 @@ Creates a new webhook.
 
 - `webhooks_manage`
 
-### Required properties
+### Required parameters
 
-| Property     | Description                                                                                                                  |
+| Parameter     | Description                                                                                                                  |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
 | `event_type` | must be one of `chat_started`, `chat_ended`, `chat_changed`, `visitor_queued`, `ticket_created` or `canned_response_changed` |
 | `data_types` | determines what information the webhook will contain                                                                         |
@@ -4251,7 +4251,7 @@ Creates a new webhook.
 
 `event_type` determines when the webhook will be sent to your script:
 
-| Property                  | Description                                            |
+| Parameter                  | Description                                            |
 | ------------------------- | ------------------------------------------------------ |
 | `chat_started`            | when the chat is started                               |
 | `chat_ended`              | when the chat is ended                                 |
@@ -4262,7 +4262,7 @@ Creates a new webhook.
 
 `data_type` is an array that includes one or more of the following values):
 
-| Property          | Description                                                                                     |
+| Parameter          | Description                                                                                     |
 | ----------------- | ----------------------------------------------------------------------------------------------- |
 | `chat`            | only supported in `chat_started`, `chat_changed` and `chat_ended` event types                   |
 | `visitor`         | only supported in `chat_started`, `chat_ended`, `chat_changed` and `visitor_queued` event types |

--- a/content/management/configuration-api/v3.1/index.mdx
+++ b/content/management/configuration-api/v3.1/index.mdx
@@ -71,7 +71,7 @@ Unlike Agents, Bot Agents don't have passwords or emails - you cannot log in as 
 
 #### Request
 
-| Request object                       | Type       | Required | Notes                                                                                                                                    |
+| Parameter                      | Type       | Required | Notes                                                                                                                                    |
 | ------------------------------------ | ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`                               | `string`   | Yes      | Display name                                                                                                                             |
 | `status` __*__                       | `string`   | Yes      | Agent status                                                                                                                             |
@@ -755,7 +755,7 @@ Informs about a new thread coming in the chat. The webhook payload contains not 
 #### Webhook payload
 
 
-| Object      | Notes                                  |
+| Field      | Notes                                  |
 | ----------- | -------------------------------------- |
 | `chat`      | [Chat data structure](/messaging/agent-chat-api/v3.1/#chats)  |
 
@@ -820,7 +820,7 @@ Informs that a thread was closed.
 
 #### Webhook payload
 
-| Object      | Notes                                  |
+| Field      | Notes                                  |
 | ----------- | -------------------------------------- |
 | `user_id`   | Missing if a thread was closed by the router. |
 
@@ -872,7 +872,7 @@ Informs that new, single access to a resource was granted. The existing access i
 
 #### Webhook payload
 
-| Object     | Notes         |
+| Field     | Notes         |
 | ---------- | ------------- |
 | `access`   | The entities that were granted access to the specified resource |
 | `resource` | Resource type |
@@ -926,7 +926,7 @@ Informs that access to a certain resource was revoked.
 
 #### Webhook payload
 
-| Object     | Notes         |
+| Field     | Notes         |
 | ---------- | ------------- |
 | `access`   | The entities that lost access to the specified resource |
 | `resource` | Resource type |
@@ -980,7 +980,7 @@ Informs that new, single access to a resource was set. The existing access is ov
 
 #### Webhook payload
 
-| Object     | Notes         |
+| Field     | Notes         |
 | ---------- | ------------- |
 | `access`   | The entities that were given access to the specified resource |
 | `resource` | Resource type |
@@ -1037,7 +1037,7 @@ Informs that a user (Customer or Agent) was added to a chat.
 
 #### Webhook payload
 
-| Object      | Notes                                   |
+| Field      | Notes                                   |
 | ----------- | --------------------------------------- |
 | `user_type` | Possible values: `agent`, `customer`    |
 
@@ -1091,7 +1091,7 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Webhook payload
 
-| Object      | Notes                                   |
+| Field      | Notes                                   |
 | ----------- | --------------------------------------- |
 | `user_type` | Possible values: `agent`, `customer`    |
 
@@ -1289,7 +1289,7 @@ Informs about those chat properties that were updated.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                      |
+| Field       | Notes                                                                                                      |
 | ------------ | ---------------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -1344,7 +1344,7 @@ Informs about those chat properties that were deleted.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                      |
+| Field       | Notes                                                                                                      |
 | ------------ | ---------------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -1396,7 +1396,7 @@ Informs about those chat thread properties that were updated.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                      |
+| Field       | Notes                                                                                                      |
 | ------------ | ---------------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -1452,7 +1452,7 @@ Informs about those chat thread properties that were deleted.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                      |
+| Field       | Notes                                                                                                      |
 | ------------ | ---------------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -1504,7 +1504,7 @@ Informs about those event properties that were updated.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                           |
+| Field       | Notes                                                                                                           |
 | ------------ | --------------------------------------------------------------------------------------------------------------- |
 | `properties` | This is not a full `properties` object. This webhook shows only the properties that have been recently updated. |
 
@@ -1561,7 +1561,7 @@ Informs about those event properties that were deleted.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                           |
+| Field       | Notes                                                                                                           |
 | ------------ | --------------------------------------------------------------------------------------------------------------- |
 | `properties` | This is not a full `properties` object. This webhook shows only the properties that have been recently updated. |
 
@@ -1707,7 +1707,7 @@ Informs that an Agent's status changed.
 
 #### Webhook payload
 
-| Object      | Notes                                  |
+| Field      | Notes                                  |
 | ----------- | -------------------------------------- |
 | `status`   | Possible values: `accepting chats`, `not accepting chats`, `offline` | 
 
@@ -1906,7 +1906,7 @@ Informs that a user has seen events up to a specific time.
 | Required scopes| `webhooks--my:rw`  |
 
 
-| Request object                           | Required   | Data type  | Notes                                                                                                           |
+| Parameter                           | Required   | Data type  | Notes                                                                                                           |
 | ---------------------------------------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------- |
 | `action`__*__                            | Yes        | `string`   | The [action](#triggering-actions) that triggers sending a webhook.                                              | 
 | `secret_key`                             | Yes        | `string`   | The secret key sent in webhooks to verify the source of a webhook.                                              |

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -197,7 +197,7 @@ It returns the info about an Agent specified by `id`.
 
 #### Request
 
-| Request object | Type       | Required | Notes                         |
+| Parameter | Type       | Required | Notes                         |
 | -------------- | ---------- | -------- | ----------------------------- |
 | `id`           | `string`   | Yes      | Agent ID                      |
 | `fields`__*__  | `string[]` | No       | Additional fields to include. |
@@ -1365,7 +1365,7 @@ Creates a new group.
 
 #### Request
 
-| Request object          | Data type | Required | Notes                                                                                                                            |
+| Parameter          | Data type | Required | Notes                                                                                                                            |
 | ----------------------- | --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `name`                  | `string`  | Yes      | Group name (up to 180 chars)                                                                                                     |
 | `language_code`         | `string`  | No       | The code of the group languange                                                                                                  |
@@ -1425,7 +1425,7 @@ Updates an existing group.
 
 #### Request
 
-| Request object          | Data type | Required | Notes                                                                        |
+| Parameter          | Data type | Required | Notes                                                                        |
 | ----------------------- | --------- | -------- | ---------------------------------------------------------------------------- |
 | `id`                    | `int`     | Yes      | Group ID                                                                     |
 | `name`                  | `string`  | No       | Group name (up to 180 chars)                                                 |
@@ -1489,7 +1489,7 @@ Deletes an existing group.
 
 #### Request
 
-| Request object | Data type | Required | Notes    |
+| Parameter | Data type | Required | Notes    |
 | -------------- | --------- | -------- | -------- |
 | `id`           | `int`     | Yes      | Group ID |
 
@@ -1536,7 +1536,7 @@ Lists all the exisiting groups.
 
 #### Request
 
-| Request object | Data type  | Required | Notes                         |
+| Parameter | Data type  | Required | Notes                         |
 | -------------- | ---------- | -------- | ----------------------------- |
 | `fields`__*__  | `string[]` | No       | Additional fields to include. |
 
@@ -1586,7 +1586,7 @@ Returns details about a group specified by its `id`.
 
 #### Request
 
-| Request object | Data type  | Required | Notes                         |
+| Parameter | Data type  | Required | Notes                         |
 | -------------- | ---------- | -------- | ----------------------------- |
 | `id`           | `int`      | Yes      | Group ID                      |
 | `fields`__*__  | `string[]` | No       | Additional fields to include. |
@@ -2340,7 +2340,7 @@ Informs about a chat coming with a new thread. The webhook payload contains the 
 
 #### Webhook payload
 
-| Object | Notes                                                   |
+| Field | Notes                                                   |
 | ------ | ------------------------------------------------------- |
 | `chat` | [Chat data structure](/messaging/agent-chat-api/#chats) |
 
@@ -2401,7 +2401,7 @@ Informs that a chat was deactivated by closing the currently open thread.
 
 #### Webhook payload
 
-| Object    | Notes                                         |
+| Field    | Notes                                         |
 | --------- | --------------------------------------------- |
 | `user_id` | Missing if a thread was closed by the router. |
 
@@ -2455,7 +2455,7 @@ Informs that new, single access to a chat was granted. The existing access isn't
 
 #### Webhook payload
 
-| Object | Notes   |
+| Field | Notes   |
 | ------ | ------- |
 | `id`   | Chat id |
 
@@ -2508,7 +2508,7 @@ Informs that access to a certain chat was revoked.
 
 #### Webhook payload
 
-| Object | Notes   |
+| Field | Notes   |
 | ------ | ------- |
 | `id`   | Chat Id |
 
@@ -2561,7 +2561,7 @@ Informs that a chat was transferred to a different group or to an agent.
 
 #### Webhook payload
 
-| Object           | Notes                                                                    |
+| Field           | Notes                                                                    |
 | ---------------- | ------------------------------------------------------------------------ |
 | `thread_id`      | Present if the chat is active.                                           |
 | `transferred_to` | IDs of the groups and agents the chat is assigned to after the transfer. |
@@ -2626,7 +2626,7 @@ Informs that a user (Customer or Agent) was added to a chat.
 
 #### Webhook payload
 
-| Object      | Notes                                |
+| Field      | Notes                                |
 | ----------- | ------------------------------------ |
 | `user_type` | Possible values: `agent`, `customer` |
 
@@ -2682,7 +2682,7 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Webhook payload
 
-| Object      | Notes                                |
+| Field      | Notes                                |
 | ----------- | ------------------------------------ |
 | `user_type` | Possible values: `agent`, `customer` |
 
@@ -2887,7 +2887,7 @@ Informs about those chat properties that were updated.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -2942,7 +2942,7 @@ Informs about those chat properties that were deleted.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -2997,7 +2997,7 @@ Informs about those thread properties that were updated.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3053,7 +3053,7 @@ Informs about those thread properties that were deleted.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3109,7 +3109,7 @@ Informs about those event properties that were updated.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                           |
+| Field       | Notes                                                                                                           |
 | ------------ | --------------------------------------------------------------------------------------------------------------- |
 | `properties` | This is not a full `properties` object. This webhook shows only the properties that have been recently updated. |
 
@@ -3166,7 +3166,7 @@ Informs about those event properties that were deleted.
 
 #### Webhook payload
 
-| Object       | Notes                                                                                                           |
+| Field       | Notes                                                                                                           |
 | ------------ | --------------------------------------------------------------------------------------------------------------- |
 | `properties` | This is not a full `properties` object. This webhook shows only the properties that have been recently updated. |
 
@@ -3319,7 +3319,7 @@ Informs that an Agent's or Bot's status has changed.
 
 #### Webhook payload
 
-| Object   | Notes                                                                                |
+| Field   | Notes                                                                                |
 | -------- | ------------------------------------------------------------------------------------ |
 | `status` | Possible values: `accepting chats`, `not accepting chats`, `offline` (for Bots only) |
 
@@ -3571,7 +3571,7 @@ Registers a webhook for the Client ID (application) provided in the request. Lat
 | Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/register_webhook` |
 | Required scopes | `webhooks.configuration:rw`                                                        |
 
-| Request object                           | Required | Data type  | Notes                                                                                                                                                     |
+| Parameter                           | Required | Data type  | Notes                                                                                                                                                     |
 | ---------------------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `action`__*__                            | yes      | `string`   | The [action](#triggering-actions) that triggers sending a webhook.                                                                                        |
 | `secret_key`                             | yes      | `string`   | The secret key sent in webhooks to verify the source of a webhook.                                                                                        |

--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -79,7 +79,7 @@ The **File** event informs about an uploaded file.
 
 ### Request
 
-| Field        | Required | Data type |                                                                                                                                     Notes |
+| Parameter        | Required | Data type |                                                                                                                                     Notes |
 | ------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`  | no       | `string`  |                                                                                                                                           |
 | `type`       | yes      | `string`  |                                                                                                                                    `file` |
@@ -119,7 +119,7 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                                    |
+| Parameter        | Required | Data type | Notes                                                                    |
 | ------------ | -------- | --------- | ------------------------------------------------------------------------ |
 | `custom_id`  | no       | `string`  |                                                                          |
 | `type`       | yes      | `string`  | `filled_form`                                                            |
@@ -158,7 +158,7 @@ The **Message** event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                        |
+| Parameter                | Required | Data type | Notes                                                                                                                        |
 | -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`          | no       | `string`  |                                                                                                                              |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
@@ -206,7 +206,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 
 ### Request
 
-| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
+| Parameter                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
 | --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                |
 | `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                       |
@@ -264,7 +264,7 @@ Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                               |  |
+| Parameter        | Required | Data type | Notes                                                               |  |
 | ------------ | -------- | --------- | ------------------------------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.                                 |
 | `type`       | yes      | `string`  | Event type: `custom`                                                |
@@ -300,7 +300,7 @@ System message event is native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type | Notes                                                                                                                            |
+| Parameter                 | Required | Data type | Notes                                                                                                                            |
 | --------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`           | no       | `string`  | You can give the system message a custom ID.                                                                                     |
 | `type`                | yes      | `string`  | `system_message`                                                                                                                 |
@@ -534,7 +534,7 @@ There's only one value allowed for a single property.
 
 #### Response
 
-| Parameter          | Data type | Notes                                                                                                        |
+| Field          | Data type | Notes                                                                                                        |
 | ------------------ | --------- | ------------------------------------------------------------------------------------------------------------ |
 | `chats_summary`    | `array`   | An array of [Chat summary](#chat-summaries) data structures                                                  |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. Appears in the response only when there's a next page.    |
@@ -1004,7 +1004,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| Field   | Data type  | Notes                                                                                                                                                                   |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `chat_id`   | `string`   |                                                                                                                                                                         |
 | `thread_id` | `string`   |                                                                                                                                                                         |
@@ -1077,7 +1077,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                     |
+| Field   | Data type  | Notes                                                                                                                                                                     |
 | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                           |
 | `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
@@ -1531,7 +1531,7 @@ The method updates the requester's `events_seen_up_to` as if they've seen all ch
 
 #### Response
 
-| Parameter  | Data type |
+| Field  | Data type |
 | ---------- | --------- |
 | `event_id` | `string`  |
 
@@ -2094,7 +2094,7 @@ Returns the info about the Customer with a given `customer_id`.
 
 #### Response
 
-| Parameter        | Data type | Notes                                                                                                                             |
+| Field        | Data type | Notes                                                                                                                             |
 | ---------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `id`             | string    | [Customer's](#customer) ID.                                                                                                       |
 | `type`           | string    | `customer`                                                                                                                        |
@@ -2259,7 +2259,7 @@ Dates are represented in ISO 8601 format with microseconds resolution, e.g. `201
 
 #### Response
 
-| Parameter          | Data type | Notes                                              |
+| Field          | Data type | Notes                                              |
 | ------------------ | --------- | -------------------------------------------------- |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
 | `previous_page_id` | `string`  | In relation to `page_id` specified in the request. |

--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -1419,7 +1419,7 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 
 #### Request
 
-| Request object          | Required | Type     | Notes                                                                                        |
+| Parameter          | Required | Type     | Notes                                                                                        |
 | ----------------------- | -------- | -------- | -------------------------------------------------------------------------------------------- |
 | `chat_id`               | Yes      | `string` |                                                                                              |
 | `user_id`               | Yes      | `string` |                                                                                              |
@@ -1469,7 +1469,7 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 
 #### Request
 
-| Request object | Required | Type     | Notes                                     |
+| Parameter | Required | Type     | Notes                                     |
 | -------------- | -------- | -------- | ----------------------------------------- |
 | `chat_id`      | Yes      | `string` |                                           |
 | `user_id`      | Yes      | `string` |                                           |

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -102,7 +102,7 @@ The **File** event informs about an uploaded file.
 
 ### Request
 
-| Field        | Required | Data type |                                                                                                                                     Notes |
+| Parameter        | Required | Data type |                                                                                                                                     Notes |
 | ------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`  | no       | `string`  |                                                                                                                                           |
 | `type`       | yes      | `string`  |                                                                                                                                    `file` |
@@ -142,7 +142,7 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                                    |
+| Parameter        | Required | Data type | Notes                                                                    |
 | ------------ | -------- | --------- | ------------------------------------------------------------------------ |
 | `custom_id`  | no       | `string`  |                                                                          |
 | `type`       | yes      | `string`  | `filled_form`                                                            |
@@ -181,7 +181,7 @@ The **Message** event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                        |
+| Parameter                | Required | Data type | Notes                                                                                                                        |
 | -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`          | no       | `string`  |                                                                                                                              |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
@@ -229,7 +229,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 
 ### Request
 
-| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                                                                                  |
+| Parameter                             | Required | Data type | Notes                                                                                                                                                                                                                                                                                                  |
 | --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                                                                      |
 | `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                                                                             |
@@ -287,7 +287,7 @@ Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                               |  |
+| Parameter        | Required | Data type | Notes                                                               |  |
 | ------------ | -------- | --------- | ------------------------------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.                                 |
 | `type`       | yes      | `string`  | Event type: `custom`                                                |
@@ -323,7 +323,7 @@ System message event is native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type |                                                                                                                            Notes |
+| Parameter                 | Required | Data type |                                                                                                                            Notes |
 | --------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`           | no       | `string`  |                                                                                     You can give the system message a custom ID. |
 | `type`                | yes      | `string`  |                                                                                                                 `system_message` |
@@ -566,7 +566,7 @@ There's only one value allowed for a single property.
 
 #### Response
 
-| Parameter          | Data type | Notes                                                                                                        |
+| Field          | Data type | Notes                                                                                                        |
 | ------------------ | --------- | ------------------------------------------------------------------------------------------------------------ |
 | `chats_summary`    | `array`   | An array of [Chat summary](#chat-summaries) data structures                                                  |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. Appears in the response only when there's a next page.    |
@@ -1040,7 +1040,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Request
 
-| Parameters               | Required | Data type  | Notes                                                                                                    |
+| Parameter               | Required | Data type  | Notes                                                                                                    |
 | ------------------------ | -------- | ---------- | -------------------------------------------------------------------------------------------------------- |
 | `chat`                   | No       | `object`   |                                                                                                          |
 | `chat.properties`        | No       | `object`   |                                                                                                          |
@@ -1055,7 +1055,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| Field   | Data type  | Notes                                                                                                                                                                   |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `chat_id`   | `string`   |                                                                                                                                                                         |
 | `thread_id` | `string`   |                                                                                                                                                                         |
@@ -1182,7 +1182,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                     |
+| Field   | Data type  | Notes                                                                                                                                                                     |
 | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                           |
 | `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
@@ -1764,7 +1764,7 @@ The method updates the requester's `events_seen_up_to` as if they've seen all ch
 
 #### Request
 
-| Parameters              | Required | Data type | Notes                                                                                                        |
+| Parameter              | Required | Data type | Notes                                                                                                        |
 | ----------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------ |
 | `chat_id`               | Yes      | `string`  | Id of the chat you want to send the message to.                                                              |
 | `event`                 | Yes      | `object`  | Event object                                                                                                 |
@@ -2384,7 +2384,7 @@ Returns the info about the Customer with a given `customer_id`.
 
 #### Response
 
-| Parameter        | Data type | Notes                                                                                                                             |
+| Field        | Data type | Notes                                                                                                                             |
 | ---------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `id`             | string    | [Customer's](#customer) ID.                                                                                                       |
 | `type`           | string    | `customer`                                                                                                                        |
@@ -2554,7 +2554,7 @@ Dates are represented in ISO 8601 format with microseconds resolution, e.g. `201
 
 #### Response
 
-| Parameter          | Data type | Notes                                              |
+| Field          | Data type | Notes                                              |
 | ------------------ | --------- | -------------------------------------------------- |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
 | `previous_page_id` | `string`  | In relation to `page_id` specified in the request. |
@@ -2826,7 +2826,7 @@ as `away`. [Read more...](#set-away-status)
 
 #### Response
 
-| Parameter    | Data type | Notes |
+| Field    | Data type | Notes |
 | ------------ | --------- | ----- |
 | `access`     | `object`  |       |
 | `properties` | `object`  |       |
@@ -3532,7 +3532,7 @@ Informs that a chat was deactivated by closing the currently open thread.
 
 #### Push payload
 
-| Object    | Notes                                         |
+| Field    | Notes                                         |
 | --------- | --------------------------------------------- |
 | `user_id` | Missing if a thread was closed by the router. |
 
@@ -3564,7 +3564,7 @@ Informs that new, single access to a chat was granted. The existing access isn't
 
 #### Push payload
 
-| Object | Notes   |
+| Field | Notes   |
 | ------ | ------- |
 | `id`   | Chat id |
 
@@ -3594,7 +3594,7 @@ Informs that access to a certain chat was revoked.
 
 #### Push payload
 
-| Object | Notes   |
+| Field | Notes   |
 | ------ | ------- |
 | `id`   | Chat Id |
 
@@ -3632,7 +3632,7 @@ Informs that a chat was transferred to a different group or to an Agent.
 
 #### Push payload
 
-| Object                  | Notes                                                |
+| Field                  | Notes                                                |
 | ----------------------- | ---------------------------------------------------- |
 | `thread_id`             | Present if the chat is active                        |
 | `transferred_to` **\*** | IDs of groups and Agents the chat is now assigned to |
@@ -3678,7 +3678,7 @@ This push can be emitted with `user.present` set to `false` when a user writes t
 
 #### Push payload
 
-| Object         | Notes                                            |
+| Field         | Notes                                            |
 | -------------- | ------------------------------------------------ |
 | `thread_id`    | Present when a user was added to an active chat. |
 | `reason`       | Why the user was added.                          |
@@ -3711,7 +3711,7 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Push payload
 
-| Object         | Notes                                                |
+| Field         | Notes                                                |
 | -------------- | ---------------------------------------------------- |
 | `thread_id`    | Present when a user was removed from an active chat. |
 | `reason`       | Why the user was removed.                            |
@@ -3839,7 +3839,7 @@ Informs about those chat properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3870,7 +3870,7 @@ Informs about those chat properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3905,7 +3905,7 @@ Informs about those thread properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3938,7 +3938,7 @@ Informs about those thread properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3973,7 +3973,7 @@ Informs about those event properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -4006,7 +4006,7 @@ Informs about those event properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -4414,7 +4414,7 @@ Informs about messages sent via the `multicast` method or by the system.
 
 #### Push payload
 
-| Object      | Required | Notes                                                                                            |
+| Field      | Required | Notes                                                                                            |
 | ----------- | -------- | ------------------------------------------------------------------------------------------------ |
 | `author_id` | No       | Present only if the push was generated by the **Multicast** method and not sent from the server. |
 | `content`   | Yes      |                                                                                                  |

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -545,7 +545,7 @@ It returns [summaries](#chat-summaries) of the chats an Agent has access to.
 
 #### Request
 
-| Request object                                        | Required | Type     | Notes                                                                                       |
+| Parameter                                        | Required | Type     | Notes                                                                                       |
 | ----------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------- |
 | `filters`                                             | No       | `object` | Mustn't change between requests for subsequent pages. Otherwise, the behavior is undefined. |
 | `filters.include_active`                              | No       | `bool`   | Defines if the returned chat summary includes active chats; default: `true`.                |
@@ -1166,7 +1166,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Request
 
-| Request object           | Required | Type       | Notes                                                                                                    |
+| Parameter           | Required | Type       | Notes                                                                                                    |
 | ------------------------ | -------- | ---------- | -------------------------------------------------------------------------------------------------------- |
 | `chat`                   | Yes      | `object`   |                                                                                                          |
 | `chat.id`                | Yes      | `string`   | The ID of the chat that will be activated.                                                               |
@@ -1638,7 +1638,7 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 
 #### Request
 
-| Request object          | Required | Type     | Notes                                                                                        |
+| Parameter          | Required | Type     | Notes                                                                                        |
 | ----------------------- | -------- | -------- | -------------------------------------------------------------------------------------------- |
 | `chat_id`               | Yes      | `string` |                                                                                              |
 | `user_id`               | Yes      | `string` |                                                                                              |
@@ -1699,7 +1699,7 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 
 #### Request
 
-| Request object | Required | Type     | Notes                                     |
+| Parameter | Required | Type     | Notes                                     |
 | -------------- | -------- | -------- | ----------------------------------------- |
 | `chat_id`      | Yes      | `string` |                                           |
 | `user_id`      | Yes      | `string` |                                           |
@@ -2945,7 +2945,7 @@ Remember that checking if Agents are active/inactive should be **implemented on 
 
 #### Request
 
-| Request object | Required | Data type |
+| Parameter | Required | Data type |
 | -------------- | -------- | --------- |
 | `away`         | Yes      | `bool`    |
 

--- a/content/messaging/agent-chat-api/v3.1/index.mdx
+++ b/content/messaging/agent-chat-api/v3.1/index.mdx
@@ -1758,7 +1758,7 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 | **RTM API equivalent** | [`remove_user_from_chat`](rtm-reference/#remove-user-from-chat)         |
 | **Webhook**            | [`chat_user_removed`](/management/configuration-api/v3.1/#chat_user_removed) |
 
-**Request payload**
+#### Request payload
 
 | Parameter | Required | Type     | Notes                                     |
 | -------------- | -------- | -------- | ----------------------------------------- |

--- a/content/messaging/agent-chat-api/v3.1/index.mdx
+++ b/content/messaging/agent-chat-api/v3.1/index.mdx
@@ -1603,7 +1603,7 @@ Gives access to a new resource overwriting the existing ones.
 
 #### Request
 
-| Request object | Required | Type     | Notes                                                     |
+| Parameter | Required | Type     | Notes                                                     |
 | -------------- | -------- | -------- | --------------------------------------------------------- |
 | `resource`     | Yes      | `string` | `chat` or `customer`                                      |
 | `id`           | Yes      | `string` | resource id                                               |
@@ -1712,7 +1712,7 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 
 #### Request
 
-| Request object | Required | Type     | Notes                                  |
+| Parameter | Required | Type     | Notes                                  |
 | -------------- | -------- | -------- | -------------------------------------- |
 | `chat_id`      | Yes      | `string` |                                        |
 | `user_id`      | Yes      | `string` |                                        |
@@ -1760,7 +1760,7 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 
 **Request payload**
 
-| Request object | Required | Type     | Notes                                     |
+| Parameter | Required | Type     | Notes                                     |
 | -------------- | -------- | -------- | ----------------------------------------- |
 | `chat_id`      | Yes      | `string` |                                           |
 | `user_id`      | Yes      | `string` |                                           |

--- a/content/messaging/agent-chat-api/v3.1/index.mdx
+++ b/content/messaging/agent-chat-api/v3.1/index.mdx
@@ -79,7 +79,7 @@ The **File** event informs about an uploaded file.
 
 ### Request
  
-| Field        | Required | Data type |                                                                                                                                     Notes |
+| Parameter        | Required | Data type |                                                                                                                                     Notes |
 | ------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`  | no       | `string`  |                                                                                                                                           |
 | `type`       | yes      | `string`  |                                                                                                                                    `file` |
@@ -120,7 +120,7 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                                    |
+| Parameter        | Required | Data type | Notes                                                                    |
 | ------------ | -------- | --------- | ------------------------------------------------------------------------ |
 | `custom_id`  | no       | `string`  |                                                                          |
 | `type`       | yes      | `string`  | `filled_form`                                                            |
@@ -159,7 +159,7 @@ The **Message** event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                         |
+| Parameter                | Required | Data type | Notes                                                                                                                         |
 | -------------------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`          | no       | `string`  |                                                                                                                               |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
@@ -207,7 +207,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 
 ### Request
 
-| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                                                                             |
+| Parameter                             | Required | Data type | Notes                                                                                                                                                                                                                                                                                             |
 | --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                                                                 |
 | `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                                                                        |
@@ -265,7 +265,7 @@ Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                               |  |
+| Parameter        | Required | Data type | Notes                                                               |  |
 | ------------ | -------- | --------- | ------------------------------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.                                 |
 | `type`       | yes      | `string`  | Event type: `custom`                                                |
@@ -301,7 +301,7 @@ System message event is native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type |                                                                                                                            Notes |
+| Parameter                 | Required | Data type |                                                                                                                            Notes |
 | --------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`           | no       | `string`  |                                                                                     You can give the system message a custom ID. |
 | `type`                | yes      | `string`  |                                                                                                                 `system_message` |
@@ -795,7 +795,7 @@ There's only one value allowed for a single property.
 
 #### Response
 
-| Parameter          | Data type | Notes                                                                    |
+| Field          | Data type | Notes                                                                    |
 | ------------------ | --------- | ------------------------------------------------------------------------ |
 | `found_chats`      | `number`  | An estimated number. The real number of found chats can slightly differ. |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request.                       |
@@ -911,7 +911,7 @@ curl -X POST \
 
 #### Response
 
-| Parameter          | Data type | Notes                                              |
+| Field          | Data type | Notes                                              |
 | ------------------ | --------- | -------------------------------------------------- |
 | `found_threads`    | `number`  | Number of threads in a chat                        |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
@@ -1239,7 +1239,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| Field   | Data type  | Notes                                                                                                                                                                   |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `chat_id`   | `string`   |                                                                                                                                                                         |
 | `thread_id` | `string`   |                                                                                                                                                                         |
@@ -1310,7 +1310,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                     |
+| Field   | Data type  | Notes                                                                                                                                                                     |
 | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                           |
 | `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
@@ -1820,7 +1820,7 @@ It's possible to write to a chat without joining it. The user sending an event w
 
 #### Response
 
-| Parameter  | Data type |
+| Field  | Data type |
 | ---------- | --------- |
 | `event_id` | `string`  |
 
@@ -2444,7 +2444,7 @@ Dates are represented in ISO 8601 format with microseconds resolution, e.g. `201
 
 #### Response
 
-| Parameter          | Data type | Notes                                              |
+| Field          | Data type | Notes                                              |
 | ------------------ | --------- | -------------------------------------------------- |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
 | `previous_page_id` | `string`  | In relation to `page_id` specified in the request. |

--- a/content/messaging/agent-chat-api/v3.1/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.1/rtm-reference/index.mdx
@@ -101,7 +101,7 @@ The **File** event informs about an uploaded file.
 
 ### Request
 
-| Field        | Required | Data type |                                                                                                                                       Notes |
+| Parameter    | Required | Data type |                                                                                                                                       Notes |
 | ------------ | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`  | no       | `string`  |                                                                                                                                             |
 | `type`       | yes      | `string`  |                                                                                                                                      `file` |
@@ -165,7 +165,7 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                                    |
+| Parameter        | Required | Data type | Notes                                                                    |
 | ------------ | -------- | --------- | ------------------------------------------------------------------------ |
 | `custom_id`  | no       | `string`  |                                                                          |
 | `type`       | yes      | `string`  | `filled_form`                                                            |
@@ -259,7 +259,7 @@ The **Message** event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                        |
+| Parameter                | Required | Data type | Notes                                                                                                                        |
 | -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`          | no       | `string`  |                                                                                                                              |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
@@ -331,7 +331,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 
 ### Request
 
-| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
+| Parameter                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
 | --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                |
 | `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                       |
@@ -344,7 +344,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 | `elements.image`                  | yes      | `image`   | Displays images on RMs. Required param: `url`; Optional params: `name`, `content_type`, `size`, `width`, `height`.                                                                                                                               |
 | `elements.buttons`                | no       | `array`   | Displays buttons. Can contain up to 11 `button` objects.                                                                                                                                                                                         |
 | `elements.buttons.text`           | yes      | `string`  | Text displayed on a button.                                                                                                                                                                                                                      |
-| `elements.buttons.type`           | yes      | `string`   | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value`. Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
+| `elements.buttons.type`           | yes      | `string`  | Defines the behavior after a user clicks the button. Should be used together with `elements.buttons.value`. Possible values: `webview`, `message`, `url`, `phone`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started) |
 | `elements.buttons.value`          | yes      | `string`  | Should be used together with `elements.buttons.type`.                                                                                                                                                                                            |
 | `elements.buttons.webview_height` | yes      | `string`  | Required only for the `webview` button`type`. Possible values: `compact`, `full`, `tall`.                                                                                                                                                        |
 | `elements.buttons.postback_id`    | yes      | `string`  | A description of the sent action. Describes the action sent via `send_rich_message_postback`. [More...](/extending-ui/extending-chat-widget/rich-messages/#getting-started)                                                                      |
@@ -440,7 +440,7 @@ The Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                               |  |
+| Parameter        | Required | Data type | Notes                                                               |  |
 | ------------ | -------- | --------- | ------------------------------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.                                 |
 | `type`       | yes      | `string`  | Event type: `custom`                                                |
@@ -497,7 +497,7 @@ System message event is native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type | Notes                                                                                                                            |
+| Parameter                 | Required | Data type | Notes                                                                                                                            |
 | --------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`           | no       | `string`  | You can give the system message a custom ID.                                                                                     |
 | `type`                | yes      | `string`  | `system_message`                                                                                                                 |
@@ -921,9 +921,9 @@ In the websocket transport, actions generate [pushes](#pushes). RTM API actions 
 <Section>
 <Text>
 
-| The API endpoint  |
-| ----------------- |
-| `wss://api.livechatinc.com/v3.1/agent/rtm/ws`|
+| The API endpoint                              |
+| --------------------------------------------- |
+| `wss://api.livechatinc.com/v3.1/agent/rtm/ws` |
 
 ## Available methods
 
@@ -1013,7 +1013,7 @@ There's only one value allowed for a single property.
 
 #### Response
 
-| Parameter          | Data type | Notes                                                                     |
+| Field          | Data type | Notes                                                                     |
 | ------------------ | --------- | ------------------------------------------------------------------------- |
 | `found_chats`      | `number`  | An estimated number. The real number of found chats can slightly differ . |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request.                        |
@@ -1134,7 +1134,7 @@ There's only one value allowed for a single property.
 
 #### Response
 
-| Parameter          | Data type | Notes                                              |
+| Field          | Data type | Notes                                              |
 | ------------------ | --------- | -------------------------------------------------- |
 | `found_threads`    | `number`  | The number of threads in a chat                    |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
@@ -1466,7 +1466,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Request
 
-| Parameters               | Required | Data type | Notes                                                                       |
+| Parameter               | Required | Data type | Notes                                                                       |
 | ------------------------ | -------- | --------- | --------------------------------------------------------------------------- |
 | `chat`                   | No       | `object`  |                                                                             |
 | `chat.properties`        | No       | `object`  |                                                                             |
@@ -1479,7 +1479,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| Field   | Data type  | Notes                                                                                                                                                                   |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `chat_id`   | `string`   |                                                                                                                                                                         |
 | `thread_id` | `string`   |                                                                                                                                                                         |
@@ -1556,7 +1556,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                     |
+| Field   | Data type  | Notes                                                                                                                                                                     |
 | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                           |
 | `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
@@ -2833,7 +2833,7 @@ Dates are represented in ISO 8601 format with microseconds resolution, e.g. `201
 
 #### Response
 
-| Parameter          | Data type | Notes                                              |
+| Field          | Data type | Notes                                              |
 | ------------------ | --------- | -------------------------------------------------- |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
 | `previous_page_id` | `string`  | In relation to `page_id` specified in the request. |
@@ -3086,7 +3086,7 @@ It returns the initial state of the current Agent.
 
 #### Response
 
-| Parameter    | Req./Optional |     |     |
+| Field    | Req./Optional |     |     |
 | ------------ | ------------- | --- | --- |
 | `access`     | optional      |     |     |
 | `properties` | optional      |     |     |
@@ -3729,7 +3729,7 @@ Informs that a thread was closed.
 
 #### Push payload
 
-| Object    | Notes                                         |
+| Field    | Notes                                         |
 | --------- | --------------------------------------------- |
 | `user_id` | Missing if a thread was closed by the router. |
 
@@ -3761,7 +3761,7 @@ Informs that new, single access to a resource was granted. The existing access i
 
 #### Push payload
 
-| Object     | Notes         |
+| Field     | Notes         |
 | ---------- | ------------- |
 | `resource` | Resource type |
 | `id`       | Resource id   |
@@ -3792,7 +3792,7 @@ Informs that access to a certain resource was revoked.
 
 #### Push payload
 
-| Object     | Notes         |
+| Field     | Notes         |
 | ---------- | ------------- |
 | `resource` | Resource type |
 | `id`       | Resource Id   |
@@ -3823,7 +3823,7 @@ Informs that new, single access to a resource was set. The existing access is ov
 
 #### Push payload
 
-| Object     | Notes         |
+| Field     | Notes         |
 | ---------- | ------------- |
 | `resource` | Resource type |
 | `id`       | Resource Id   |
@@ -3853,7 +3853,7 @@ Informs that a chat was transferred to a different group or to an Agent.
 
 #### Push payload
 
-| Object | Notes                        |
+| Field | Notes                        |
 | ------ | ---------------------------- |
 | `type` | `agent` or `group`           |
 | `ids`  | `group` or `agent` IDs array |
@@ -3889,7 +3889,7 @@ This push can be emitted with `user.present` set to `false` when a user writes t
 
 #### Push payload
 
-| Object      | Notes                                          |
+| Field      | Notes                                          |
 | ----------- | ---------------------------------------------- |
 | `user_type` | Possible values: `agent`, `customer`           |
 | `thread_id` | Empty if a user was added to an inactive chat. |
@@ -3919,7 +3919,7 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Push payload
 
-| Object      | Notes                                              |
+| Field      | Notes                                              |
 | ----------- | -------------------------------------------------- |
 | `user_type` | Possible values: `agent`, `customer`               |
 | `thread_id` | Empty if a user was removed from an inactive chat. |
@@ -4048,7 +4048,7 @@ Informs about those chat properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -4079,7 +4079,7 @@ Informs about those chat properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -4117,7 +4117,7 @@ Informs about those chat thread properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -4149,7 +4149,7 @@ Informs about those chat thread properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -4184,7 +4184,7 @@ Informs about those event properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -4217,7 +4217,7 @@ Informs about those event properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -4606,7 +4606,7 @@ Informs about messages sent via the `multicast` method or by the system.
 
 #### Push payload
 
-| Object      | Required | Notes                                                                                            |
+| Field      | Required | Notes                                                                                            |
 | ----------- | -------- | ------------------------------------------------------------------------------------------------ |
 | `author_id` | No       | Present only if the push was generated by the **Multicast** method and not sent from the server. |
 | `content`   | Yes      |                                                                                                  |

--- a/content/messaging/agent-chat-api/v3.1/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.1/rtm-reference/index.mdx
@@ -993,7 +993,7 @@ It returns [summaries](#chat-summaries) of the chats an Agent has access to.
 
 #### Request
 
-| Request object                                        | Required | Type     | Notes                                                                                       |
+| Parameter                                        | Required | Type     | Notes                                                                                       |
 | ----------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------- |
 | `filters`                                             | No       | `object` | Mustn't change between requests for subsequent pages. Otherwise, the behavior is undefined. |
 | `filters.include_active`                              | No       | `bool`   | Defines if the returned chat summary includes active chats; default: `true`.                |
@@ -1542,7 +1542,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Request
 
-| Request object           | Required | Type     | Notes                                                                      |
+| Parameter           | Required | Type     | Notes                                                                      |
 | ------------------------ | -------- | -------- | -------------------------------------------------------------------------- |
 | `chat`                   | Yes      | `object` |                                                                            |
 | `chat.id`                | Yes      | `string` | The ID of the chat that will be activated.                                 |
@@ -1910,7 +1910,7 @@ Gives access to a new resource overwriting the existing ones.
 
 #### Request
 
-| Request object | Required | Type     | Notes                                                     |
+| Parameter | Required | Type     | Notes                                                     |
 | -------------- | -------- | -------- | --------------------------------------------------------- |
 | `resource`     | Yes      | `string` | `chat` or `customer`                                      |
 | `id`           | Yes      | `string` | Resource Id                                               |
@@ -2039,7 +2039,7 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 
 #### Request
 
-| Request object | Required | Type     | Notes                                  |
+| Parameter | Required | Type     | Notes                                  |
 | -------------- | -------- | -------- | -------------------------------------- |
 | `chat_id`      | Yes      | `string` |                                        |
 | `user_id`      | Yes      | `string` |                                        |
@@ -2098,7 +2098,7 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 
 **Request payload**
 
-| Request object | Required | Type     | Notes                                     |
+| Parameter | Required | Type     | Notes                                     |
 | -------------- | -------- | -------- | ----------------------------------------- |
 | `chat_id`      | Yes      | `string` |                                           |
 | `user_id`      | Yes      | `string` |                                           |
@@ -3212,7 +3212,7 @@ It returns the initial state of the current Agent.
 
 #### Request
 
-| Request object | Required | Type   |     |
+| Parameter | Required | Type   |     |
 | -------------- | -------- | ------ | --- |
 | `away`         | Yes      | `bool` |     |
 

--- a/content/messaging/agent-chat-api/v3.3/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/index.mdx
@@ -73,7 +73,7 @@ The **File** event informs about an uploaded file.
 
 ### Request
 
-| Field              | Required | Data type |                                                                                                                                     Notes |
+| Parameter              | Required | Data type |                                                                                                                                     Notes |
 | ------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`        | no       | `string`  |                                                                                                                                           |
 | `type`             | yes      | `string`  |                                                                                                                                    `file` |
@@ -115,7 +115,7 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                                    |
+| Parameter        | Required | Data type | Notes                                                                    |
 | ------------ | -------- | --------- | ------------------------------------------------------------------------ |
 | `custom_id`  | no       | `string`  |                                                                          |
 | `type`       | yes      | `string`  | `filled_form`                                                            |
@@ -154,7 +154,7 @@ The **Message** event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                        |
+| Parameter                | Required | Data type | Notes                                                                                                                        |
 | -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`          | no       | `string`  |                                                                                                                              |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
@@ -202,7 +202,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 
 ### Request
 
-| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
+| Parameter                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
 | --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                |
 | `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                       |
@@ -262,7 +262,7 @@ Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                               |  |
+| Parameter        | Required | Data type | Notes                                                               |  |
 | ------------ | -------- | --------- | ------------------------------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.                                 |
 | `type`       | yes      | `string`  | Event type: `custom`                                                |
@@ -298,7 +298,7 @@ System message event is native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type |                                                                                                                            Notes |
+| Parameter                 | Required | Data type |                                                                                                                            Notes |
 | --------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`           | no       | `string`  |                                                                                     You can give the system message a custom ID. |
 | `type`                | yes      | `string`  |                                                                                                                 `system_message` |
@@ -530,7 +530,7 @@ There's only one value allowed for a single property.
 
 #### Response
 
-| Parameter          | Data type | Notes                                                                                                        |
+| Field          | Data type | Notes                                                                                                        |
 | ------------------ | --------- | ------------------------------------------------------------------------------------------------------------ |
 | `chats_summary`    | `array`   | An array of [Chat summary](#chat-summaries) data structures                                                  |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. Appears in the response only when there's a next page.    |
@@ -1006,7 +1006,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| Field   | Data type  | Notes                                                                                                                                                                   |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `chat_id`   | `string`   |                                                                                                                                                                         |
 | `thread_id` | `string`   |                                                                                                                                                                         |
@@ -1082,7 +1082,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| Field   | Data type  | Notes                                                                                                                                                                   |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                         |
 | `event_ids` | `[]string` | Returned only when the chat was resumed with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
@@ -1536,7 +1536,7 @@ The method updates the requester's `events_seen_up_to` as if they've seen all ch
 
 #### Response
 
-| Parameter  | Data type |
+| Field  | Data type |
 | ---------- | --------- |
 | `event_id` | `string`  |
 
@@ -2099,7 +2099,7 @@ Returns the info about the Customer with a given `id`.
 
 #### Response
 
-| Parameter        | Data type | Notes                                                                                                                             |
+| Field        | Data type | Notes                                                                                                                             |
 | ---------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `id`             | string    | [Customer's](#customer) ID.                                                                                                       |
 | `type`           | string    | `customer`                                                                                                                        |
@@ -2285,7 +2285,7 @@ Dates are represented in ISO 8601 format with microseconds resolution, e.g. `201
 
 #### Response
 
-| Parameter          | Data type | Notes                                              |
+| Field          | Data type | Notes                                              |
 | ------------------ | --------- | -------------------------------------------------- |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
 | `previous_page_id` | `string`  | In relation to `page_id` specified in the request. |

--- a/content/messaging/agent-chat-api/v3.3/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/index.mdx
@@ -1424,7 +1424,7 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 
 #### Request
 
-| Request object          | Required | Type     | Notes                                                                                        |
+| Parameter          | Required | Type     | Notes                                                                                        |
 | ----------------------- | -------- | -------- | -------------------------------------------------------------------------------------------- |
 | `chat_id`               | Yes      | `string` |                                                                                              |
 | `user_id`               | Yes      | `string` |                                                                                              |
@@ -1474,7 +1474,7 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 
 #### Request
 
-| Request object | Required | Type     | Notes                                     |
+| Parameter | Required | Type     | Notes                                     |
 | -------------- | -------- | -------- | ----------------------------------------- |
 | `chat_id`      | Yes      | `string` |                                           |
 | `user_id`      | Yes      | `string` |                                           |

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -102,7 +102,7 @@ The **File** event informs about an uploaded file.
 
 ### Request
 
-| Field              | Required | Data type |                                                                                                                                     Notes |
+| Parameter              | Required | Data type |                                                                                                                                     Notes |
 | ------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`        | no       | `string`  |                                                                                                                                           |
 | `type`             | yes      | `string`  |                                                                                                                                    `file` |
@@ -144,7 +144,7 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                                    |
+| Parameter        | Required | Data type | Notes                                                                    |
 | ------------ | -------- | --------- | ------------------------------------------------------------------------ |
 | `custom_id`  | no       | `string`  |                                                                          |
 | `type`       | yes      | `string`  | `filled_form`                                                            |
@@ -183,7 +183,7 @@ The **Message** event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                        |
+| Parameter                | Required | Data type | Notes                                                                                                                        |
 | -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`          | no       | `string`  |                                                                                                                              |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
@@ -231,7 +231,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 
 ### Request
 
-| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                                                                                  |
+| Parameter                             | Required | Data type | Notes                                                                                                                                                                                                                                                                                                  |
 | --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                                                                      |
 | `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                                                                             |
@@ -291,7 +291,7 @@ Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                               |  |
+| Parameter        | Required | Data type | Notes                                                               |  |
 | ------------ | -------- | --------- | ------------------------------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.                                 |
 | `type`       | yes      | `string`  | Event type: `custom`                                                |
@@ -327,7 +327,7 @@ System message event is native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type | Notes                                                                                                                            |
+| Parameter                 | Required | Data type | Notes                                                                                                                            |
 | --------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`           | no       | `string`  | You can give the system message a custom ID.                                                                                     |
 | `type`                | yes      | `string`  | `system_message`                                                                                                                 |
@@ -577,7 +577,7 @@ There's only one value allowed for a single property.
 
 #### Response
 
-| Parameter          | Data type | Notes                                                                                                        |
+| Field          | Data type | Notes                                                                                                        |
 | ------------------ | --------- | ------------------------------------------------------------------------------------------------------------ |
 | `chats_summary`    | `array`   | An array of [Chat summary](#chat-summaries) data structures                                                  |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. Appears in the response only when there's a next page.    |
@@ -1056,7 +1056,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Request
 
-| Parameters               | Required | Data type  | Notes                                                                                                    |
+| Parameter               | Required | Data type  | Notes                                                                                                    |
 | ------------------------ | -------- | ---------- | -------------------------------------------------------------------------------------------------------- |
 | `chat`                   | No       | `object`   |                                                                                                          |
 | `chat.properties`        | No       | `object`   |                                                                                                          |
@@ -1072,7 +1072,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| Field   | Data type  | Notes                                                                                                                                                                   |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `chat_id`   | `string`   |                                                                                                                                                                         |
 | `thread_id` | `string`   |                                                                                                                                                                         |
@@ -1202,7 +1202,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| Field   | Data type  | Notes                                                                                                                                                                   |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                         |
 | `event_ids` | `[]string` | Returned only when the chat was resumed with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
@@ -1743,7 +1743,7 @@ The method updates the requester's `events_seen_up_to` as if they've seen all ch
 
 #### Request
 
-| Parameters              | Required | Data type | Notes                                                                                                        |
+| Parameter              | Required | Data type | Notes                                                                                                        |
 | ----------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------ |
 | `chat_id`               | Yes      | `string`  | Id of the chat you want to send the message to.                                                              |
 | `event`                 | Yes      | `object`  | Event object                                                                                                 |
@@ -2363,7 +2363,7 @@ Returns the info about the Customer with a given `id`.
 
 #### Response
 
-| Parameter        | Data type | Notes                                                                                                                             |
+| Field        | Data type | Notes                                                                                                                             |
 | ---------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `id`             | string    | [Customer's](#customer) ID.                                                                                                       |
 | `type`           | string    | `customer`                                                                                                                        |
@@ -2554,7 +2554,7 @@ Dates are represented in ISO 8601 format with microseconds resolution, e.g. `201
 
 #### Response
 
-| Parameter          | Data type | Notes                                              |
+| Field          | Data type | Notes                                              |
 | ------------------ | --------- | -------------------------------------------------- |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. |
 | `previous_page_id` | `string`  | In relation to `page_id` specified in the request. |
@@ -2950,7 +2950,7 @@ __**__ These values mean:
 
 #### Response
 
-| Parameter    | Data type | Notes |
+| Field    | Data type | Notes |
 | ------------ | --------- | ----- |
 | `access`     | `object`  |       |
 | `properties` | `object`  |       |
@@ -3720,7 +3720,7 @@ Informs that a chat was deactivated by closing the currently open thread.
 
 #### Push payload
 
-| Object    | Notes                                         |
+| Field    | Notes                                         |
 | --------- | --------------------------------------------- |
 | `user_id` | Missing if a thread was closed by the router. |
 
@@ -3752,7 +3752,7 @@ Informs that new, single access to a chat was granted. The existing access isn't
 
 #### Push payload
 
-| Object | Notes   |
+| Field | Notes   |
 | ------ | ------- |
 | `id`   | Chat id |
 
@@ -3782,7 +3782,7 @@ Informs that access to a certain chat was revoked.
 
 #### Push payload
 
-| Object | Notes   |
+| Field | Notes   |
 | ------ | ------- |
 | `id`   | Chat Id |
 
@@ -3821,7 +3821,7 @@ Informs that a chat was transferred to a different group or to an agent.
 
 #### Push payload
 
-| Object           | Notes                                                                    |
+| Field           | Notes                                                                    |
 | ---------------- | ------------------------------------------------------------------------ |
 | `thread_id`      | Present if the chat is active.                                           |
 | `transferred_to` | IDs of the groups and agents the chat is assigned to after the transfer. |
@@ -3864,7 +3864,7 @@ This push can be emitted with `user.present` set to `false` when a user writes t
 
 #### Push payload
 
-| Object         | Notes                                            |
+| Field         | Notes                                            |
 | -------------- | ------------------------------------------------ |
 | `thread_id`    | Present when a user was added to an active chat. |
 | `reason`       | Why the user was added.                          |
@@ -3897,7 +3897,7 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Push payload
 
-| Object         | Notes                                                |
+| Field         | Notes                                                |
 | -------------- | ---------------------------------------------------- |
 | `thread_id`    | Present when a user was removed from an active chat. |
 | `reason`       | Why the user was removed.                            |
@@ -4025,7 +4025,7 @@ Informs about those chat properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -4056,7 +4056,7 @@ Informs about those chat properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -4091,7 +4091,7 @@ Informs about those thread properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -4124,7 +4124,7 @@ Informs about those thread properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -4159,7 +4159,7 @@ Informs about those event properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -4192,7 +4192,7 @@ Informs about those event properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -4606,7 +4606,7 @@ Informs about messages sent via the `multicast` method or by the system.
 
 #### Push payload
 
-| Object      | Required | Notes                                                                                            |
+| Field      | Required | Notes                                                                                            |
 | ----------- | -------- | ------------------------------------------------------------------------------------------------ |
 | `author_id` | No       | Present only if the push was generated by the **Multicast** method and not sent from the server. |
 | `content`   | Yes      |                                                                                                  |

--- a/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -556,7 +556,7 @@ It returns [summaries](#chat-summaries) of the chats an Agent has access to.
 
 #### Request
 
-| Request object                                        | Required | Type     | Notes                                                                                       |
+| Parameter                                        | Required | Type     | Notes                                                                                       |
 | ----------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------- |
 | `filters`                                             | No       | `object` | Mustn't change between requests for subsequent pages. Otherwise, the behavior is undefined. |
 | `filters.include_active`                              | No       | `bool`   | Defines if the returned chat summary includes active chats; default: `true`.                |
@@ -1185,7 +1185,7 @@ When `chat.users` is defined, one of following scopes is required:
 
 #### Request
 
-| Request object           | Required | Type       | Notes                                                                                                    |
+| Parameter           | Required | Type       | Notes                                                                                                    |
 | ------------------------ | -------- | ---------- | -------------------------------------------------------------------------------------------------------- |
 | `chat`                   | Yes      | `object`   |                                                                                                          |
 | `chat.id`                | Yes      | `string`   | The ID of the chat that will be resumed.                                                                 |
@@ -1617,7 +1617,7 @@ Adds a user to the chat. You can't add more than one `customer` user type to the
 
 #### Request
 
-| Request object          | Required | Type     | Notes                                                                                        |
+| Parameter          | Required | Type     | Notes                                                                                        |
 | ----------------------- | -------- | -------- | -------------------------------------------------------------------------------------------- |
 | `chat_id`               | Yes      | `string` |                                                                                              |
 | `user_id`               | Yes      | `string` |                                                                                              |
@@ -1678,7 +1678,7 @@ Removes a user from chat. Removing `customer` user type is not allowed. It's alw
 
 #### Request
 
-| Request object | Required | Type     | Notes                                     |
+| Parameter | Required | Type     | Notes                                     |
 | -------------- | -------- | -------- | ----------------------------------------- |
 | `chat_id`      | Yes      | `string` |                                           |
 | `user_id`      | Yes      | `string` |                                           |
@@ -3069,7 +3069,7 @@ Remember that checking if Agents are active/inactive should be **implemented on 
 
 #### Request
 
-| Request object | Required | Data type |
+| Parameter | Required | Data type |
 | -------------- | -------- | --------- |
 | `away`         | Yes      | `bool`    |
 

--- a/content/messaging/customer-chat-api/index.mdx
+++ b/content/messaging/customer-chat-api/index.mdx
@@ -845,7 +845,7 @@ Used to restart an archived chat.
 
 #### Request
 
-| Request object           | Required | Type     | Notes                                                                      |
+| Parameter           | Required | Type     | Notes                                                                      |
 | ------------------------ | -------- | -------- | -------------------------------------------------------------------------- |
 | `chat`                   | Yes      | `object` |                                                                            |
 | `chat.id`                | Yes      | `string` | ID of the chat that will be activated.                                     |

--- a/content/messaging/customer-chat-api/index.mdx
+++ b/content/messaging/customer-chat-api/index.mdx
@@ -68,7 +68,7 @@ File event informs about a file being uploaded.
 
 ### Request
 
-| Field        | Required | Data type |                                                                                                                                     Notes |
+| Parameter        | Required | Data type |                                                                                                                                     Notes |
 | ------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`  | no       | `string`  |                                                                                                                                           |
 | `type`       | yes      | `string`  |                                                                                                                                    `file` |
@@ -111,7 +111,7 @@ Filled form event contains data from a form (prechat or postchat survey).
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                                    |
+| Parameter        | Required | Data type | Notes                                                                    |
 | ------------ | -------- | --------- | ------------------------------------------------------------------------ |
 | `custom_id`  | no       | `string`  |                                                                          |
 | `type`       | yes      | `string`  | `filled_form`                                                            |
@@ -152,7 +152,7 @@ Message event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                        |
+| Parameter                | Required | Data type | Notes                                                                                                                        |
 | -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`          | no       | `string`  |                                                                                                                              |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
@@ -201,7 +201,7 @@ Rich message event contains rich message data structure. [Read more](/extending-
 
 ### Request
 
-| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
+| Parameter                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
 | --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                |
 | `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                       |
@@ -259,7 +259,7 @@ Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                        |  |
+| Parameter        | Required | Data type | Notes                                        |  |
 | ------------ | -------- | --------- | -------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.          |
 | `type`       | yes      | `string`  | Event type: `custom`                         |
@@ -295,7 +295,7 @@ System message event is a native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type |                                                         Notes |
+| Parameter                 | Required | Data type |                                                         Notes |
 | --------------------- | -------- | --------- | ------------------------------------------------------------: |
 | `custom_id`           | no       | `string`  |                  You can give the system message a custom ID. |
 | `type`                | yes      | `string`  |                                              `system_message` |
@@ -502,7 +502,7 @@ It returns [summaries](#chat-summaries) of the chats a Customer participated in.
 
 #### Response
 
-| Parameter          | Data type | Notes                                                                                                           |
+| Field          | Data type | Notes                                                                                                           |
 | ------------------ | --------- | --------------------------------------------------------------------------------------------------------------- |
 | `total_chats`      | `number`  | An estimated number. The real number of found chats can slightly differ.                                        |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. Appears in the response only when there's the next page.     |
@@ -790,7 +790,7 @@ Starts a chat.
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| Field   | Data type  | Notes                                                                                                                                                                   |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `chat_id`   | `string`   |                                                                                                                                                                         |
 | `thread_id` | `string`   |                                                                                                                                                                         |
@@ -858,7 +858,7 @@ Used to restart an archived chat.
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                     |
+| Field   | Data type  | Notes                                                                                                                                                                     |
 | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                           |
 | `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
@@ -967,7 +967,7 @@ The method updates the requester's `events_seen_up_to` as if they've seen all ch
 
 #### Request
 
-| Parameters              | Required | Data type | Notes                                                                                                          |
+| Parameter              | Required | Data type | Notes                                                                                                          |
 | ----------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------- |
 | `chat_id`               | Yes      | `string`  | Id of the chat that you to send a message to.                                                                  |
 | `event`                 | Yes      | `object`  | The event object                                                                                               |
@@ -1953,7 +1953,7 @@ Returns an empty ticket form of a <a href="https://www.livechatinc.com/help/chat
 
 #### Response
 
-| Parameter | Notes                                                                                                                  |
+| Field | Notes                                                                                                                  |
 | --------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `enabled` | If `enabled: false`, the `form` object is not returned. Prechat/postchat survey disabled in the LiveChat Agent App UI. |
 | `form`    | The `form` object                                                                                                      |
@@ -2111,7 +2111,7 @@ It returns the info on a given URL.
 
 #### Response
 
-| Parameter            | Data type | Notes                                                  |
+| Field            | Data type | Notes                                                  |
 | -------------------- | --------- | ------------------------------------------------------ |
 | `image_url`          | `string`  | URL of the minified image hosted on the LiveChat's CDN |
 | `image_original_url` | `string`  | URL of the original image                              |

--- a/content/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -937,7 +937,7 @@ Used to restart an archived chat.
 
 #### Request
 
-| Request object           | Required | Type     | Notes                                                                      |
+| Parameter           | Required | Type     | Notes                                                                      |
 | ------------------------ | -------- | -------- | -------------------------------------------------------------------------- |
 | `chat`                   | Yes      | `object` |                                                                            |
 | `chat.id`                | Yes      | `string` | The ID of the chat that will be activated.                                 |

--- a/content/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -96,7 +96,7 @@ The **File** event informs about an uploaded file.
 
 ### Request
 
-| Field        | Required | Data type |                                                                                                                                     Notes |
+| Parameter        | Required | Data type |                                                                                                                                     Notes |
 | ------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`  | no       | `string`  |                                                                                                                                           |
 | `type`       | yes      | `string`  |                                                                                                                                    `file` |
@@ -139,7 +139,7 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                                    |
+| Parameter        | Required | Data type | Notes                                                                    |
 | ------------ | -------- | --------- | ------------------------------------------------------------------------ |
 | `custom_id`  | no       | `string`  |                                                                          |
 | `type`       | yes      | `string`  | `filled_form`                                                            |
@@ -178,7 +178,7 @@ The **Message** event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                        |
+| Parameter                | Required | Data type | Notes                                                                                                                        |
 | -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`          | no       | `string`  |                                                                                                                              |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
@@ -227,7 +227,7 @@ Rich message event contains rich message data structure. [Read more](/extending-
 
 ### Request
 
-| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
+| Parameter                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
 | --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                |
 | `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                       |
@@ -285,7 +285,7 @@ Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                        |  |
+| Parameter        | Required | Data type | Notes                                        |  |
 | ------------ | -------- | --------- | -------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.          |
 | `type`       | yes      | `string`  | Event type: `custom`                         |
@@ -321,7 +321,7 @@ System message event is a native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type | Notes                                                         |
+| Parameter                 | Required | Data type | Notes                                                         |
 | --------------------- | -------- | --------- | ------------------------------------------------------------- |
 | `custom_id`           | no       | `string`  | You can give the system message a custom ID.                  |
 | `type`                | yes      | `string`  | `system_message`                                              |
@@ -535,7 +535,7 @@ It returns [summaries](#chat-summaries) of the chats a Customer participated in.
 
 #### Response
 
-| Parameter          | Data type | Notes                                                                                                           |
+| Field          | Data type | Notes                                                                                                           |
 | ------------------ | --------- | --------------------------------------------------------------------------------------------------------------- |
 | `total_chats`      | `number`  | An estimated number. The real number of found chats can slightly differ.                                        |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. Appears in the response only when there's the next page.     |
@@ -826,7 +826,7 @@ Starts a chat.
 
 #### Request
 
-| Parameters               | Required | Data type | Notes                                                                       |
+| Parameter               | Required | Data type | Notes                                                                       |
 | ------------------------ | -------- | --------- | --------------------------------------------------------------------------- |
 | `chat`                   | No       | `object`  |                                                                             |
 | `chat.properties`        | No       | `object`  | Initial chat properties                                                     |
@@ -839,7 +839,7 @@ Starts a chat.
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| Field   | Data type  | Notes                                                                                                                                                                   |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `chat_id`   | `string`   |                                                                                                                                                                         |
 | `thread_id` | `string`   |                                                                                                                                                                         |
@@ -950,7 +950,7 @@ Used to restart an archived chat.
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                     |
+| Field   | Data type  | Notes                                                                                                                                                                     |
 | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                           |
 | `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
@@ -2220,7 +2220,7 @@ Returns an empty ticket form of a <a href="https://www.livechatinc.com/help/chat
 
 #### Response
 
-| Parameter | Notes                                                                                                                  |
+| Field | Notes                                                                                                                  |
 | --------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `enabled` | If `enabled: false`, the `form` object is not returned. Prechat/postchat survey disabled in the LiveChat Agent App UI. |
 | `form`    | The `form` object                                                                                                      |
@@ -2382,7 +2382,7 @@ It returns the info on a given URL.
 
 #### Response
 
-| Parameter            | Data type | Notes                                                  |
+| Field            | Data type | Notes                                                  |
 | -------------------- | --------- | ------------------------------------------------------ |
 | `image_url`          | `string`  | URL of the minified image hosted on the LiveChat's CDN |
 | `image_original_url` | `string`  | URL of the original image                              |
@@ -2719,7 +2719,7 @@ Informs that a chat was deactivated by closing the currently open thread.
 
 #### Push payload
 
-| Object    | Notes                                         |
+| Field    | Notes                                         |
 | --------- | --------------------------------------------- |
 | `user_id` | Missing if a thread was closed by the router. |
 
@@ -2759,7 +2759,7 @@ Informs that a chat was transferred to a different group or to an Agent.
 
 #### Push payload
 
-| Object           | Notes                                                  |
+| Field           | Notes                                                  |
 | ---------------- | ------------------------------------------------------ |
 | `thread_id`      | Present if the chat is active                          |
 | `transferred_to` | IDs of groups and Agents the chat has been assigned to |
@@ -2798,7 +2798,7 @@ This push can be emitted with `user.present` set to `false` when a user writes t
 
 #### Push payload
 
-| Object         | Notes                                            |
+| Field         | Notes                                            |
 | -------------- | ------------------------------------------------ |
 | `thread_id`    | Present when a user was added to an active chat. |
 | `reason`       | Why the user was added.                          |
@@ -2831,7 +2831,7 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Push payload
 
-| Object         | Notes                                                |
+| Field         | Notes                                                |
 | -------------- | ---------------------------------------------------- |
 | `thread_id`    | Present when a user was removed from an active chat. |
 | `reason`       | Why the user was removed.                            |
@@ -2958,7 +2958,7 @@ Informs about those chat properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -2989,7 +2989,7 @@ Informs about those chat properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3023,7 +3023,7 @@ Informs about those thread properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                       |
+| Field       | Notes                                                                                                       |
 | ------------ | ----------------------------------------------------------------------------------------------------------- |
 | `properties` | This is not a full `properties` object. This push shows only the properties the have been recently updated. |
 
@@ -3055,7 +3055,7 @@ Informs about those thread properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3089,7 +3089,7 @@ Informs about those event properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3122,7 +3122,7 @@ Informs about those event properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3199,7 +3199,7 @@ Informs that a Customer updated the data stored on their side.
 
 #### Push payload
 
-| Object                  | Notes                                                                                                                                              |
+| Field                  | Notes                                                                                                                                              |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `customer_side_storage` | A map in the `key : value` format. Map content should be kept on the client side (e.g. in browsers local storages) and sent via [`login`](#login). |
 
@@ -3232,7 +3232,7 @@ Informs that a Customer was disconnected. The payload contains the reason of Cus
 
 #### Push payload
 
-| Object   | Notes |
+| Field   | Notes |
 | -------- | ----- |
 | `reason` |       |
 
@@ -3317,7 +3317,7 @@ Informs about messages sent via the `multicast` method or by the system.
 
 #### Push payload
 
-| Object      | Required | Notes                                                                                            |
+| Field      | Required | Notes                                                                                            |
 | ----------- | -------- | ------------------------------------------------------------------------------------------------ |
 | `author_id` | No       | Present only if the push was generated by the **Multicast** method and not sent from the server. |
 | `content`   | Yes      |                                                                                                  |
@@ -3387,7 +3387,7 @@ Informs about an incoming [greeting](https://www.livechatinc.com/help/why-should
 
 #### Push payload
 
-| Object                 | Notes                                                                 |
+| Field                 | Notes                                                                 |
 | ---------------------- | --------------------------------------------------------------------- |
 | `id`                   | ID of the greeting configured within the license.                     |
 | `unique_id`            | ID of the greeting that was generated, sent, and cancelled.           |
@@ -3423,7 +3423,7 @@ Informs about a greeting accepted by the Customer.
 
 #### Push payload
 
-| Object      | Notes                                                      |
+| Field      | Notes                                                      |
 | ----------- | ---------------------------------------------------------- |
 | `unique_id` | ID of the greeting that was generated, sent, and accepted. |
 
@@ -3454,7 +3454,7 @@ Informs about a greeting rejected by the Customer. Also, the push is sent when a
 
 #### Push payload
 
-| Object      | Notes                                                      |
+| Field      | Notes                                                      |
 | ----------- | ---------------------------------------------------------- |
 | `unique_id` | ID of the greeting that was generated, sent, and rejected. |
 

--- a/content/messaging/customer-chat-api/v3.1/index.mdx
+++ b/content/messaging/customer-chat-api/v3.1/index.mdx
@@ -68,7 +68,7 @@ The **File** event informs about a file being uploaded.
 
 ### Request
  
-| Field        | Required | Data type |                                                                                                                                     Notes |
+| Parameter        | Required | Data type |                                                                                                                                     Notes |
 | ------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`  | no       | `string`  |                                                                                                                                           |
 | `type`       | yes      | `string`  |                                                                                                                                    `file` |
@@ -134,7 +134,7 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                                    |
+| Parameter        | Required | Data type | Notes                                                                    |
 | ------------ | -------- | --------- | ------------------------------------------------------------------------ |
 | `custom_id`  | no       | `string`  |                                                                          |
 | `type`       | yes      | `string`  | `filled_form`                                                            |
@@ -229,7 +229,7 @@ Message event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                         |
+| Parameter                | Required | Data type | Notes                                                                                                                         |
 | -------------------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`          | no       | `string`  |                                                                                                                               |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
@@ -303,7 +303,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 
 ### Request
 
-| Field                            | Required | Data type | Notes                                                                                             |
+| Parameter                            | Required | Data type | Notes                                                                                             |
 | -------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------- |
 | `custom_id`                      | no       | `string`  | You can give your RM a custom ID.                                                                 |
 | `type`                           | yes      | `string`  | Event type: `rich_message`                                                                        |
@@ -412,7 +412,7 @@ Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                               |                                                                                   |
+| Parameter        | Required | Data type | Notes                                                               |                                                                                   |
 | ------------ | -------- | --------- | ------------------------------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.                                 |
 | `type`       | yes      | `string`  | Event type: `custom`                                                |
@@ -469,7 +469,7 @@ System message event is a native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type |                                                                                                                            Notes |
+| Parameter                 | Required | Data type |                                                                                                                            Notes |
 | --------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`           | no       | `string`  |                                                                                     You can give the system message a custom ID. |
 | `type`                | yes      | `string`  |                                                                                                                 `system_message` |
@@ -997,7 +997,7 @@ curl -X POST \
 
 #### Response
 
-| Parameter         | Notes                           |     |
+| Field         | Notes                           |     |
 | ----------------- | ------------------------------- | --- |
 | `threads_summary` | Sorted descendingly by `order`. |     |
 
@@ -1163,7 +1163,7 @@ Starts a chat.
 
 #### Request
 
-| Parameters               | Required | Data type | Notes                                                                       |
+| Parameter               | Required | Data type | Notes                                                                       |
 | ------------------------ | -------- | --------- | --------------------------------------------------------------------------- |
 | `chat`                   | No       | `object`  |                                                                             |
 | `chat.properties`        | No       | `object`  | Initial chat properties                                                     |
@@ -1175,7 +1175,7 @@ Starts a chat.
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| Field   | Data type  | Notes                                                                                                                                                                   |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `chat_id`   | `string`   |                                                                                                                                                                         |
 | `thread_id` | `string`   |                                                                                                                                                                         |
@@ -1243,7 +1243,7 @@ Used to restart an archived chat.
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                     |
+| Field   | Data type  | Notes                                                                                                                                                                     |
 | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                           |
 | `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
@@ -2156,7 +2156,7 @@ Returns an empty ticket form of a <a href="https://www.livechatinc.com/help/chat
 
 #### Response
 
-| Parameter | Notes                                                                                                                  |
+| Field | Notes                                                                                                                  |
 | --------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `enabled` | If `enabled: false`, the `form` object is not returned. Prechat/postchat survey disabled in the LiveChat Agent App UI. |
 | `form`    |  The `form` object                                                                                                                    |

--- a/content/messaging/customer-chat-api/v3.1/index.mdx
+++ b/content/messaging/customer-chat-api/v3.1/index.mdx
@@ -1230,7 +1230,7 @@ Used to restart an archived chat.
 
 #### Request
 
-| Request object           | Required | Type     | Notes                                                                      |
+| Parameter           | Required | Type     | Notes                                                                      |
 | ------------------------ | -------- | -------- | -------------------------------------------------------------------------- |
 | `chat`                   | Yes      | `object` |                                                                            |
 | `chat.id`                | Yes      | `string` | ID of the chat that will be activated.                                     |

--- a/content/messaging/customer-chat-api/v3.1/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.1/rtm-reference/index.mdx
@@ -96,7 +96,7 @@ File event informs about a file being uploaded.
 
 ### Request
  
-| Field        | Required | Data type |                                                                                                                                          Notes |
+| Parameter        | Required | Data type |                                                                                                                                          Notes |
 | ------------ | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`  | no       | `string`  |                                                                                                                                                |
 | `type`       | yes      | `string`  |                                                                                                                                         `file` |
@@ -162,7 +162,7 @@ Filled form event contains data from a form (prechat or postchat survey).
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                                    |
+| Parameter        | Required | Data type | Notes                                                                    |
 | ------------ | -------- | --------- | ------------------------------------------------------------------------ |
 | `custom_id`  | no       | `string`  |                                                                          |
 | `type`       | yes      | `string`  | `filled_form`                                                            |
@@ -257,7 +257,7 @@ Message event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                        |
+| Parameter                | Required | Data type | Notes                                                                                                                        |
 | -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`          | no       | `string`  |                                                                                                                              |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
@@ -330,7 +330,7 @@ Rich message (RM) event contains a rich message data structure. [Read more](/ext
 
 ### Request
 
-| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
+| Parameter                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
 | --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                |
 | `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                       |
@@ -440,7 +440,7 @@ The Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                        |  |
+| Parameter        | Required | Data type | Notes                                        |  |
 | ------------ | -------- | --------- | -------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.          |
 | `type`       | yes      | `string`  | Event type: `custom`                         |
@@ -497,7 +497,7 @@ System message event is a native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type | Notes                                                         |
+| Parameter                 | Required | Data type | Notes                                                         |
 | --------------------- | -------- | --------- | ------------------------------------------------------------- |
 | `custom_id`           | no       | `string`  | You can give the system message a custom ID.                  |
 | `type`                | yes      | `string`  | `system_message`                                              |
@@ -1032,7 +1032,7 @@ It returns [summaries](#chat-summaries) of the chats a Customer participated in.
 
 #### Response
 
-| Parameter         | Notes                           |     |
+| Field         | Notes                           |     |
 | ----------------- | ------------------------------- | --- |
 | `threads_summary` | Sorted descendingly by `order`. |     |
 
@@ -1208,7 +1208,7 @@ Starts a chat.
 
 #### Request
 
-| Parameters               | Required | Data type | Notes                                                                       |
+| Parameter               | Required | Data type | Notes                                                                       |
 | ------------------------ | -------- | --------- | --------------------------------------------------------------------------- |
 | `chat`                   | No       | `object`  |                                                                             |
 | `chat.properties`        | No       | `object`  | Initial chat properties                                                     |
@@ -1220,7 +1220,7 @@ Starts a chat.
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| Field   | Data type  | Notes                                                                                                                                                                   |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `chat_id`   | `string`   |                                                                                                                                                                         |
 | `thread_id` | `string`   |                                                                                                                                                                         |
@@ -1293,7 +1293,7 @@ Used to restart an archived chat.
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                     |
+| Field   | Data type  | Notes                                                                                                                                                                     |
 | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                           |
 | `event_ids` | `[]string` | Returned only when the chat was activated with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
@@ -1417,7 +1417,7 @@ Sends an [Event](#events) object. Use this method to send a message by specifing
 
 #### Request
 
-| Parameters              | Required | Data type | Notes                                                                                                             |
+| Parameter              | Required | Data type | Notes                                                                                                             |
 | ----------------------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------- |
 | `chat_id`               | Yes      | `string`  | Id of the chat you want to send the message to.                                                                   |
 | `event`                 | Yes      | `object`  | The Event object                                                                                                  |
@@ -2457,7 +2457,7 @@ Returns an empty ticket form of a <a href="https://www.livechatinc.com/help/chat
 
 #### Response
 
-| Parameter | Notes                                                                                                                  |
+| Field | Notes                                                                                                                  |
 | --------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `enabled` | If `enabled: false`, the `form` object is not returned. Prechat/postchat survey disabled in the LiveChat Agent App UI. |
 | `form`    | The `form` object                                                                                                      |
@@ -2829,7 +2829,7 @@ Informs that a thread was closed.
 
 #### Push payload
 
-| Object    | Notes                                         |
+| Field    | Notes                                         |
 | --------- | --------------------------------------------- |
 | `user_id` | Missing if a thread was closed by the router. |
 
@@ -2862,7 +2862,7 @@ Informs that new, single access to a resource was set. The existing access is ov
 
 #### Push payload
 
-| Object     | Notes         |
+| Field     | Notes         |
 | ---------- | ------------- |
 | `resource` | Resource type |
 | `id`       | Resource id   |
@@ -2893,7 +2893,7 @@ Informs that a chat was transferred to a different group or to an Agent.
 
 #### Push payload
 
-| Object | Notes                                  |
+| Field | Notes                                  |
 | ------ | -------------------------------------- |
 | `type` | `agent` or `group`                     |
 | `ids`  | An array of the `group` or `agent` IDs |
@@ -2929,7 +2929,7 @@ This push can be emitted with `user.present` set to `false` when a user writes t
 
 #### Push payload
 
-| Object      | Notes                                          |
+| Field      | Notes                                          |
 | ----------- | ---------------------------------------------- |
 | `user_type` | Possible values: `agent`, `customer`           |
 | `thread_id` | Empty if a user was added to an inactive chat. |
@@ -2959,7 +2959,7 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Push payload
 
-| Object      | Notes                                              |
+| Field      | Notes                                              |
 | ----------- | -------------------------------------------------- |
 | `user_type` | Possible values: `agent`, `customer`               |
 | `thread_id` | Empty if a user was removed from an inactive chat. |
@@ -3088,7 +3088,7 @@ Informs about those chat properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3119,7 +3119,7 @@ Informs about those chat properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3157,7 +3157,7 @@ Informs about those chat thread properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                       |
+| Field       | Notes                                                                                                       |
 | ------------ | ----------------------------------------------------------------------------------------------------------- |
 | `properties` | This is not a full `properties` object. This push shows only the properties the have been recently updated. |
 
@@ -3189,7 +3189,7 @@ Informs about those chat thread properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3224,7 +3224,7 @@ Informs about those event properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3257,7 +3257,7 @@ Informs about those event properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3331,7 +3331,7 @@ Informs that a Customer updated the data stored on their side.
 
 #### Push payload
 
-| Object                  | Notes                                                                                                                                              |
+| Field                  | Notes                                                                                                                                              |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `customer_side_storage` | A map in the `key : value` format. Map content should be kept on the client side (e.g. in browsers local storages) and sent via [`login`](#login). |
 
@@ -3363,7 +3363,7 @@ Informs that a Customer was disconnected. The payload contains the reason of Cus
 
 #### Push payload
 
-| Object   | Notes |
+| Field   | Notes |
 | -------- | ----- |
 | `reason` |       |
 
@@ -3446,7 +3446,7 @@ Informs about messages sent via the `multicast` method or by the system.
 
 #### Push payload
 
-| Object      | Required | Notes                                                                                            |
+| Field      | Required | Notes                                                                                            |
 | ----------- | -------- | ------------------------------------------------------------------------------------------------ |
 | `author_id` | No       | Present only if the push was generated by the **Multicast** method and not sent from the server. |
 | `content`   | Yes      |                                                                                                  |

--- a/content/messaging/customer-chat-api/v3.1/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.1/rtm-reference/index.mdx
@@ -1280,7 +1280,7 @@ Used to restart an archived chat.
 
 #### Request
 
-| Request object           | Required | Type     | Notes                                                                      |
+| Parameter           | Required | Type     | Notes                                                                      |
 | ------------------------ | -------- | -------- | -------------------------------------------------------------------------- |
 | `chat`                   | Yes      | `object` |                                                                            |
 | `chat.id`                | Yes      | `string` | The ID of the chat that will be activated.                                 |

--- a/content/messaging/customer-chat-api/v3.3/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/index.mdx
@@ -62,7 +62,7 @@ File event informs about a file being uploaded.
 
 ### Request
 
-| Field              | Required | Data type |                                                                                                                                     Notes |
+| Parameter              | Required | Data type |                                                                                                                                     Notes |
 | ------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`        | no       | `string`  |                                                                                                                                           |
 | `type`             | yes      | `string`  |                                                                                                                                    `file` |
@@ -107,7 +107,7 @@ Filled form event contains data from a form (prechat or postchat survey).
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                                    |
+| Parameter        | Required | Data type | Notes                                                                    |
 | ------------ | -------- | --------- | ------------------------------------------------------------------------ |
 | `custom_id`  | no       | `string`  |                                                                          |
 | `type`       | yes      | `string`  | `filled_form`                                                            |
@@ -148,7 +148,7 @@ Message event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                        |
+| Parameter                | Required | Data type | Notes                                                                                                                        |
 | -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`          | no       | `string`  |                                                                                                                              |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
@@ -197,7 +197,7 @@ Rich message event contains rich message data structure. [Read more](/extending-
 
 ### Request
 
-| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
+| Parameter                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
 | --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                |
 | `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                       |
@@ -257,7 +257,7 @@ Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                        |  |
+| Parameter        | Required | Data type | Notes                                        |  |
 | ------------ | -------- | --------- | -------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.          |
 | `type`       | yes      | `string`  | Event type: `custom`                         |
@@ -293,7 +293,7 @@ System message event is a native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type |                                                         Notes |
+| Parameter                 | Required | Data type |                                                         Notes |
 | --------------------- | -------- | --------- | ------------------------------------------------------------: |
 | `custom_id`           | no       | `string`  |                  You can give the system message a custom ID. |
 | `type`                | yes      | `string`  |                                              `system_message` |

--- a/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
@@ -96,7 +96,7 @@ The **File** event informs about an uploaded file.
 
 ### Request
 
-| Field              | Required | Data type |                                                                                                                                     Notes |
+| Parameter              | Required | Data type |                                                                                                                                     Notes |
 | ------------------ | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------: |
 | `custom_id`        | no       | `string`  |                                                                                                                                           |
 | `type`             | yes      | `string`  |                                                                                                                                    `file` |
@@ -141,7 +141,7 @@ The **Filled form** event contains data from a form (prechat or postchat survey)
 
 ### Request
 
-| Field        | Required | Data type | Notes                                                                    |
+| Parameter        | Required | Data type | Notes                                                                    |
 | ------------ | -------- | --------- | ------------------------------------------------------------------------ |
 | `custom_id`  | no       | `string`  |                                                                          |
 | `type`       | yes      | `string`  | `filled_form`                                                            |
@@ -180,7 +180,7 @@ The **Message** event contains text message to other chat users.
 
 ### Request
 
-| Field                | Required | Data type | Notes                                                                                                                        |
+| Parameter                | Required | Data type | Notes                                                                                                                        |
 | -------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `custom_id`          | no       | `string`  |                                                                                                                              |
 | `text`               | yes      | `string`  | Max. raw text size is 16 KB (one UTF-8 char like emoji 😁 can use up to 4 B); to send more, split text into several messages. |
@@ -229,7 +229,7 @@ Rich message event contains rich message data structure. [Read more](/extending-
 
 ### Request
 
-| Field                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
+| Parameter                             | Required | Data type | Notes                                                                                                                                                                                                                                            |
 | --------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `custom_id`                       | no       | `string`  | You can give your RM a custom ID.                                                                                                                                                                                                                |
 | `type`                            | yes      | `string`  | Event type: `rich_message`                                                                                                                                                                                                                       |
@@ -289,7 +289,7 @@ Custom event is an event with customizable payload.
 
 ### Request
 
-| Field        | Required | Data type | Notes                                        |  |
+| Parameter        | Required | Data type | Notes                                        |  |
 | ------------ | -------- | --------- | -------------------------------------------- |
 | `custom_id`  | no       | `string`  | You can give the event a custom ID.          |
 | `type`       | yes      | `string`  | Event type: `custom`                         |
@@ -325,7 +325,7 @@ System message event is a native system event sent in specific situations.
 
 ### Request
 
-| Field                 | Required | Data type |                                                         Notes |
+| Parameter                 | Required | Data type |                                                         Notes |
 | --------------------- | -------- | --------- | ------------------------------------------------------------: |
 | `custom_id`           | no       | `string`  |                  You can give the system message a custom ID. |
 | `type`                | yes      | `string`  |                                              `system_message` |
@@ -559,7 +559,7 @@ It returns [summaries](#chat-summaries) of the chats a Customer participated in.
 
 #### Response
 
-| Parameter          | Data type | Notes                                                                                                           |
+| Field          | Data type | Notes                                                                                                           |
 | ------------------ | --------- | --------------------------------------------------------------------------------------------------------------- |
 | `total_chats`      | `number`  | An estimated number. The real number of found chats can slightly differ.                                        |
 | `next_page_id`     | `string`  | In relation to `page_id` specified in the request. Appears in the response only when there's the next page.     |
@@ -852,7 +852,7 @@ The method updates the requester's `events_seen_up_to` as if they've seen all ch
 
 #### Request
 
-| Parameters               | Required | Data type | Notes                                                                       |
+| Parameter               | Required | Data type | Notes                                                                       |
 | ------------------------ | -------- | --------- | --------------------------------------------------------------------------- |
 | `chat`                   | No       | `object`  |                                                                             |
 | `chat.properties`        | No       | `object`  | Initial chat properties                                                     |
@@ -866,7 +866,7 @@ The method updates the requester's `events_seen_up_to` as if they've seen all ch
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| Field   | Data type  | Notes                                                                                                                                                                   |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `chat_id`   | `string`   |                                                                                                                                                                         |
 | `thread_id` | `string`   |                                                                                                                                                                         |
@@ -942,7 +942,7 @@ The method updates the requester's `events_seen_up_to` as if they've seen all ch
 
 #### Response
 
-| Parameter   | Data type  | Notes                                                                                                                                                                   |
+| Field   | Data type  | Notes                                                                                                                                                                   |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `thread_id` | `string`   |                                                                                                                                                                         |
 | `event_ids` | `[]string` | Returned only when the chat was resumed with initial events. Returns only the IDs of user-generated events; server-side generated events are not included in the array. |
@@ -1067,7 +1067,7 @@ The method updates the requester's `events_seen_up_to` as if they've seen all ch
 
 #### Request
 
-| Parameters              | Required | Data type | Notes                                                                                                             |
+| Parameter              | Required | Data type | Notes                                                                                                             |
 | ----------------------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------- |
 | `chat_id`               | Yes      | `string`  | Id of the chat you want to send the message to.                                                                   |
 | `event`                 | Yes      | `object`  | The Event object                                                                                                  |
@@ -2174,7 +2174,7 @@ Returns an empty ticket form of a <a href="https://www.livechatinc.com/help/chat
 
 #### Response
 
-| Parameter | Notes                                                                                                                  |
+| Field | Notes                                                                                                                  |
 | --------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `enabled` | If `enabled: false`, the `form` object is not returned. Prechat/postchat survey disabled in the LiveChat Agent App UI. |
 | `form`    | The [Form](#forms) data structure.                                                                                     |
@@ -2303,7 +2303,7 @@ It returns the info on a given URL.
 
 #### Response
 
-| Parameter            | Data type | Notes                                                  |
+| Field            | Data type | Notes                                                  |
 | -------------------- | --------- | ------------------------------------------------------ |
 | `image_url`          | `string`  | URL of the minified image hosted on the LiveChat's CDN |
 | `image_original_url` | `string`  | URL of the original image                              |
@@ -2640,7 +2640,7 @@ Informs that a chat was deactivated by closing the currently open thread.
 
 #### Push payload
 
-| Object    | Notes                                         |
+| Field    | Notes                                         |
 | --------- | --------------------------------------------- |
 | `user_id` | Missing if a thread was closed by the router. |
 
@@ -2680,7 +2680,7 @@ Informs that a chat was transferred to a different group or to an Agent.
 
 #### Push payload
 
-| Object           | Notes                                                  |
+| Field           | Notes                                                  |
 | ---------------- | ------------------------------------------------------ |
 | `thread_id`      | Present if the chat is active                          |
 | `transferred_to` | IDs of groups and Agents the chat has been assigned to |
@@ -2719,7 +2719,7 @@ This push can be emitted with `user.present` set to `false` when a user writes t
 
 #### Push payload
 
-| Object         | Notes                                            |
+| Field         | Notes                                            |
 | -------------- | ------------------------------------------------ |
 | `thread_id`    | Present when a user was added to an active chat. |
 | `reason`       | Why the user was added.                          |
@@ -2752,7 +2752,7 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Push payload
 
-| Object         | Notes                                                |
+| Field         | Notes                                                |
 | -------------- | ---------------------------------------------------- |
 | `thread_id`    | Present when a user was removed from an active chat. |
 | `reason`       | Why the user was removed.                            |
@@ -2879,7 +2879,7 @@ Informs about those chat properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -2910,7 +2910,7 @@ Informs about those chat properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -2944,7 +2944,7 @@ Informs about those thread properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                       |
+| Field       | Notes                                                                                                       |
 | ------------ | ----------------------------------------------------------------------------------------------------------- |
 | `properties` | This is not a full `properties` object. This push shows only the properties the have been recently updated. |
 
@@ -2976,7 +2976,7 @@ Informs about those thread properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3010,7 +3010,7 @@ Informs about those event properties that were updated.
 
 #### Push payload
 
-| Object       | Notes                                                                                                |
+| Field       | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3043,7 +3043,7 @@ Informs about those event properties that were deleted.
 
 #### Push payload
 
-| Object       | Notes                                                                                                        |
+| Field       | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3120,7 +3120,7 @@ Informs that a Customer updated the data stored on their side.
 
 #### Push payload
 
-| Object                  | Notes                                                                                                                                              |
+| Field                  | Notes                                                                                                                                              |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `customer_side_storage` | A map in the `key : value` format. Map content should be kept on the client side (e.g. in browsers local storages) and sent via [`login`](#login). |
 
@@ -3153,7 +3153,7 @@ Informs that a Customer was disconnected. The payload contains the reason of Cus
 
 #### Push payload
 
-| Object   | Notes |
+| Field   | Notes |
 | -------- | ----- |
 | `reason` |       |
 
@@ -3238,7 +3238,7 @@ Informs about messages sent via the `multicast` method or by the system.
 
 #### Push payload
 
-| Object      | Required | Notes                                                                                            |
+| Field      | Required | Notes                                                                                            |
 | ----------- | -------- | ------------------------------------------------------------------------------------------------ |
 | `author_id` | No       | Present only if the push was generated by the **Multicast** method and not sent from the server. |
 | `content`   | Yes      |                                                                                                  |
@@ -3309,7 +3309,7 @@ Informs about an incoming [greeting](https://www.livechatinc.com/help/why-should
 
 #### Push payload
 
-| Object                 | Notes                                                                 |
+| Field                 | Notes                                                                 |
 | ---------------------- | --------------------------------------------------------------------- |
 | `id`                   | ID of the greeting configured within the license.                     |
 | `unique_id`            | ID of the greeting that was generated, sent, and cancelled.           |
@@ -3346,7 +3346,7 @@ Informs about a greeting accepted by the Customer.
 
 #### Push payload
 
-| Object      | Notes                                                      |
+| Field      | Notes                                                      |
 | ----------- | ---------------------------------------------------------- |
 | `unique_id` | ID of the greeting that was generated, sent, and accepted. |
 
@@ -3377,7 +3377,7 @@ Informs about a greeting rejected by the Customer. Also, the push is sent when a
 
 #### Push payload
 
-| Object      | Notes                                                      |
+| Field      | Notes                                                      |
 | ----------- | ---------------------------------------------------------- |
 | `unique_id` | ID of the greeting that was generated, sent, and rejected. |
 

--- a/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
+++ b/content/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
@@ -928,7 +928,7 @@ The method updates the requester's `events_seen_up_to` as if they've seen all ch
 
 #### Request
 
-| Request object           | Required | Type     | Notes                                                                      |
+| Parameter           | Required | Type     | Notes                                                                      |
 | ------------------------ | -------- | -------- | -------------------------------------------------------------------------- |
 | `chat`                   | Yes      | `object` |                                                                            |
 | `chat.id`                | Yes      | `string` | The ID of the chat that will be resumed.                                   |


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/DPS-2587)
- [Jira](https://livechatinc.atlassian.net/browse/DPS-2587)

## 📓 Description

Messaging and Configuration APIs required changes to unify the nomenclature for request and response objects. 
Changes can be summarized as:

Agent Chat API, Customer Chat API, Configuration API:
- **Events** > request "field" changed to "parameter"
- **Methods** > response "parameter" changed to "field, 
request "request object" changed to "field"
- **Pushes** > push payload "object" changed to "field"

Configuration API:
- **Webhooks** > webhook payload "object" changed to "field"

## ✅ Checklist (for API docs)
- API versions - **3.3, 3.2, 3.1, and 2.0 applicable only for Configuration API**
- Both Web & RTM APIs
- Updated: **Events, Methods, Pushes, and applicable only for Configuration API - webhooks**

Note: Currently, applied changes are **without formatting** for an easier review. Formatting will be applied in the final commit after approved reviews. 

## 👷 Type of change
### Content
- Proofreading/content fixes

