### PR TITLE
API-8114: new WH filters/additional data

### DIFF
--- a/content/management/changelog/index.mdx
+++ b/content/management/changelog/index.mdx
@@ -87,6 +87,8 @@ Since the migration is still ongoing, different parts will be successively moved
     - [**Enable License Webhooks**](/management/configuration-api/v3.3/#enable-license-webhooks)
     - [**Disable License Webhooks**](/management/configuration-api/v3.3/#disable-license-webhooks)
     - [**Get License Webhooks State**](/management/configuration-api/v3.3/#get-license-webhooks-state)
+- The `chat_member_ids` filter was replaced by the `chat_presence` filter.
+- There's new additional data `chat_presence_user_ids` available for the same webhooks that support `chat_properties` additional data.
 
 ## [v3.2] - 2020-06-18
 

--- a/content/management/changelog/index.mdx
+++ b/content/management/changelog/index.mdx
@@ -88,7 +88,7 @@ Since the migration is still ongoing, different parts will be successively moved
     - [**Disable License Webhooks**](/management/configuration-api/v3.3/#disable-license-webhooks)
     - [**Get License Webhooks State**](/management/configuration-api/v3.3/#get-license-webhooks-state)
 - The `chat_member_ids` filter was replaced by the `chat_presence` filter.
-- There's new additional data `chat_presence_user_ids` available for the same webhooks that support `chat_properties` additional data.
+- There's new additional data, `chat_presence_user_ids`, available for the same webhooks that support the `chat_properties` additional data.
 
 ## [v3.2] - 2020-06-18
 

--- a/content/management/configuration-api/index.mdx
+++ b/content/management/configuration-api/index.mdx
@@ -3100,7 +3100,7 @@ __*__ The table below presents the possible values for the `action` parameter.
 | [`thread_tagged`](#thread_tagged)                                   |                `chat_member_ids`, `only_my_chats` |
 | [`thread_untagged`](#thread_untagged)                               |                `chat_member_ids`, `only_my_chats` |
 | [`routing_status_set`](#routing_status_set)                         |                                                 - |
-| [`agent_deleted`](#agent_deleted)                                   |                    `chat_member_ids`, `agent_ids` |
+| [`agent_deleted`](#agent_deleted)                                   |                                       `agent_ids` |
 | [`customer_created`](#customer_created)                             |                                                 - |
 | [`events_marked_as_seen`](#events_marked_as_seen)                   |                `chat_member_ids`, `only_my_chats` |
 

--- a/content/management/configuration-api/v3.1/index.mdx
+++ b/content/management/configuration-api/v3.1/index.mdx
@@ -1924,8 +1924,8 @@ Informs that a user has seen events up to a specific time.
 
 __*__ The table below presents the possible values for the `action` parameter.
 
-| Possible action                   | Informs about                                                                                               | Available filters                                 |
-| --------------------------------- |:-----------------------------------------------------------------------------------------------------------:| -------------------------------------------------:|
+| Possible action                   | Informs about                                                                                                    | Available filters                                 |
+| --------------------------------- |:----------------------------------------------------------------------------------------------------------------:| -------------------------------------------------:|
 | `incoming_chat_thread`            | [`incoming_chat_thread`](/messaging/agent-chat-api/v3.1/rtm-reference/#incoming_chat_thread)                     | `chat_member_ids`, `only_my_chats`                |
 | `incoming_event`                  | [`incoming_event`](/messaging/agent-chat-api/v3.1/rtm-reference/#incoming_event)                                 | `chat_member_ids`, `author_type`, `only_my_chats` |
 | `event_updated`                   | [`event_updated`](/messaging/agent-chat-api/v3.1/rtm-reference/#event_updated)                                   | `chat_member_ids`, `author_type`, `only_my_chats` |
@@ -1941,7 +1941,7 @@ __*__ The table below presents the possible values for the `action` parameter.
 | `chat_thread_tagged`              | [`chat_thread_tagged`](/messaging/agent-chat-api/v3.1/rtm-reference/#chat_thread_tagged)                         | `chat_member_ids`, `only_my_chats`                |
 | `chat_thread_untagged`            | [`chat_thread_untagged`](/messaging/agent-chat-api/v3.1/rtm-reference/#chat_thread_untagged)                     | `chat_member_ids`, `only_my_chats`                |
 | `agent_status_changed`            | [`agent_updated`](/messaging/agent-chat-api/v3.1/rtm-reference/#agent_updated)                                   | `chat_member_ids`                                 |
-| `agent_deleted`                   | An Agent's account being deleted from the license                                                           | `chat_member_ids`                                 |
+| `agent_deleted`                   | An Agent's account being deleted from the license                                                                | `agent_ids`                                       |
 
 
 __*__ The table below presents the possible values for the `additional_data` parameter:

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -2397,7 +2397,10 @@ Here's what you need to know about **webhooks**:
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -2460,7 +2463,10 @@ Informs about a chat coming with a new thread. The webhook payload contains the 
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -2512,7 +2518,10 @@ Informs that a chat was deactivated by closing the currently open thread.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -2567,7 +2576,10 @@ Informs that new, single access to a chat was granted. The existing access isn't
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -2620,7 +2632,10 @@ Informs that access to a certain chat was revoked.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -2741,7 +2756,10 @@ Informs that a user (Customer or Agent) was added to a chat.
   "additional_data": {
     "chat_properties": { //optional
       // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -2795,7 +2813,10 @@ Informs that a user (Customer or Agent) was removed from a chat.
   "additional_data": {
     "chat_properties": { //optional
       // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -2845,7 +2866,10 @@ Informs about an incoming [event](/messaging/agent-chat-api/v3.3/#events) sent t
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -2893,7 +2917,10 @@ Informs that an [event](/messaging/agent-chat-api/v3.3/#events) was updated.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -2944,7 +2971,10 @@ Informs about an incoming [rich message](/messaging/agent-chat-api/v3.3/#rich-me
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -3001,7 +3031,10 @@ Informs about those chat properties that were updated.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -3056,7 +3089,10 @@ Informs about those chat properties that were deleted.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -3112,7 +3148,10 @@ Informs about those thread properties that were updated.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -3168,7 +3207,10 @@ Informs about those thread properties that were deleted.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -3225,7 +3267,10 @@ Informs about those event properties that were updated.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -3282,7 +3327,10 @@ Informs about those event properties that were deleted.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -3330,7 +3378,10 @@ Informs that a thread was tagged.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -3376,7 +3427,10 @@ Informs that a thread was untagged.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -3429,7 +3483,10 @@ Informs that an Agent's or Bot's status has changed.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -3473,7 +3530,10 @@ Informs that an Agent's account was deleted.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -3521,7 +3581,10 @@ Informs that a new Customer registered.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -3574,7 +3637,10 @@ Informs that a chatting Customer's session fields were updated. The webhook will
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -3622,7 +3688,10 @@ Informs that a user has seen events up to a specific time.
   "additional_data": {
     "chat_properties": { //optional
         // chat properties
-    }
+    },
+    "chat_presence_user_ids": [ //optional
+      // User IDs
+    ]
   }
 }
 ```
@@ -3658,21 +3727,23 @@ Registers a webhook for the Client ID (application) provided in the request. Lat
 | Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/register_webhook` |
 | Required scopes | `webhooks.configuration:rw`                                              |
 
-| Parameter                                | Required | Data type  | Notes                                                                                                                                                     |
-| ---------------------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `action`__*__                            | yes      | `string`   | The [action](#triggering-actions) that triggers sending a webhook.                                                                                        |
-| `secret_key`                             | yes      | `string`   | The secret key sent in webhooks to verify the source of a webhook.                                                                                        |
-| `url`                                    | yes      | `string`   | Destination URL for the webhook                                                                                                                           |
-| `additional_data`                        | no       | `[]string` | Additional data arriving with the webhook. Value: `chat properties` (all actions except for `agent_status_changed`, `agent_deleted`, `incoming_customer`) |
-| `description`                            | no       | `string`   | Webhook description                                                                                                                                       |
-| `filters`                                | no       | `object`   | Filters to check if a webhook should be triggered.                                                                                                        |
-| `filters.author_type`                    | no       | `string`   | Possible values: `customer`, `agent`; allowed only for the `incoming_event` and `event_updated` actions.                                                  |
-| `filters.only_my_chats`                  | no       | `bool`     | `true` or `false`; triggers webhooks only for chats with the property `source.client_id` set to my `client_id`.                                           |
-| `filters.chat_member_ids`                | no       | `object`   | Only one filter (`agents_any` or `agents_exclude`) is allowed.                                                                                            |
-| `filters.chat_member_ids.agents_any`     | no       | `[]string` | Array of Agents' ids; if any specified Agent is in the chat, the webhook will be triggered.                                                               |
-| `filters.chat_member_ids.agents_exclude` | no       | `[]string` | Array of Agents' ids; If any specified Agent is in the chat, the webhook will not be triggered.                                                           |
-| `owner_client_id`                        | yes      | `string`   | The Client ID for which the webhook will be registered.                                                                                                   |
-| `type`                                   | yes      | `string`   | `bot` or `license`                                                                                                                                        |
+| Parameter                                       | Required | Data type  | Notes                                                                                                                                                                               |
+| ----------------------------------------------- | -------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `action`__*__                                   | yes      | `string`   | The [action](#triggering-actions) that triggers sending a webhook.                                                                                                                  |
+| `secret_key`                                    | yes      | `string`   | The secret key sent in webhooks to verify the source of a webhook.                                                                                                                  |
+| `url`                                           | yes      | `string`   | Destination URL for the webhook                                                                                                                                                     |
+| `additional_data`                               | no       | `[]string` | Additional data arriving with the webhook. Value: `chat properties`, `chat_presence_user_ids` (all actions except for `agent_status_changed`, `agent_deleted`, `incoming_customer`) |
+| `description`                                   | no       | `string`   | Webhook description                                                                                                                                                                 |
+| `filters`                                       | no       | `object`   | Filters to check if a webhook should be triggered.                                                                                                                                  |
+| `filters.author_type`                           | no       | `string`   | Possible values: `customer`, `agent`; allowed only for the `incoming_event` and `event_updated` actions.                                                                            |
+| `filters.only_my_chats`                         | no       | `bool`     | `true` or `false`; triggers webhooks only for chats with the property `source.client_id` set to my `client_id`.                                                                     |
+| `filters.chat_presence`                         | no       | `object`   | Filters to check if a webhook should be triggered based on user's presence in the chat.                                                                                             |
+| `filters.chat_presence.user_ids`                | no       | `object`   | Only one filter (`values` or `exclude_values`) is allowed. Supports every user type (Agent, Customer, Bot).                                                                         |
+| `filters.chat_presence.user_ids.values`         | no       | `[]string` | Array of Users' ids; if any specified User is in the chat, the webhook will be triggered.                                                                                           |
+| `filters.chat_presence.user_ids.exclude_values` | no       | `[]string` | Array of Users' ids; if any specified Users is in the chat, the webhook will not be triggered.                                                                                      |
+| `filters.chat_presence.my_bots`                 | no       | `bool`     | If any bot owned by `owner_client_id` is in the chat, the webhook will be triggered.                                                                                                |
+| `owner_client_id`                               | yes      | `string`   | The Client ID for which the webhook will be registered.                                                                                                                             |
+| `type`                                          | yes      | `string`   | `bot` or `license`                                                                                                                                                                  |
 
 #### Triggering actions
 
@@ -3680,28 +3751,28 @@ __*__ The table below presents the possible values for the `action` parameter.
 
 | Possible action                                                       |                                 Available filters |
 | --------------------------------------------------------------------- | ------------------------------------------------: |
-| [`incoming_chat`](#incoming_chat)                                     |                `chat_member_ids`, `only_my_chats` |
-| [`chat_deactivated`](#chat_deactivated)                               |                `chat_member_ids`, `only_my_chats` |
-| [`chat_access_granted`](#chat_access_granted)                         |                `chat_member_ids`, `only_my_chats` |
-| [`chat_access_revoked`](#chat_access_revoked)                         |                `chat_member_ids`, `only_my_chats` |
-| [`user_added_to_chat`](#user_added_to_chat)                           |                `chat_member_ids`, `only_my_chats` |
-| [`user_removed_from_chat`](#user_removed_from_chat)                   |                `chat_member_ids`, `only_my_chats` |
-| [`incoming_event`](#incoming_event)                                   | `chat_member_ids`, `author_type`, `only_my_chats` |
-| [`event_updated`](#event_updated)                                     | `chat_member_ids`, `author_type`, `only_my_chats` |
-| [`incoming_rich_message_postback`](#incoming_rich_message_postback)   |                `chat_member_ids`, `only_my_chats` |
-| [`chat_properties_updated`](#chat_properties_updated)                 |                `chat_member_ids`, `only_my_chats` |
-| [`chat_properties_deleted`](#chat_properties_deleted)                 |                `chat_member_ids`, `only_my_chats` |
-| [`thread_properties_updated`](#thread_properties_updated)             |                `chat_member_ids`, `only_my_chats` |
-| [`thread_properties_deleted`](#thread_properties_deleted)             |                `chat_member_ids`, `only_my_chats` |
-| [`event_properties_updated`](#event_properties_updated)               |                `chat_member_ids`, `only_my_chats` |
-| [`event_properties_deleted`](#event_properties_deleted)               |                `chat_member_ids`, `only_my_chats` |
-| [`thread_tagged`](#thread_tagged)                                     |                `chat_member_ids`, `only_my_chats` |
-| [`thread_untagged`](#thread_untagged)                                 |                `chat_member_ids`, `only_my_chats` |
+| [`incoming_chat`](#incoming_chat)                                     |                  `chat_presence`, `only_my_chats` |
+| [`chat_deactivated`](#chat_deactivated)                               |                  `chat_presence`, `only_my_chats` |
+| [`chat_access_granted`](#chat_access_granted)                         |                  `chat_presence`, `only_my_chats` |
+| [`chat_access_revoked`](#chat_access_revoked)                         |                  `chat_presence`, `only_my_chats` |
+| [`user_added_to_chat`](#user_added_to_chat)                           |                  `chat_presence`, `only_my_chats` |
+| [`user_removed_from_chat`](#user_removed_from_chat)                   |                  `chat_presence`, `only_my_chats` |
+| [`incoming_event`](#incoming_event)                                   |   `chat_presence`, `author_type`, `only_my_chats` |
+| [`event_updated`](#event_updated)                                     |   `chat_presence`, `author_type`, `only_my_chats` |
+| [`incoming_rich_message_postback`](#incoming_rich_message_postback)   |                  `chat_presence`, `only_my_chats` |
+| [`chat_properties_updated`](#chat_properties_updated)                 |                  `chat_presence`, `only_my_chats` |
+| [`chat_properties_deleted`](#chat_properties_deleted)                 |                  `chat_presence`, `only_my_chats` |
+| [`thread_properties_updated`](#thread_properties_updated)             |                  `chat_presence`, `only_my_chats` |
+| [`thread_properties_deleted`](#thread_properties_deleted)             |                  `chat_presence`, `only_my_chats` |
+| [`event_properties_updated`](#event_properties_updated)               |                  `chat_presence`, `only_my_chats` |
+| [`event_properties_deleted`](#event_properties_deleted)               |                  `chat_presence`, `only_my_chats` |
+| [`thread_tagged`](#thread_tagged)                                     |                  `chat_presence`, `only_my_chats` |
+| [`thread_untagged`](#thread_untagged)                                 |                  `chat_presence`, `only_my_chats` |
 | [`routing_status_set`](#routing_status_set)                           |                                                 - |
-| [`agent_deleted`](#agent_deleted)                                     |                    `chat_member_ids`, `agent_ids` |
+| [`agent_deleted`](#agent_deleted)                                     |                      `chat_presence`, `agent_ids` |
 | [`incoming_customer`](#incoming_customer)                             |                                                 - |
-| [`customer_session_fields_updated`](#customer_session_fields_updated) |                                 `chat_member_ids` |
-| [`events_marked_as_seen`](#events_marked_as_seen)                     |                `chat_member_ids`, `only_my_chats` |
+| [`customer_session_fields_updated`](#customer_session_fields_updated) |                                   `chat_presence` |
+| [`events_marked_as_seen`](#events_marked_as_seen)                     |                  `chat_presence`, `only_my_chats` |
 
 </Text>
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -3769,7 +3769,7 @@ __*__ The table below presents the possible values for the `action` parameter.
 | [`thread_tagged`](#thread_tagged)                                     |                  `chat_presence`, `only_my_chats` |
 | [`thread_untagged`](#thread_untagged)                                 |                  `chat_presence`, `only_my_chats` |
 | [`routing_status_set`](#routing_status_set)                           |                                                 - |
-| [`agent_deleted`](#agent_deleted)                                     |                      `chat_presence`, `agent_ids` |
+| [`agent_deleted`](#agent_deleted)                                     |                                       `agent_ids` |
 | [`incoming_customer`](#incoming_customer)                             |                                                 - |
 | [`customer_session_fields_updated`](#customer_session_fields_updated) |                                   `chat_presence` |
 | [`events_marked_as_seen`](#events_marked_as_seen)                     |                  `chat_presence`, `only_my_chats` |

--- a/payloads/management/v3.3/configuration-api/responses/webhooks/listWebhookNames.json
+++ b/payloads/management/v3.3/configuration-api/responses/webhooks/listWebhookNames.json
@@ -8,11 +8,12 @@
     {
         "action": "chat_access_granted",
         "filters": [
-            "chat_member_ids",
+            "chat_presence",
             "only_my_chats"
         ],
         "additional_data": [
-            "chat_properties"
+            "chat_properties",
+            "chat_presence_user_ids"
         ]
     },
     {

--- a/payloads/management/v3.3/configuration-api/responses/webhooks/listWebhooks.json
+++ b/payloads/management/v3.3/configuration-api/responses/webhooks/listWebhooks.json
@@ -5,10 +5,13 @@
     "description": "Test webhook",
     "action": "chat_deactivated",
     "filters": {
-      "chat_member_ids": {
-        "agents_any": [
-          "johndoe@mail.com"
-        ]
+      "chat_presence": {
+        "user_ids": {
+          "values": [
+            "johndoe@mail.com"
+          ]
+        },
+        "my_bots": true
       }
     },
     "owner_client_id": "asXdesldiAJSq9padj",


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-8114-update-wh-filters)
- [Jira](https://livechatinc.atlassian.net/browse/API-8114)

## 📓 Description
Add new webhook filter `chat_presence`. 
Add new webhook additional data `chat_presence_user_ids`.

## ✅ Checklist (for API docs)

- Changelog ✅
- API versions ✅
- Web & RTM ✅
- **Table:** Available methods/webhooks/pushes ✅
- **Table:** Specifics

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)

### Content

- New content
  
### Features (for the website)

- New feature
