### PR TITLE
API-8565: rename reorder_ to update_auto_access

### DIFF
--- a/content/management/changelog/index.mdx
+++ b/content/management/changelog/index.mdx
@@ -27,7 +27,7 @@ Since the migration is still ongoing, different parts will be successively moved
   - [**Add Auto Access**](/management/configuration-api/v3.3/#add-auto-access)
   - [**List Auto Accesses**](/management/configuration-api/v3.3/#list-auto-accesses)
   - [**Delete Auto Access**](/management/configuration-api/v3.3/#delete-auto-access)
-  - [**Reorder Auto Access**](/management/configuration-api/v3.3/#reorder-auto-access)
+  - [**Update Auto Access**](/management/configuration-api/v3.3/#update-auto-access)
 
 ### Bots
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -975,7 +975,7 @@ If `next_id` is an empty string, then auto access will be placed at the end of t
 
 In the following list: **A -> B -> C -> D -> null**, letters represent the `auto_access` data structures while arrows indicate the `next_id` relation. Therefore, A has `next_id` set to B, B has `next_id` set to C, and so on.
 
-An `update_auto_access` call with the `{"id": "C", "next_id": "B"}` payload would result in the **A -> C -> B -> D -> null** sequence, maintaining consistency.
+An `update_auto_access` call with the `{"id": "C", "next_id": "B"}` payload would result in reordering the sequence, which after the successful request, would look like this: **A -> C -> B -> D -> null**. Consistency is maintained by keeping the `next_id` references properly assigned in each of the elements after a single request.
 
 #### Response
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -744,7 +744,7 @@ Creates an `auto access` data structure, which is a set of conditions for the tr
 
 | Parameter      | Required | Data type | Example         |
 | -------------- | -------- | --------- | --------------- |
-| `country`      | No       | `string`  | "United States  |
+| `country`      | No       | `string`  | "United States" |
 | `country_code` | No       | `string`  | "US"            |
 | `region`       | No       | `string`  | "California"    |
 | `city`         | No       | `string`  | "Mountain View" |
@@ -954,16 +954,16 @@ Updates an existing `auto access`.  Only specified fields are updated (overwritt
 
 **2)** `<match_object>` structure:
 
-| Parameter     | Required | Data type | Notes                                                                                                   |
-| ------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------- |
-| `value`       | Yes      | `string`  | A value to match                                                                                        |
-| `exact_match` | No       | `bool`    | If set to `false`, a `match_object.value` will be matched as a substring of the customer URL or domain. |
+| Parameter     | Required | Data type | Notes                                                                                                                   |
+| ------------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `value`       | Yes      | `string`  | A value to match                                                                                                        |
+| `exact_match` | No       | `bool`    | If set to `false`, a `match_object.value` will be matched as a substring of the customer URL or domain; default: false. |
 
 **3)** the `geolocation_object` structure.  The condition is fulfilled only when all of the specified fields match.  At least one field must be specified.
 
 | Parameter      | Required | Data type | Example         |
 | -------------- | -------- | --------- | --------------- |
-| `country`      | No       | `string`  | "United States  |
+| `country`      | No       | `string`  | "United States" |
 | `country_code` | No       | `string`  | "US"            |
 | `region`       | No       | `string`  | "California"    |
 | `city`         | No       | `string`  | "Mountain View" |

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -717,31 +717,30 @@ Creates an `auto access` data structure, which is a set of conditions for the tr
 | Method URL     | `https://api.livechatinc.com/v3.3/configuration/action/add_auto_access`       |
 | Required scopes| `access_rules:rw`                                                             |
 
-
 | Parameter                              | Required     | Data type                    | Notes                                                                                                   |
 | -------------------------------------- | ------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `access`                               | Yes          | `object`                     | Destination access                                                                                      |
 | `access.groups`                        | Yes          | `[]int`                      | Destination groups                                                                                      |
-| `conditions`__*__                     | Yes          | `object`                     | Conditions to check                                                                                     |
+| `conditions`<sup>**1**</sup>                    | Yes          | `object`                     | Conditions to check                                                                                     |
 | `conditions.url`                       | No           | `object`                     | The condition that matches on `customer_page.url` from **Login** or `url` from **Update Customer Page** |
 | `conditions.domain`                    | No           | `object`                     | The condition that matches on the domain of the `customer_url`                                          |
-| `conditions.{url,domain}.values`         | No           | `[]match_object`_**_          | Positive match, may not be used together with `exclude_values`                                          |
+| `conditions.{url,domain}.values`         | No           | `[]match_object`<sup>**2**</sup>          | Positive match, may not be used together with `exclude_values`                                          |
 | `conditions.{url,domain}.exclude_values` | No           | `[]match_object`             | Negative match                                                                                          |
 | `conditions.geolocation`               | No           | `object`                     | The condition that matches on the customer's geolocation                                                |
-| `conditions.geolocation.values`        | Yes          | `[]geolocation_object`__***__ | An array of objects; matches when at least one subcondition matches.                                    |
+| `conditions.geolocation.values`        | Yes          | `[]geolocation_object`<sup>**3**</sup> | An array of objects; matches when at least one subcondition matches.                                    |
 | `description`                          | No           | `string`                     | Description of the auto access                                                                          |
 | `next_id`                              | No           | `string`                     | ID of an existing auto access. Leave empty if the new auto access should be the last one on the list.   |
 
-_*_ `conditions` must have at least one of `url`, `domain`, `geolocation` set.
+**1)** `conditions` must have at least one of `url`, `domain`, `geolocation` set.
 
-__**__ `<match_object>` structure:
+**2)** `<match_object>` structure:
 
 | Parameter     | Required | Data type | Notes                                                                                                   |
 | ------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------- |
 | `value`       | Yes      | `string`  | A value to match                                                                                        |
 | `exact_match` | No       | `bool`    | If set to `false`, a `match_object.value` will be matched as a substring of the customer URL or domain. |
 
-__***__ the `geolocation_object` structure.  The condition is fulfilled only when all of the specified fields match.  At least one field must be specified.
+**3)** the `geolocation_object` structure.  The condition is fulfilled only when all of the specified fields match.  At least one field must be specified.
 
 | Parameter      | Required | Data type | Example         |
 | -------------- | -------- | --------- | --------------- |
@@ -749,7 +748,6 @@ __***__ the `geolocation_object` structure.  The condition is fulfilled only whe
 | `country_code` | No       | `string`  | "US"            |
 | `region`       | No       | `string`  | "California"    |
 | `city`         | No       | `string`  | "Mountain View" |
-
 
 </Text>
 
@@ -892,7 +890,6 @@ Deletes an existing `auto access` data structure specified by its ID.
 | Method URL     | `https://api.livechatinc.com/v3.3/configuration/action/delete_auto_access`       |
 | Required scopes| `access_rules:rw`                                                                |
 
-
 | Parameter              | Required     | Data type | Notes                         |
 | ---------------------- | ------------ | --------- | ----------------------------- |
 | `id`                   | Yes          | `string`  | Auto access ID                |
@@ -938,32 +935,31 @@ Updates an existing `auto access`.  Only specified fields are updated (overwritt
 | Method URL     | `https://api.livechatinc.com/v3.3/configuration/action/update_auto_access`      |
 | Required scopes| `access_rules:rw`                                                                |
 
-
 | Parameter                             | Required     | Data type                     | Notes                                                                                                                                    |
 | ------------------------------------- | ------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `id`                                  | Yes          | `string`                      | ID of the auto access to modify                                                                                                            |
 | `access`                              | No           | `object`                      | Destination access                                                                                      |
 | `access.groups`                       | Yes          | `[]int`                       | Destination groups                                                                                      |
-| `conditions`__*__                     | No          | `object`                       | Conditions to check                                                                                     |
+| `conditions`<sup>**1**</sup>                     | No          | `object`                       | Conditions to check                                                                                     |
 | `conditions.url`                      | No           | `object`                      | The condition that matches on `customer_page.url` from **Login** or `url` from **Update Customer Page** |
 | `conditions.domain`                   | No           | `object`                      | The condition that matches on the domain of the `customer_url`                                          |
-| `conditions.{url,domain}.values`         | No        | `[]match_object`_**_          | Positive match, may not be used together with `exclude_values`                                          |
+| `conditions.{url,domain}.values`         | No        | `[]match_object`<sup>**2**</sup>          | Positive match, may not be used together with `exclude_values`                                          |
 | `conditions.{url,domain}.exclude_values` | No        | `[]match_object`              | Negative match                                                                                          |
 | `conditions.geolocation`               | No          | `object`                      | The condition that matches on the customer's geolocation                                                |
-| `conditions.geolocation.values`        | Yes         | `[]geolocation_object`__***__ | An array of objects; matches when at least one subcondition matches.                                    |
+| `conditions.geolocation.values`        | Yes         | `[]geolocation_object`<sup>**3**</sup> | An array of objects; matches when at least one subcondition matches.                                    |
 | `description`                          | No          | `string`                      | Description of the auto access                                                                          |
-| `next_id`__****__                      | No          | `string`                      | ID of an existing auto access. Empty string moves the auto access to the end of the list. |
+| `next_id`<sup>**4**</sup>                      | No          | `string`                      | ID of an existing auto access. If `next_id` is an empty string, auto_access moves to the end of the list. |
 
-_*_ `conditions` must have at least one of `url`, `domain`, `geolocation` set.
+**1)** `conditions` must have at least one of `url`, `domain`, `geolocation` set.
 
-__**__ `<match_object>` structure:
+**2)** `<match_object>` structure:
 
 | Parameter     | Required | Data type | Notes                                                                                                   |
 | ------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------- |
 | `value`       | Yes      | `string`  | A value to match                                                                                        |
 | `exact_match` | No       | `bool`    | If set to `false`, a `match_object.value` will be matched as a substring of the customer URL or domain. |
 
-__***__ the `geolocation_object` structure.  The condition is fulfilled only when all of the specified fields match.  At least one field must be specified.
+**3)** the `geolocation_object` structure.  The condition is fulfilled only when all of the specified fields match.  At least one field must be specified.
 
 | Parameter      | Required | Data type | Example         |
 | -------------- | -------- | --------- | --------------- |
@@ -972,13 +968,14 @@ __***__ the `geolocation_object` structure.  The condition is fulfilled only whe
 | `region`       | No       | `string`  | "California"    |
 | `city`         | No       | `string`  | "Mountain View" |
 
+**4)** Modifying `next_id` moves the auto access specified by `id` before the auto access that is specified by `next_id`.
+If `next_id` is an empty string, then auto access will be placed at the end of the list. If you don't intend to reorder the rule at all, don't include `next_id` in the request. To better understand it, analyze the example below.
 
-__****__ Modifying `next_id` reorders `auto access` specified by `id`, before another one, specified by `next_id`.
-If `next_id` is empty string, then the auto access will be placed at the end of the list. If the rule is not supposed to be moved at all, do not set the field in request.
+💡 **Example:**
 
-An example of move, arrow indicates `next_id` relation, so A will have `next_id` set to B:
+In the following list: **A -> B -> C -> D -> null**, letters represent the `auto_access` data structures while arrows indicate the `next_id` relation. Therefore, A has `next_id` set to B, B has `next_id` set to C, and so on.
 
-Given list A -> B -> C -> D -> null, `update_auto_access` with payload `{"id": "C", "next_id": "B"}` will result in a A -> C -> B -> D -> null sequence, maintaining consistency.
+An `update_auto_access` call with the `{"id": "C", "next_id": "B"}` payload would result in the **A -> C -> B -> D -> null** sequence, maintaining consistency.
 
 #### Response
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -197,10 +197,10 @@ It returns the info about an Agent specified by `id`.
 
 #### Request
 
-| Parameter | Type       | Required | Notes                         |
-| -------------- | ---------- | -------- | ----------------------------- |
-| `id`           | `string`   | Yes      | Agent ID                      |
-| `fields`__*__  | `string[]` | No       | Additional fields to include. |
+| Parameter     | Type       | Required | Notes                         |
+| ------------- | ---------- | -------- | ----------------------------- |
+| `id`          | `string`   | Yes      | Agent ID                      |
+| `fields`__*__ | `string[]` | No       | Additional fields to include. |
 
 __*__ Possible values for the `fields[]` parameter:
 
@@ -712,24 +712,24 @@ Creates an `auto access` data structure, which is a set of conditions for the tr
 
 #### Specifics
 
-|                |                                                                               |
-| -------------- | ----------------------------------------------------------------------------- |
-| Method URL     | `https://api.livechatinc.com/v3.3/configuration/action/add_auto_access`       |
-| Required scopes| `access_rules:rw`                                                             |
+|                 |                                                                         |
+| --------------- | ----------------------------------------------------------------------- |
+| Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/add_auto_access` |
+| Required scopes | `access_rules:rw`                                                       |
 
-| Parameter                              | Required     | Data type                    | Notes                                                                                                   |
-| -------------------------------------- | ------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `access`                               | Yes          | `object`                     | Destination access                                                                                      |
-| `access.groups`                        | Yes          | `[]int`                      | Destination groups                                                                                      |
-| `conditions`<sup>**1**</sup>                    | Yes          | `object`                     | Conditions to check                                                                                     |
-| `conditions.url`                       | No           | `object`                     | The condition that matches on `customer_page.url` from **Login** or `url` from **Update Customer Page** |
-| `conditions.domain`                    | No           | `object`                     | The condition that matches on the domain of the `customer_url`                                          |
-| `conditions.{url,domain}.values`         | No           | `[]match_object`<sup>**2**</sup>          | Positive match, may not be used together with `exclude_values`                                          |
-| `conditions.{url,domain}.exclude_values` | No           | `[]match_object`             | Negative match                                                                                          |
-| `conditions.geolocation`               | No           | `object`                     | The condition that matches on the customer's geolocation                                                |
-| `conditions.geolocation.values`        | Yes          | `[]geolocation_object`<sup>**3**</sup> | An array of objects; matches when at least one subcondition matches.                                    |
-| `description`                          | No           | `string`                     | Description of the auto access                                                                          |
-| `next_id`                              | No           | `string`                     | ID of an existing auto access. Leave empty if the new auto access should be the last one on the list.   |
+| Parameter                                | Required | Data type                              | Notes                                                                                                   |
+| ---------------------------------------- | -------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `access`                                 | Yes      | `object`                               | Destination access                                                                                      |
+| `access.groups`                          | Yes      | `[]int`                                | Destination groups                                                                                      |
+| `conditions`<sup>**1**</sup>             | Yes      | `object`                               | Conditions to check                                                                                     |
+| `conditions.url`                         | No       | `object`                               | The condition that matches on `customer_page.url` from **Login** or `url` from **Update Customer Page** |
+| `conditions.domain`                      | No       | `object`                               | The condition that matches on the domain of the `customer_url`                                          |
+| `conditions.{url,domain}.values`         | No       | `[]match_object`<sup>**2**</sup>       | Positive match, may not be used together with `exclude_values`                                          |
+| `conditions.{url,domain}.exclude_values` | No       | `[]match_object`                       | Negative match                                                                                          |
+| `conditions.geolocation`                 | No       | `object`                               | The condition that matches on the customer's geolocation                                                |
+| `conditions.geolocation.values`          | Yes      | `[]geolocation_object`<sup>**3**</sup> | An array of objects; matches when at least one subcondition matches.                                    |
+| `description`                            | No       | `string`                               | Description of the auto access                                                                          |
+| `next_id`                                | No       | `string`                               | ID of an existing auto access. Leave empty if the new auto access should be the last one on the list.   |
 
 **1)** `conditions` must have at least one of `url`, `domain`, `geolocation` set.
 
@@ -813,10 +813,10 @@ Returns all existing `auto access` data structures.
 
 #### Specifics
 
-|                |                                                                                      |
-| -------------- | ------------------------------------------------------------------------------------ |
-| Method URL     | `https://api.livechatinc.com/v3.3/configuration/action/list_auto_accesses`           |
-| Required scopes| `access_rules:ro`                                                                    |
+|                 |                                                                            |
+| --------------- | -------------------------------------------------------------------------- |
+| Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/list_auto_accesses` |
+| Required scopes | `access_rules:ro`                                                          |
 
 </Text>
 
@@ -885,14 +885,14 @@ Deletes an existing `auto access` data structure specified by its ID.
 
 #### Specifics
 
-|                |                                                                                  |
-| -------------- | -------------------------------------------------------------------------------- |
-| Method URL     | `https://api.livechatinc.com/v3.3/configuration/action/delete_auto_access`       |
-| Required scopes| `access_rules:rw`                                                                |
+|                 |                                                                            |
+| --------------- | -------------------------------------------------------------------------- |
+| Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/delete_auto_access` |
+| Required scopes | `access_rules:rw`                                                          |
 
-| Parameter              | Required     | Data type | Notes                         |
-| ---------------------- | ------------ | --------- | ----------------------------- |
-| `id`                   | Yes          | `string`  | Auto access ID                |
+| Parameter | Required | Data type | Notes          |
+| --------- | -------- | --------- | -------------- |
+| `id`      | Yes      | `string`  | Auto access ID |
 
 #### Response
 
@@ -930,25 +930,25 @@ Updates an existing `auto access`.  Only specified fields are updated (overwritt
 
 #### Specifics
 
-|                |                                                                                  |
-| -------------- | -------------------------------------------------------------------------------- |
-| Method URL     | `https://api.livechatinc.com/v3.3/configuration/action/update_auto_access`      |
-| Required scopes| `access_rules:rw`                                                                |
+|                 |                                                                            |
+| --------------- | -------------------------------------------------------------------------- |
+| Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/update_auto_access` |
+| Required scopes | `access_rules:rw`                                                          |
 
-| Parameter                             | Required     | Data type                     | Notes                                                                                                                                    |
-| ------------------------------------- | ------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`                                  | Yes          | `string`                      | ID of the auto access to modify                                                                                                            |
-| `access`                              | No           | `object`                      | Destination access                                                                                      |
-| `access.groups`                       | Yes          | `[]int`                       | Destination groups                                                                                      |
-| `conditions`<sup>**1**</sup>                     | No          | `object`                       | Conditions to check                                                                                     |
-| `conditions.url`                      | No           | `object`                      | The condition that matches on `customer_page.url` from **Login** or `url` from **Update Customer Page** |
-| `conditions.domain`                   | No           | `object`                      | The condition that matches on the domain of the `customer_url`                                          |
-| `conditions.{url,domain}.values`         | No        | `[]match_object`<sup>**2**</sup>          | Positive match, may not be used together with `exclude_values`                                          |
-| `conditions.{url,domain}.exclude_values` | No        | `[]match_object`              | Negative match                                                                                          |
-| `conditions.geolocation`               | No          | `object`                      | The condition that matches on the customer's geolocation                                                |
-| `conditions.geolocation.values`        | Yes         | `[]geolocation_object`<sup>**3**</sup> | An array of objects; matches when at least one subcondition matches.                                    |
-| `description`                          | No          | `string`                      | Description of the auto access                                                                          |
-| `next_id`<sup>**4**</sup>                      | No          | `string`                      | ID of an existing auto access. If `next_id` is an empty string, auto_access moves to the end of the list. |
+| Parameter                                | Required | Data type                              | Notes                                                                                                     |
+| ---------------------------------------- | -------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `id`                                     | Yes      | `string`                               | ID of the auto access to modify                                                                           |
+| `access`                                 | No       | `object`                               | Destination access                                                                                        |
+| `access.groups`                          | Yes      | `[]int`                                | Destination groups                                                                                        |
+| `conditions`<sup>**1**</sup>             | No       | `object`                               | Conditions to check                                                                                       |
+| `conditions.url`                         | No       | `object`                               | The condition that matches on `customer_page.url` from **Login** or `url` from **Update Customer Page**   |
+| `conditions.domain`                      | No       | `object`                               | The condition that matches on the domain of the `customer_url`                                            |
+| `conditions.{url,domain}.values`         | No       | `[]match_object`<sup>**2**</sup>       | Positive match, may not be used together with `exclude_values`                                            |
+| `conditions.{url,domain}.exclude_values` | No       | `[]match_object`                       | Negative match                                                                                            |
+| `conditions.geolocation`                 | No       | `object`                               | The condition that matches on the customer's geolocation                                                  |
+| `conditions.geolocation.values`          | Yes      | `[]geolocation_object`<sup>**3**</sup> | An array of objects; matches when at least one subcondition matches.                                      |
+| `description`                            | No       | `string`                               | Description of the auto access                                                                            |
+| `next_id`<sup>**4**</sup>                | No       | `string`                               | ID of an existing auto access. If `next_id` is an empty string, auto_access moves to the end of the list. |
 
 **1)** `conditions` must have at least one of `url`, `domain`, `geolocation` set.
 
@@ -1041,19 +1041,19 @@ Creates a new Bot.
 
 #### Request
 
-| Parameter                              | Required | Data type  | Notes                                                                                                                                  |
-| -------------------------------------- | -------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                                 | Yes      | `string`   | Display name                                                                                                                           |
-| `avatar`                               | No       | `string`   | Avatar URL                                                                                                                             |
-| `max_chats_count`                      | No       | `int`      | Max. number of incoming chats that can be routed to the Bot; default: 6.                                                               |
-| `default_group_priority` __****__      | No       | `string`   | The default routing priority for a group without defined priority.                                                                     |
-| `groups`                               | No       | `object[]` | Groups the Bot belongs to.                                                                                                             |
-| `groups[].id`                          | No       | `int`      | Group ID; required only when `group`'s included.                                                                                       |
-| `groups[].priority` __*__              | Yes      | `string`   | Bot's priority in a group; required only when `group`'s included.                                                                      |
-| `work_scheduler`                       | No       | `object`   | Work scheduler options to set for the new Bot.                                                                                         |
-| `work_scheduler.**.<work_scheduler>`   | No       | `object`   | `<work_scheduler>` values __***__.                                                                                                     |
-| `timezone`                             | Yes      | `string`   | The time zone in which the Bot's work scheduler should operate. Required only if `work_scheduler` is provided.                                       |
-| `owner_client_id` __*****__            | Yes      | `string`   | Required when authorizing via [PATs](/authorization/authorizing-api-calls/#personal-access-tokens); ignored otherwise. |
+| Parameter                            | Required | Data type  | Notes                                                                                                                  |
+| ------------------------------------ | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `name`                               | Yes      | `string`   | Display name                                                                                                           |
+| `avatar`                             | No       | `string`   | Avatar URL                                                                                                             |
+| `max_chats_count`                    | No       | `int`      | Max. number of incoming chats that can be routed to the Bot; default: 6.                                               |
+| `default_group_priority` __****__    | No       | `string`   | The default routing priority for a group without defined priority.                                                     |
+| `groups`                             | No       | `object[]` | Groups the Bot belongs to.                                                                                             |
+| `groups[].id`                        | No       | `int`      | Group ID; required only when `group`'s included.                                                                       |
+| `groups[].priority` __*__            | Yes      | `string`   | Bot's priority in a group; required only when `group`'s included.                                                      |
+| `work_scheduler`                     | No       | `object`   | Work scheduler options to set for the new Bot.                                                                         |
+| `work_scheduler.**.<work_scheduler>` | No       | `object`   | `<work_scheduler>` values __***__.                                                                                     |
+| `timezone`                           | Yes      | `string`   | The time zone in which the Bot's work scheduler should operate. Required only if `work_scheduler` is provided.         |
+| `owner_client_id` __*****__          | Yes      | `string`   | Required when authorizing via [PATs](/authorization/authorizing-api-calls/#personal-access-tokens); ignored otherwise. |
 
 __*__ Possible values for the `groups[].priority` parameter:
 
@@ -1080,11 +1080,11 @@ __***__ `<work_scheduler>` contains the following fields:
 
 __****__ The table below presents the possible values for the `default_group_priority` parameter:
 
-| Possible values |  Notes        |
-| --------------- |:-------------:|
-| `first`         | The highest chat routing priority. Agents with the `first` priority get chats before others from the same group, e.g. Bots can get chats before regular Agents.  |
+| Possible values |                                                                                                      Notes                                                                                                      |
+| --------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| `first`         |                         The highest chat routing priority. Agents with the `first` priority get chats before others from the same group, e.g. Bots can get chats before regular Agents.                         |
 | `normal`        | The medium chat routing priority. Agents with the `normal` priority get chats before those with the `last` priority, when there are no Agents with the `first` priority available with free slots in the group. |
-| `last`          | The lowest chat routing priority. Agents with the `last` priority get chats when there are no Agents with the `first` or `normal` priority available with free slots in the group.   |
+| `last`          |               The lowest chat routing priority. Agents with the `last` priority get chats when there are no Agents with the `first` or `normal` priority available with free slots in the group.                |
 
 __\*\*\*\*\*__ The number of sent webhooks depends on the number of webhooks registered for an `owner_client_id`, not the number of bots belonging to that `owner_client_id`.
 
@@ -1174,19 +1174,19 @@ Updates an existing Bot.
 
 #### Request
 
-| Parameter                            | Required | Data type | Notes                                                                                                     |
-| ------------------------------------ | -------- | --------- | --------------------------------------------------------------------------------------------------------- |
-| `id`                                 | Yes      | `string`  | Bot ID                                                                                                    |
-| `name`                               | No       | `string`  | Display name                                                                                              |
-| `avatar`                             | No       | `string`  | Avatar URL                                                                                                |
-| `max_chats_count`                    | No       | `int`     | Maximum incoming chats that can be routed to the Bot.                                                     |
-| `groups`                             | No       | `object[]`| Groups the Bot belongs to                                                                                 |
-| `groups[].id`                        | Yes      | `uint`    | Group ID, required only when `groups`'s present.                                                          |
-| `groups[].priority` __*__            | Yes      | `string`  | Bot's priority in the group; required only when `groups` is included.                                     |
-| `default_group_priority` __**__      | No       | `string`  | The default routing priority for a group without defined priority.                                        |
-| `work_scheduler`                     | No       | `object`  | Work scheduler options to set for the new Bot.                                                            |
-| `work_scheduler.***.<work_scheduler>`| No       | `object`  | `<work_scheduler>` values __****__.                                                                       |
-| `timezone`                           | No       | `string`  | The time zone in which the Bot's work scheduler should operate. Required if `work_scheduler` is provided. |
+| Parameter                             | Required | Data type  | Notes                                                                                                     |
+| ------------------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------- |
+| `id`                                  | Yes      | `string`   | Bot ID                                                                                                    |
+| `name`                                | No       | `string`   | Display name                                                                                              |
+| `avatar`                              | No       | `string`   | Avatar URL                                                                                                |
+| `max_chats_count`                     | No       | `int`      | Maximum incoming chats that can be routed to the Bot.                                                     |
+| `groups`                              | No       | `object[]` | Groups the Bot belongs to                                                                                 |
+| `groups[].id`                         | Yes      | `uint`     | Group ID, required only when `groups`'s present.                                                          |
+| `groups[].priority` __*__             | Yes      | `string`   | Bot's priority in the group; required only when `groups` is included.                                     |
+| `default_group_priority` __**__       | No       | `string`   | The default routing priority for a group without defined priority.                                        |
+| `work_scheduler`                      | No       | `object`   | Work scheduler options to set for the new Bot.                                                            |
+| `work_scheduler.***.<work_scheduler>` | No       | `object`   | `<work_scheduler>` values __****__.                                                                       |
+| `timezone`                            | No       | `string`   | The time zone in which the Bot's work scheduler should operate. Required if `work_scheduler` is provided. |
 
 __*__ The table below presents the possible values for the `groups[].priority` parameter:
 
@@ -1264,10 +1264,10 @@ Returns the list of Bots created within a license. The method behavior differs d
 
 #### Request
 
-| Parameter      | Required | Type       | Notes                                                                         |
-| -------------- | -------- | ---------- | ----------------------------------------------------------------------------- |
+| Parameter      | Required | Type       | Notes                                                                                                      |
+| -------------- | -------- | ---------- | ---------------------------------------------------------------------------------------------------------- |
 | `all`          | No       | `bool`     | `true` - gets all Bots within a license. &nbsp;`false` (default)__*__ - returns only the requester's Bots. |
-| `fields`__**__  | No       | `string[]` | Additional Bot fields to include                                            |
+| `fields`__**__ | No       | `string[]` | Additional Bot fields to include                                                                           |
 
 __*__ **Calling List Bots with `all:false`**
 
@@ -1277,7 +1277,7 @@ __*__ **Calling List Bots with `all:false`**
 __**__ Possible values for the `fields[]` parameter:
 
 | Possible value    | Notes                                                    |
-|-------------------|----------------------------------------------------------|
+| ----------------- | -------------------------------------------------------- |
 | `groups`          | Groups a Bot belongs to                                  |
 | `work_scheduler`  | Work scheduler object for a Bot                          |
 | `job_title`       | Bot's job title                                          |
@@ -1323,15 +1323,15 @@ curl -X POST \
 
 #### Request
 
-| Parameter      | Required   | Type     | Notes                         |
-| -------------- | ---------- | -------- | ----------------------------- |
-| `id`           | Yes        | `string` | Bot ID                        |
-| `fields`__*__  | `string[]` | No       | Additional fields to include. |
+| Parameter     | Required   | Type     | Notes                         |
+| ------------- | ---------- | -------- | ----------------------------- |
+| `id`          | Yes        | `string` | Bot ID                        |
+| `fields`__*__ | `string[]` | No       | Additional fields to include. |
 
 __*__ Possible values for the `fields[]` parameter:
 
 | Possible value    | Notes                                                    |
-|-------------------|----------------------------------------------------------|
+| ----------------- | -------------------------------------------------------- |
 | `work_scheduler`  | Work scheduler object for a Bot                          |
 | `groups`          | Groups a Bot belongs to                                  |
 | `job_title`       | Bot's job title                                          |
@@ -1393,7 +1393,7 @@ Creates a new group.
 
 #### Request
 
-| Parameter          | Data type | Required | Notes                                                                                                                            |
+| Parameter               | Data type | Required | Notes                                                                                                                            |
 | ----------------------- | --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `name`                  | `string`  | Yes      | Group name (up to 180 chars)                                                                                                     |
 | `language_code`         | `string`  | No       | The code of the group languange                                                                                                  |
@@ -1453,7 +1453,7 @@ Updates an existing group.
 
 #### Request
 
-| Parameter          | Data type | Required | Notes                                                                        |
+| Parameter               | Data type | Required | Notes                                                                        |
 | ----------------------- | --------- | -------- | ---------------------------------------------------------------------------- |
 | `id`                    | `int`     | Yes      | Group ID                                                                     |
 | `name`                  | `string`  | No       | Group name (up to 180 chars)                                                 |
@@ -1518,8 +1518,8 @@ Deletes an existing group.
 #### Request
 
 | Parameter | Data type | Required | Notes    |
-| -------------- | --------- | -------- | -------- |
-| `id`           | `int`     | Yes      | Group ID |
+| --------- | --------- | -------- | -------- |
+| `id`      | `int`     | Yes      | Group ID |
 
 #### Response
 
@@ -1564,9 +1564,9 @@ Lists all the exisiting groups.
 
 #### Request
 
-| Parameter | Data type  | Required | Notes                         |
-| -------------- | ---------- | -------- | ----------------------------- |
-| `fields`__*__  | `string[]` | No       | Additional fields to include. |
+| Parameter     | Data type  | Required | Notes                         |
+| ------------- | ---------- | -------- | ----------------------------- |
+| `fields`__*__ | `string[]` | No       | Additional fields to include. |
 
 __*__ Possible values for the `fields[]` parameter:
 
@@ -1614,10 +1614,10 @@ Returns details about a group specified by its `id`.
 
 #### Request
 
-| Parameter | Data type  | Required | Notes                         |
-| -------------- | ---------- | -------- | ----------------------------- |
-| `id`           | `int`      | Yes      | Group ID                      |
-| `fields`__*__  | `string[]` | No       | Additional fields to include. |
+| Parameter     | Data type  | Required | Notes                         |
+| ------------- | ---------- | -------- | ----------------------------- |
+| `id`          | `int`      | Yes      | Group ID                      |
+| `fields`__*__ | `string[]` | No       | Additional fields to include. |
 
 __*__ Possible values for the `fields[]` parameter:
 
@@ -1814,20 +1814,20 @@ Registers a new private property for a given **Client Id**.
 
 #### Request
 
-| Parameter                  | Required            | Data type  | Notes                                                                                 |
-| -------------------------- | ------------------- | ---------- | ------------------------------------------------------------------------------------- |
-| `name`                     | Yes                 | `string`   | Property name                                                                         |
-| `owner_client_id`          | Yes                 | `string`   | **Client Id** that will own the property; must be owned by your organization.         |
-| `type`                     | Yes                 | `string`   | Possible values: `int`, `string`, `bool`, and `tokenized_string`                      |
-| `access`                   | Yes                 | `object`   |                                                                                       |
-| `access.<location>`        | min. one `location` | `object`   | Possible values: `chat`, `thread`, `event`, `license`, `group`                        |
-| `access.<location>.<user>` | min. one `user`     | `[string]` | Possible `<user>` values: `agent`, `customer`; possible values: `read`, `write`       |
-| `description`              | No                  | `string`   | Property description                                                                  |
-| `domain` __*__             | No                  | `[<type>]` | Array of values that properties can be set to                                         |
-| `range` __*__              | No                  | `object`   | Range of values that properties can be set to                                         |
-| `range.from`               | No                  | `int`      | Only values **equal** or **greater** than this parameter can be set to this property  |
-| `range.to`                 | No                  | `int`      | Only values **equal** or **lower** than this parameter can be set to this property    |
-| `default_value` __**__     | No                  | `type`     | Default value of property; validated by **domain** or **range**, if one exists        |
+| Parameter                  | Required            | Data type  | Notes                                                                                |
+| -------------------------- | ------------------- | ---------- | ------------------------------------------------------------------------------------ |
+| `name`                     | Yes                 | `string`   | Property name                                                                        |
+| `owner_client_id`          | Yes                 | `string`   | **Client Id** that will own the property; must be owned by your organization.        |
+| `type`                     | Yes                 | `string`   | Possible values: `int`, `string`, `bool`, and `tokenized_string`                     |
+| `access`                   | Yes                 | `object`   |                                                                                      |
+| `access.<location>`        | min. one `location` | `object`   | Possible values: `chat`, `thread`, `event`, `license`, `group`                       |
+| `access.<location>.<user>` | min. one `user`     | `[string]` | Possible `<user>` values: `agent`, `customer`; possible values: `read`, `write`      |
+| `description`              | No                  | `string`   | Property description                                                                 |
+| `domain` __*__             | No                  | `[<type>]` | Array of values that properties can be set to                                        |
+| `range` __*__              | No                  | `object`   | Range of values that properties can be set to                                        |
+| `range.from`               | No                  | `int`      | Only values **equal** or **greater** than this parameter can be set to this property |
+| `range.to`                 | No                  | `int`      | Only values **equal** or **lower** than this parameter can be set to this property   |
+| `default_value` __**__     | No                  | `type`     | Default value of property; validated by **domain** or **range**, if one exists       |
 
 __*)__ Only one `domain` and one `range` can be set for a single property.
 __**)__ Registering a property with `default_value` is possible only if `access.<location>` is set to `license` or to `group`.
@@ -1888,10 +1888,10 @@ Unregisters a private property.
 
 #### Request
 
-| Parameter         | Required | Data type  | Notes                                                                     |
-| ----------------- | -------- | ---------- | ------------------------------------------------------------------------- |
-| `name`            | Yes      | `string`   | Property name                                                             |
-| `owner_client_id` | Yes      | `string`   | **Client Id** that owns the property; must be owned by your organization |
+| Parameter         | Required | Data type | Notes                                                                    |
+| ----------------- | -------- | --------- | ------------------------------------------------------------------------ |
+| `name`            | Yes      | `string`  | Property name                                                            |
+| `owner_client_id` | Yes      | `string`  | **Client Id** that owns the property; must be owned by your organization |
 
 #### Response
 
@@ -1937,11 +1937,11 @@ Publishes a private property. A published property cannot be unpublished or unre
 
 #### Request
 
-| Parameter         | Required            | Data type  | Notes                                                                                                        |
-| ------------------| ------------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
-| `name`            | Yes                 | `string`   | Property name                                                                                                |
-| `owner_client_id` | Yes                 | `string`   | **Client Id** that owns the property; must be owned by your organization.                                    |
-| `access_type`     | Yes                 | `[string]` | Possible values: `read`, `write`. It determines the access level for the **Client Ids** different than `owner_client_id`. |
+| Parameter         | Required | Data type  | Notes                                                                                                                     |
+| ----------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `name`            | Yes      | `string`   | Property name                                                                                                             |
+| `owner_client_id` | Yes      | `string`   | **Client Id** that owns the property; must be owned by your organization.                                                 |
+| `access_type`     | Yes      | `[string]` | Possible values: `read`, `write`. It determines the access level for the **Client Ids** different than `owner_client_id`. |
 
 #### Response
 
@@ -1988,9 +1988,9 @@ Lists private and public properties owned by a given **Client Id**.
 
 #### Request
 
-| Parameter         | Required            | Data type  | Notes                                                                       |
-| ------------------| ------------------- | ---------- | --------------------------------------------------------------------------- |
-| `owner_client_id` | Yes                 | `string`   | **Client Id** that owns the properties; must be owned by your organization. |
+| Parameter         | Required | Data type | Notes                                                                       |
+| ----------------- | -------- | --------- | --------------------------------------------------------------------------- |
+| `owner_client_id` | Yes      | `string`  | **Client Id** that owns the properties; must be owned by your organization. |
 
 </Text>
 
@@ -2099,10 +2099,10 @@ Otherwise, the permission depends on how the property was configured during [reg
 
 #### Request
 
-| Parameter          | Required | Data type | Notes                       |
-| ------------------ | -------- | --------- | --------------------------- |
-| `namespace`        | No       | `string`  | Properties namespace        |
-| `name_prefix`      | No       | `string`  | Properties name prefix      |
+| Parameter     | Required | Data type | Notes                  |
+| ------------- | -------- | --------- | ---------------------- |
+| `namespace`   | No       | `string`  | Properties namespace   |
+| `name_prefix` | No       | `string`  | Properties name prefix |
 
 </Text>
 
@@ -2427,7 +2427,7 @@ Informs about a chat coming with a new thread. The webhook payload contains the 
 
 #### Webhook payload
 
-| Field | Notes                                                   |
+| Field  | Notes                                                   |
 | ------ | ------------------------------------------------------- |
 | `chat` | [Chat data structure](/messaging/agent-chat-api/#chats) |
 
@@ -2488,7 +2488,7 @@ Informs that a chat was deactivated by closing the currently open thread.
 
 #### Webhook payload
 
-| Field    | Notes                                         |
+| Field     | Notes                                         |
 | --------- | --------------------------------------------- |
 | `user_id` | Missing if a thread was closed by the router. |
 
@@ -2543,8 +2543,8 @@ Informs that new, single access to a chat was granted. The existing access isn't
 #### Webhook payload
 
 | Field | Notes   |
-| ------ | ------- |
-| `id`   | Chat id |
+| ----- | ------- |
+| `id`  | Chat id |
 
 </Text>
 
@@ -2596,8 +2596,8 @@ Informs that access to a certain chat was revoked.
 #### Webhook payload
 
 | Field | Notes   |
-| ------ | ------- |
-| `id`   | Chat Id |
+| ----- | ------- |
+| `id`  | Chat Id |
 
 </Text>
 
@@ -2648,7 +2648,7 @@ Informs that a chat was transferred to a different group or to an agent.
 
 #### Webhook payload
 
-| Field           | Notes                                                                    |
+| Field            | Notes                                                                    |
 | ---------------- | ------------------------------------------------------------------------ |
 | `thread_id`      | Present if the chat is active.                                           |
 | `transferred_to` | IDs of the groups and agents the chat is assigned to after the transfer. |
@@ -2713,7 +2713,7 @@ Informs that a user (Customer or Agent) was added to a chat.
 
 #### Webhook payload
 
-| Field      | Notes                                |
+| Field       | Notes                                |
 | ----------- | ------------------------------------ |
 | `user_type` | Possible values: `agent`, `customer` |
 
@@ -2769,7 +2769,7 @@ Informs that a user (Customer or Agent) was removed from a chat.
 
 #### Webhook payload
 
-| Field      | Notes                                |
+| Field       | Notes                                |
 | ----------- | ------------------------------------ |
 | `user_type` | Possible values: `agent`, `customer` |
 
@@ -2974,7 +2974,7 @@ Informs about those chat properties that were updated.
 
 #### Webhook payload
 
-| Field       | Notes                                                                                                |
+| Field        | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3029,7 +3029,7 @@ Informs about those chat properties that were deleted.
 
 #### Webhook payload
 
-| Field       | Notes                                                                                                |
+| Field        | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3084,7 +3084,7 @@ Informs about those thread properties that were updated.
 
 #### Webhook payload
 
-| Field       | Notes                                                                                                |
+| Field        | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3140,7 +3140,7 @@ Informs about those thread properties that were deleted.
 
 #### Webhook payload
 
-| Field       | Notes                                                                                                |
+| Field        | Notes                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------- |
 | `properties` | Not a full `properties` object. This push shows only the properties that have been recently updated. |
 
@@ -3196,7 +3196,7 @@ Informs about those event properties that were updated.
 
 #### Webhook payload
 
-| Field       | Notes                                                                                                           |
+| Field        | Notes                                                                                                           |
 | ------------ | --------------------------------------------------------------------------------------------------------------- |
 | `properties` | This is not a full `properties` object. This webhook shows only the properties that have been recently updated. |
 
@@ -3253,7 +3253,7 @@ Informs about those event properties that were deleted.
 
 #### Webhook payload
 
-| Field       | Notes                                                                                                           |
+| Field        | Notes                                                                                                           |
 | ------------ | --------------------------------------------------------------------------------------------------------------- |
 | `properties` | This is not a full `properties` object. This webhook shows only the properties that have been recently updated. |
 
@@ -3406,7 +3406,7 @@ Informs that an Agent's or Bot's status has changed.
 
 #### Webhook payload
 
-| Field   | Notes                                                                                |
+| Field    | Notes                                                                                |
 | -------- | ------------------------------------------------------------------------------------ |
 | `status` | Possible values: `accepting chats`, `not accepting chats`, `offline` (for Bots only) |
 
@@ -3542,9 +3542,9 @@ Informs that a chatting Customer's session fields were updated. The webhook will
 
 #### Specifics
 
-|                        |                                                                                     |
-| ---------------------- | ----------------------------------------------------------------------------------- |
-| **Action**             | `customer_session_fields_updated`                                                   |
+|            |                                   |
+| ---------- | --------------------------------- |
+| **Action** | `customer_session_fields_updated` |
 
 </Text>
 
@@ -3656,9 +3656,9 @@ Registers a webhook for the Client ID (application) provided in the request. Lat
 |                 |                                                                          |
 | --------------- | ------------------------------------------------------------------------ |
 | Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/register_webhook` |
-| Required scopes | `webhooks.configuration:rw`                                                        |
+| Required scopes | `webhooks.configuration:rw`                                              |
 
-| Parameter                           | Required | Data type  | Notes                                                                                                                                                     |
+| Parameter                                | Required | Data type  | Notes                                                                                                                                                     |
 | ---------------------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `action`__*__                            | yes      | `string`   | The [action](#triggering-actions) that triggers sending a webhook.                                                                                        |
 | `secret_key`                             | yes      | `string`   | The secret key sent in webhooks to verify the source of a webhook.                                                                                        |
@@ -3678,30 +3678,30 @@ Registers a webhook for the Client ID (application) provided in the request. Lat
 
 __*__ The table below presents the possible values for the `action` parameter.
 
-| Possible action                                                      |                                 Available filters |
-| -------------------------------------------------------------------- | ------------------------------------------------: |
-| [`incoming_chat`](#incoming_chat)                                    |                `chat_member_ids`, `only_my_chats` |
-| [`chat_deactivated`](#chat_deactivated)                              |                `chat_member_ids`, `only_my_chats` |
-| [`chat_access_granted`](#chat_access_granted)                        |                `chat_member_ids`, `only_my_chats` |
-| [`chat_access_revoked`](#chat_access_revoked)                        |                `chat_member_ids`, `only_my_chats` |
-| [`user_added_to_chat`](#user_added_to_chat)                          |                `chat_member_ids`, `only_my_chats` |
-| [`user_removed_from_chat`](#user_removed_from_chat)                  |                `chat_member_ids`, `only_my_chats` |
-| [`incoming_event`](#incoming_event)                                  | `chat_member_ids`, `author_type`, `only_my_chats` |
-| [`event_updated`](#event_updated)                                    | `chat_member_ids`, `author_type`, `only_my_chats` |
-| [`incoming_rich_message_postback`](#incoming_rich_message_postback)  |                `chat_member_ids`, `only_my_chats` |
-| [`chat_properties_updated`](#chat_properties_updated)                |                `chat_member_ids`, `only_my_chats` |
-| [`chat_properties_deleted`](#chat_properties_deleted)                |                `chat_member_ids`, `only_my_chats` |
-| [`thread_properties_updated`](#thread_properties_updated)            |                `chat_member_ids`, `only_my_chats` |
-| [`thread_properties_deleted`](#thread_properties_deleted)            |                `chat_member_ids`, `only_my_chats` |
-| [`event_properties_updated`](#event_properties_updated)              |                `chat_member_ids`, `only_my_chats` |
-| [`event_properties_deleted`](#event_properties_deleted)              |                `chat_member_ids`, `only_my_chats` |
-| [`thread_tagged`](#thread_tagged)                                    |                `chat_member_ids`, `only_my_chats` |
-| [`thread_untagged`](#thread_untagged)                                |                `chat_member_ids`, `only_my_chats` |
-| [`routing_status_set`](#routing_status_set)                          |                                                 - |
-| [`agent_deleted`](#agent_deleted)                                    |                    `chat_member_ids`, `agent_ids` |
-| [`incoming_customer`](#incoming_customer)                            |                                                 - |
-| [`customer_session_fields_updated`](#customer_session_fields_updated)|                                 `chat_member_ids` |
-| [`events_marked_as_seen`](#events_marked_as_seen)                    |                `chat_member_ids`, `only_my_chats` |
+| Possible action                                                       |                                 Available filters |
+| --------------------------------------------------------------------- | ------------------------------------------------: |
+| [`incoming_chat`](#incoming_chat)                                     |                `chat_member_ids`, `only_my_chats` |
+| [`chat_deactivated`](#chat_deactivated)                               |                `chat_member_ids`, `only_my_chats` |
+| [`chat_access_granted`](#chat_access_granted)                         |                `chat_member_ids`, `only_my_chats` |
+| [`chat_access_revoked`](#chat_access_revoked)                         |                `chat_member_ids`, `only_my_chats` |
+| [`user_added_to_chat`](#user_added_to_chat)                           |                `chat_member_ids`, `only_my_chats` |
+| [`user_removed_from_chat`](#user_removed_from_chat)                   |                `chat_member_ids`, `only_my_chats` |
+| [`incoming_event`](#incoming_event)                                   | `chat_member_ids`, `author_type`, `only_my_chats` |
+| [`event_updated`](#event_updated)                                     | `chat_member_ids`, `author_type`, `only_my_chats` |
+| [`incoming_rich_message_postback`](#incoming_rich_message_postback)   |                `chat_member_ids`, `only_my_chats` |
+| [`chat_properties_updated`](#chat_properties_updated)                 |                `chat_member_ids`, `only_my_chats` |
+| [`chat_properties_deleted`](#chat_properties_deleted)                 |                `chat_member_ids`, `only_my_chats` |
+| [`thread_properties_updated`](#thread_properties_updated)             |                `chat_member_ids`, `only_my_chats` |
+| [`thread_properties_deleted`](#thread_properties_deleted)             |                `chat_member_ids`, `only_my_chats` |
+| [`event_properties_updated`](#event_properties_updated)               |                `chat_member_ids`, `only_my_chats` |
+| [`event_properties_deleted`](#event_properties_deleted)               |                `chat_member_ids`, `only_my_chats` |
+| [`thread_tagged`](#thread_tagged)                                     |                `chat_member_ids`, `only_my_chats` |
+| [`thread_untagged`](#thread_untagged)                                 |                `chat_member_ids`, `only_my_chats` |
+| [`routing_status_set`](#routing_status_set)                           |                                                 - |
+| [`agent_deleted`](#agent_deleted)                                     |                    `chat_member_ids`, `agent_ids` |
+| [`incoming_customer`](#incoming_customer)                             |                                                 - |
+| [`customer_session_fields_updated`](#customer_session_fields_updated) |                                 `chat_member_ids` |
+| [`events_marked_as_seen`](#events_marked_as_seen)                     |                `chat_member_ids`, `only_my_chats` |
 
 </Text>
 
@@ -3742,16 +3742,16 @@ Lists all webhooks registered for the given Client ID.
 
 #### Specifics
 
-|                 |                                                                                  |
-| --------------- | -------------------------------------------------------------------------------- |
-| Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/list_webhooks`            |
-| Required scopes | `webhooks.configuration:rw`                                                      |
+|                 |                                                                       |
+| --------------- | --------------------------------------------------------------------- |
+| Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/list_webhooks` |
+| Required scopes | `webhooks.configuration:rw`                                           |
 
 #### Request
 
-| Parameter         | Required | Data type | Notes                                                                                        |
-| ----------------- | -------- | --------- | -------------------------------------------------------------------------------------------- |
-| `owner_client_id` | yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered).                       |
+| Parameter         | Required | Data type | Notes                                                                  |
+| ----------------- | -------- | --------- | ---------------------------------------------------------------------- |
+| `owner_client_id` | yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). |
 
 </Text>
 
@@ -3788,14 +3788,14 @@ Unregisters a webhook previously [registered](#register-webhook) for a Client ID
 |                 |                                                                            |
 | --------------- | -------------------------------------------------------------------------- |
 | Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/unregister_webhook` |
-| Required scopes | `webhooks.configuration:rw`                                       |
+| Required scopes | `webhooks.configuration:rw`                                                |
 
 #### Request
 
-| Parameter         | Required | Data type | Notes                                                                                        |
-| ----------------- | -------- | --------- | -------------------------------------------------------------------------------------------- |
-| `id`              | Yes      | `string`  | Webhook ID                                                                                   |
-| `owner_client_id` | Yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered).                       |
+| Parameter         | Required | Data type | Notes                                                                  |
+| ----------------- | -------- | --------- | ---------------------------------------------------------------------- |
+| `id`              | Yes      | `string`  | Webhook ID                                                             |
+| `owner_client_id` | Yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). |
 
 
 #### Response
@@ -3841,9 +3841,9 @@ Lists all webhooks that are supported in a given API version. This method requir
 
 #### Request
 
-| Parameter      | Required | Data type | Notes                                      |
-| -------------- | -------- | --------- | ------------------------------------------ |
-| `version`      | No       | `string`  | Defaults to the current stable API version |
+| Parameter | Required | Data type | Notes                                      |
+| --------- | -------- | --------- | ------------------------------------------ |
+| `version` | No       | `string`  | Defaults to the current stable API version |
 
 </Text>
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -929,7 +929,7 @@ curl -X POST \
 
 ### Update Auto Access
 
-Updates existing `auto access`.  Only specified fields are updated (overwritten), leaving unspecified fields unchanged.
+Updates an existing `auto access`.  Only specified fields are updated (overwritten), leaving unspecified fields unchanged.
 
 #### Specifics
 

--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -722,24 +722,26 @@ Creates an `auto access` data structure, which is a set of conditions for the tr
 | -------------------------------------- | ------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `access`                               | Yes          | `object`                     | Destination access                                                                                      |
 | `access.groups`                        | Yes          | `[]int`                      | Destination groups                                                                                      |
-| `conditions`__**__                     | Yes          | `object`                     | Conditions to check                                                                                     |
-| `conditions.customer_url`              | No           | `object`                     | The condition that matches on `customer_page.url` from **Login** or `url` from **Update Customer Page** |
-| `conditions.customer_domain`           | No           | `object`                     | The condition that matches on the domain of the `customer_url`                                          |
-| `conditions.customer_*.values`         | No           | `[]match_object`_*_          | Positive match, may not be used together with `exclude_values`                                          |
-| `conditions.customer_*.exclude_values` | No           | `[]match_object`             | Negative match                                                                                          |
+| `conditions`__*__                     | Yes          | `object`                     | Conditions to check                                                                                     |
+| `conditions.url`                       | No           | `object`                     | The condition that matches on `customer_page.url` from **Login** or `url` from **Update Customer Page** |
+| `conditions.domain`                    | No           | `object`                     | The condition that matches on the domain of the `customer_url`                                          |
+| `conditions.{url,domain}.values`         | No           | `[]match_object`_**_          | Positive match, may not be used together with `exclude_values`                                          |
+| `conditions.{url,domain}.exclude_values` | No           | `[]match_object`             | Negative match                                                                                          |
 | `conditions.geolocation`               | No           | `object`                     | The condition that matches on the customer's geolocation                                                |
-| `conditions.geolocation.values`        | Yes          | `[]geolocation_object`__**__ | An array of objects; matches when at least one subcondition matches.                                    |
+| `conditions.geolocation.values`        | Yes          | `[]geolocation_object`__***__ | An array of objects; matches when at least one subcondition matches.                                    |
 | `description`                          | No           | `string`                     | Description of the auto access                                                                          |
 | `next_id`                              | No           | `string`                     | ID of an existing auto access. Leave empty if the new auto access should be the last one on the list.   |
 
-__*__ `<match_object>` structure:
+_*_ `conditions` must have at least one of `url`, `domain`, `geolocation` set.
+
+__**__ `<match_object>` structure:
 
 | Parameter     | Required | Data type | Notes                                                                                                   |
 | ------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------- |
 | `value`       | Yes      | `string`  | A value to match                                                                                        |
 | `exact_match` | No       | `bool`    | If set to `false`, a `match_object.value` will be matched as a substring of the customer URL or domain. |
 
-__**__ the `geolocation_object` structure.  The condition is fulfilled only when all of the specified fields match:
+__***__ the `geolocation_object` structure.  The condition is fulfilled only when all of the specified fields match.  At least one field must be specified.
 
 | Parameter      | Required | Data type | Example         |
 | -------------- | -------- | --------- | --------------- |
@@ -925,23 +927,58 @@ curl -X POST \
 
 <Text>
 
-### Reorder Auto Access
+### Update Auto Access
 
-Moves an existing `auto access` data structure, specified by `id`, before another one, specified by `next_id`. 
-If `next_id` is empty, then the auto access will be placed at the end of the list.
+Updates existing `auto access`.  Only specified fields are updated (overwritten), leaving unspecified fields unchanged.
 
 #### Specifics
 
 |                |                                                                                  |
 | -------------- | -------------------------------------------------------------------------------- |
-| Method URL     | `https://api.livechatinc.com/v3.3/configuration/action/reorder_auto_access`      |
+| Method URL     | `https://api.livechatinc.com/v3.3/configuration/action/update_auto_access`      |
 | Required scopes| `access_rules:rw`                                                                |
 
 
-| Parameter              | Required     | Data type | Notes                                                                                                                                    |
-| ---------------------- | ------------ | --------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`                   | Yes          | `string`  | ID of the auto access to move                                                                                                            |
-| `next_id`              | No           | `string`  | ID of the auto access that should follow the moved auto access. Leave empty if the moved auto access should be the last one on the list. |
+| Parameter                             | Required     | Data type                     | Notes                                                                                                                                    |
+| ------------------------------------- | ------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                                  | Yes          | `string`                      | ID of the auto access to modify                                                                                                            |
+| `access`                              | No           | `object`                      | Destination access                                                                                      |
+| `access.groups`                       | Yes          | `[]int`                       | Destination groups                                                                                      |
+| `conditions`__*__                     | No          | `object`                       | Conditions to check                                                                                     |
+| `conditions.url`                      | No           | `object`                      | The condition that matches on `customer_page.url` from **Login** or `url` from **Update Customer Page** |
+| `conditions.domain`                   | No           | `object`                      | The condition that matches on the domain of the `customer_url`                                          |
+| `conditions.{url,domain}.values`         | No        | `[]match_object`_**_          | Positive match, may not be used together with `exclude_values`                                          |
+| `conditions.{url,domain}.exclude_values` | No        | `[]match_object`              | Negative match                                                                                          |
+| `conditions.geolocation`               | No          | `object`                      | The condition that matches on the customer's geolocation                                                |
+| `conditions.geolocation.values`        | Yes         | `[]geolocation_object`__***__ | An array of objects; matches when at least one subcondition matches.                                    |
+| `description`                          | No          | `string`                      | Description of the auto access                                                                          |
+| `next_id`__****__                      | No          | `string`                      | ID of an existing auto access. Empty string moves the auto access to the end of the list. |
+
+_*_ `conditions` must have at least one of `url`, `domain`, `geolocation` set.
+
+__**__ `<match_object>` structure:
+
+| Parameter     | Required | Data type | Notes                                                                                                   |
+| ------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------- |
+| `value`       | Yes      | `string`  | A value to match                                                                                        |
+| `exact_match` | No       | `bool`    | If set to `false`, a `match_object.value` will be matched as a substring of the customer URL or domain. |
+
+__***__ the `geolocation_object` structure.  The condition is fulfilled only when all of the specified fields match.  At least one field must be specified.
+
+| Parameter      | Required | Data type | Example         |
+| -------------- | -------- | --------- | --------------- |
+| `country`      | No       | `string`  | "United States  |
+| `country_code` | No       | `string`  | "US"            |
+| `region`       | No       | `string`  | "California"    |
+| `city`         | No       | `string`  | "Mountain View" |
+
+
+__****__ Modifying `next_id` reorders `auto access` specified by `id`, before another one, specified by `next_id`.
+If `next_id` is empty string, then the auto access will be placed at the end of the list. If the rule is not supposed to be moved at all, do not set the field in request.
+
+An example of move, arrow indicates `next_id` relation, so A will have `next_id` set to B:
+
+Given list A -> B -> C -> D -> null, `update_auto_access` with payload `{"id": "C", "next_id": "B"}` will result in a A -> C -> B -> D -> null sequence, maintaining consistency.
 
 #### Response
 
@@ -955,11 +992,14 @@ No response payload (`200 OK`).
 
 ```shell
 curl -X POST \
-  https://api.livechatinc.com/v3.3/configuration/action/reorder_auto_access \
+  https://api.livechatinc.com/v3.3/configuration/action/update_auto_access \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <your_access_token>' \
   -d '{
     "id": "pqi8oasdjahuakndw9nsad9na",
+    "access": {
+      groups: [0, 42]
+    },
     "next_id": "1faad6f5f1d6e8fdf27e8af9839783b7"
   }'
 ```


### PR DESCRIPTION
drop `customer_` from rule names

give explicit example of how reorder works

highlight that at least one rule needs to be specified

## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-8565-update_auto_access/management/configuration-api/v3.3/#auto-access)
- [Jira](https://livechatinc.atlassian.net/browse/API-8565)

## 📓 Description


## ✅ Checklist (for API docs)

- Changelog
- API versions
- Web & RTM
- **Table:** Available methods/webhooks/pushes
- **Table:** Specifics

For more guidelines, see [Updating API docs](https://livechatinc.atlassian.net/wiki/spaces/PAT/pages/761529400/Updating+API+docs).

## 👷 Type of change (remove not needed)

### Content

- New content
- Proofreading/content fixes
  
### Features (for the website)

- New feature
- Bug fix
- Breaking change
