### PR TITLE
Remove 'customer_' prefix from AAR code examples

### DIFF
--- a/content/management/configuration-api/v3.3/index.mdx
+++ b/content/management/configuration-api/v3.3/index.mdx
@@ -766,7 +766,7 @@ curl -X POST \
           "groups": [ 1 ]
         },
         "conditions": {
-          "customer_domain": {
+          "domain": {
             "values": [
               {
                 "value": "livechat.com",
@@ -774,7 +774,7 @@ curl -X POST \
               }
             ]
           },
-          "customer_geolocation": {
+          "geolocation": {
             "values": [
               {
                 "country": "United States",
@@ -847,7 +847,7 @@ curl -X POST \
       ]
     },
     "conditions": {
-      "customer_geolocation": {
+      "geolocation": {
         "values": [
           {
             "country": "United States",
@@ -855,7 +855,7 @@ curl -X POST \
           }
         ]
       },
-      "customer_domain": {
+      "domain": {
         "values": [
           {
             "value": "livechat.com",


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/feature/remove-customer-prefix-from-aar-examples)

## 📓 Description
Remove `customer_` prefix from Auto access rules documentation code examples. It is a small leftover after https://github.com/livechat/livechat-public-docs/pull/868