### PR TITLE
Add info about max_chats_count limit for bots

### DIFF
--- a/content/management/configuration-api/index.mdx
+++ b/content/management/configuration-api/index.mdx
@@ -1045,7 +1045,7 @@ Creates a new Bot.
 | ------------------------------------ | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `name`                               | Yes      | `string`   | Display name                                                                                                           |
 | `avatar`                             | No       | `string`   | Avatar URL                                                                                                             |
-| `max_chats_count`                    | No       | `int`      | Max. number of incoming chats that can be routed to the Bot; default: 6.                                               |
+| `max_chats_count`                    | No       | `int`      | Max. number of incoming chats that can be routed to the Bot; default: 6. Limited to 500.                               |
 | `default_group_priority` __****__    | No       | `string`   | The default routing priority for a group without defined priority.                                                     |
 | `groups`                             | No       | `object[]` | Groups the Bot belongs to.                                                                                             |
 | `groups[].id`                        | No       | `int`      | Group ID; required only when `group`'s included.                                                                       |
@@ -1179,7 +1179,7 @@ Updates an existing Bot.
 | `id`                                  | Yes      | `string`   | Bot ID                                                                                                    |
 | `name`                                | No       | `string`   | Display name                                                                                              |
 | `avatar`                              | No       | `string`   | Avatar URL                                                                                                |
-| `max_chats_count`                     | No       | `int`      | Maximum incoming chats that can be routed to the Bot.                                                     |
+| `max_chats_count`                     | No       | `int`      | Maximum incoming chats that can be routed to the Bot. Limited to 500.                                     |
 | `groups`                              | No       | `object[]` | Groups the Bot belongs to                                                                                 |
 | `groups[].id`                         | Yes      | `uint`     | Group ID, required only when `groups`'s present.                                                          |
 | `groups[].priority` __*__             | Yes      | `string`   | Bot's priority in the group; required only when `groups` is included.                                     |

--- a/content/management/configuration-api/v3.1/index.mdx
+++ b/content/management/configuration-api/v3.1/index.mdx
@@ -76,7 +76,7 @@ Unlike Agents, Bot Agents don't have passwords or emails - you cannot log in as 
 | `name`                               | `string`   | Yes      | Display name                                                                                                                             |
 | `status` __*__                       | `string`   | Yes      | Agent status                                                                                                                             |
 | `avatar`                             | `string`   | No       | Avatar URL                                                                                                                               |
-| `max_chats_count`                    | `int`      | No       | Max. number of incoming chats that can be routed to an Agent; default: 6.                                                                |
+| `max_chats_count`                    | `int`      | No       | Max. number of incoming chats that can be routed to an Agent; default: 6. Limited to 500.                                                |
 | `default_group_priority` __***__     | `string`   | No       | The default routing priority for a group without defined priority.                                                                       |
 | `groups`                             | `object[]` | No       | Groups an Agent belongs to.                                                                                                              |
 | `groups[].id`                        | `uint`     | Yes      | Group ID; required only when `group`'s included.                                                                                         |
@@ -209,7 +209,7 @@ curl -X POST \
 | `name`                               | No       | `string`   | Display name                                                                                                            |
 | `avatar`                             | No       | `string`   | Avatar URL                                                                                                              |
 | `status` __*__                       | No       | `string`   | Agent status                                                                                                            |
-| `max_chats_count`                    | No       | `int`      | Maximum incoming chats that can be routed to an Agent.                                                                  |
+| `max_chats_count`                    | No       | `int`      | Maximum incoming chats that can be routed to an Agent. Limited to 500.                                                  |
 | `groups`                             | No       | `object[]` | Groups an Agent belongs to                                                                                              |
 | `groups[].id`                        | Yes      | `uint`     | Group ID, required only when `groups`'s present.                                                                        |
 | `groups[].priority` __**__           | Yes      | `string`   | Agent's priority in the group; required only when `groups` is included.                                                 |

--- a/content/management/configuration-api/v3.2/index.mdx
+++ b/content/management/configuration-api/v3.2/index.mdx
@@ -730,7 +730,7 @@ Creates a new Bot.
 | --------------------------------------- | -------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`                                  | Yes      | `string`   | Display name                                                                                                                           |
 | `avatar`                                | No       | `string`   | Avatar URL                                                                                                                             |
-| `max_chats_count`                       | No       | `int`      | Max. number of incoming chats that can be routed to the Bot; default: 6.                                                               |
+| `max_chats_count`                       | No       | `int`      | Max. number of incoming chats that can be routed to the Bot; default: 6. Limited to 500.                                               |
 | `default_group_priority` __\*\*\*\*\*__ | No       | `string`   | The default routing priority for a group without defined priority.                                                                     |
 | `groups`                                | No       | `object[]` | Groups the Bot belongs to.                                                                                                             |
 | `groups[].id`                           | No       | `int`      | Group ID; required only when `group`'s included.                                                                                       |
@@ -869,7 +869,7 @@ Updates an existing Bot.
 | `id`                                   | Yes      | `string`   | Bot ID                                                                                                                  |
 | `name`                                 | No       | `string`   | Display name                                                                                                            |
 | `avatar`                               | No       | `string`   | Avatar URL                                                                                                              |
-| `max_chats_count`                      | No       | `int`      | Maximum incoming chats that can be routed to the Bot.                                                                   |
+| `max_chats_count`                      | No       | `int`      | Maximum incoming chats that can be routed to the Bot. Limited to 500.                                                   |
 | `groups`                               | No       | `object[]` | Groups the Bot belongs to                                                                                               |
 | `groups[].id`                          | Yes      | `uint`     | Group ID, required only when `groups`'s present.                                                                        |
 | `groups[].priority` __*__              | Yes      | `string`   | Bot's priority in the group; required only when `groups` is included.                                                   |

--- a/content/management/configuration-api/v3.4/index.mdx
+++ b/content/management/configuration-api/v3.4/index.mdx
@@ -1045,7 +1045,7 @@ Creates a new Bot.
 | ------------------------------------ | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `name`                               | Yes      | `string`   | Display name                                                                                                           |
 | `avatar`                             | No       | `string`   | Avatar URL                                                                                                             |
-| `max_chats_count`                    | No       | `int`      | Max. number of incoming chats that can be routed to the Bot; default: 6.                                               |
+| `max_chats_count`                    | No       | `int`      | Max. number of incoming chats that can be routed to the Bot; default: 6. Limited to 500.                               |
 | `default_group_priority` __****__    | No       | `string`   | The default routing priority for a group without defined priority.                                                     |
 | `groups`                             | No       | `object[]` | Groups the Bot belongs to.                                                                                             |
 | `groups[].id`                        | No       | `int`      | Group ID; required only when `group`'s included.                                                                       |
@@ -1179,7 +1179,7 @@ Updates an existing Bot.
 | `id`                                  | Yes      | `string`   | Bot ID                                                                                                    |
 | `name`                                | No       | `string`   | Display name                                                                                              |
 | `avatar`                              | No       | `string`   | Avatar URL                                                                                                |
-| `max_chats_count`                     | No       | `int`      | Maximum incoming chats that can be routed to the Bot.                                                     |
+| `max_chats_count`                     | No       | `int`      | Maximum incoming chats that can be routed to the Bot. Limited to 500.                                     |
 | `groups`                              | No       | `object[]` | Groups the Bot belongs to                                                                                 |
 | `groups[].id`                         | Yes      | `uint`     | Group ID, required only when `groups`'s present.                                                          |
 | `groups[].priority` __*__             | Yes      | `string`   | Bot's priority in the group; required only when `groups` is included.                                     |


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-8636-limit-chats-count)
- [Jira](https://livechatinc.atlassian.net/browse/API-8636)

## 📓 Description

Add info about limit for value of `max_chats_count` param in create/update bot methods.
Autoformatted tables to look nicer.

### Content

- New content
- Proofreading/content fixes
