### PR TITLE
CustomerSDK: Rename the wrong property in the chat transcript feature recipe

### DIFF
--- a/content/extending-chat-widget/customer-sdk/index.mdx
+++ b/content/extending-chat-widget/customer-sdk/index.mdx
@@ -46,6 +46,12 @@ customerSDK.auth.getToken().then(token => {
 
 If you have any questions, you can start a chat with our [24/7 Support](https://direct.lc.chat/1520/125).
 
+## Examples
+
+We have prepared a sample chat widget implementation to present the features of LiveChat Customer JS SDK:
+
+- [Sample widget at CodeSandbox](https://codesandbox.io/s/rm3prxw88n)
+
 # How to start
 
 This tutorial is here to help you get started with LiveChat Customer SDK.
@@ -2120,7 +2126,7 @@ Wrong format of request, for example a `string` sent in the place of a `number`.
 
 ## Chat transcript feature
 
-To implement [Chat transcript](https://www.livechat.com/features/engaging-customers/#Chat-transcript), you need to set the `transcriptSentTo` thread property in the `routing` namespace. The value of this property should be set to the email address of the requester.
+To implement [Chat transcript](https://www.livechat.com/features/engaging-customers/#Chat-transcript), you need to set the `transcript_email` thread property in the `routing` namespace. The value of this property should be set to the email address of the requester.
 
 ```js
 customerSDK
@@ -2129,7 +2135,7 @@ customerSDK
     threadId: 'OS0C0W0Z1B',
     properties: {
       routing: {
-        transcriptSentTo: 'john.doe@example.com',
+        transcript_email: 'john.doe@example.com',
       },
     },
   })

--- a/content/extending-chat-widget/customer-sdk/v1.0/index.mdx
+++ b/content/extending-chat-widget/customer-sdk/v1.0/index.mdx
@@ -54,12 +54,6 @@ customerSDK.auth.getToken().then(token => console.log(token));
 
 </CodeSample>
 
-## Examples
-
-We have prepared a sample chat widget implementation to present the features of LiveChat Customer JS SDK:
-
-- [Sample widget at CodeSandbox](https://codesandbox.io/s/rm3prxw88n)
-
 # How to start
 
 This tutorial will help you get started with using LiveChat Customer JS SDK.


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/fix-property-name

## 📓 Description
- Rename the wrong property in the chat transcript feature recipe
- Move example to the proper version