### PR TITLE
Feature/api 8750 agent-api new pushes - thread_deleted,threads_deleted,chat_deleted

### DIFF
--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -11,7 +11,12 @@ This document is the record of all the changes in the **Agent Chat API**, Web an
 
 ## [v3.4] - Developer preview
 
-No changes yet.
+### Chats
+
+- There are new pushes:
+  - [**chat_deleted**](/messaging/agent-chat-api/v3.4/rtm-reference/#chat_deleted)
+  - [**thread_deleted**](/messaging/agent-chat-api/v3.4/rtm-reference/#thread_deleted)
+  - [**threads_deleted**](/messaging/agent-chat-api/v3.4/rtm-reference/#threads_deleted)
 
 ## [v3.3] - 2021-03-30
 

--- a/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
@@ -3765,8 +3765,7 @@ Informs that a chat was deleted.
 
 ```json
 {
-  "chat_id": "PJ0MRSHTDG",
-  "thread_id": "K600PKZON8"
+  "chat_id": "PJ0MRSHTDG"
 }
 ```
 

--- a/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
@@ -3651,12 +3651,11 @@ Here's what you need to know about **pushes**:
 
 |                 |                                                                                                                                                                                                                                                                                                                                                 |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated) [`chat_deleted`](#chat_deleted)                                                                                                                                                                                                                                                                       |
+| **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated) [`chat_deleted`](#chat_deleted) [`thread_deleted`](#thread_deleted) [`threads_deleted`](#threads_deleted)                                                                                                                                                             |
 | **Chat access** | [`chat_access_granted`](#chat_access_granted) [`chat_access_revoked`](#chat_access_revoked) [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                             |
 | **Chat users**  | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                 |
 | **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                        |
-| **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
-| **Threads**     | [`thread_deleted`](#thread_deleted) [`threads_deleted`](#threads_deleted)                                                                                                                                                                                                                                                                         |
+| **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |                                                                                                                                                                                                                                                                    |
 | **Thread tags** | [`thread_tagged`](#thread_tagged) [`thread_untagged`](#thread_untagged)                                                                                                                                                                                                                                                                         |
 | **Customers**   | [`incoming_customers`](#incoming_customers) [`incoming_customer`](#incoming_customer) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_banned`](#customer_banned) [`customer_transferred`](#customer_transferred) [`customer_left`](#customer_left)                                         |
 | **Status**      | [`routing_status_set`](#routing_status_set) [`agent_disconnected`](#agent_disconnected)                                                                                                                                                                                                                                                         |
@@ -3775,7 +3774,52 @@ Informs that a chat was deleted.
 
 |                        |                     |
 | ---------------------- | --------------------|
-| **Action**             | `chat_deleted`      |                                                   |
+| **Action**             | `chat_deleted`      |
+| **Webhook equivalent** | -                   |
+
+### `thread_deleted`
+
+Informs that a thread was deleted.
+
+<CodeResponse title={'Sample push payload'}>
+
+```json
+{
+  "chat_id": "PJ0MRSHTDG",
+  "thread_id": "K600PKZON8"
+}
+```
+
+</CodeResponse>
+
+#### Specifics
+
+|                        |                     |
+| ---------------------- | --------------------|
+| **Action**             | `thread_deleted`    |
+| **Webhook equivalent** | -                   |
+
+### `threads_deleted`
+
+Informs that several threads from a specific date range or with the same tag were deleted.
+
+<CodeResponse title={'Sample push payload'}>
+
+```json
+{
+  "date_from": "2017-10-12T15:19:21.010200Z",
+  "date_to": "2019-10-12T15:19:21.010200Z",
+  "tag": "bug_report"
+}
+```
+
+</CodeResponse>
+
+#### Specifics
+
+|                        |                     |
+| ---------------------- | --------------------|
+| **Action**             | `threads_deleted`   |
 | **Webhook equivalent** | -                   |
 
 ## Chat access
@@ -4249,53 +4293,6 @@ Informs about those event properties that were deleted.
 | Field        | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
-
-## Threads
-
-### `thread_deleted`
-
-Informs that a thread was deleted.
-
-<CodeResponse title={'Sample push payload'}>
-
-```json
-{
-  "chat_id": "PJ0MRSHTDG",
-  "thread_id": "K600PKZON8"
-}
-```
-
-</CodeResponse>
-
-#### Specifics
-
-|                        |                     |
-| ---------------------- | --------------------|
-| **Action**             | `thread_deleted`    |                                                   |
-| **Webhook equivalent** | -                   |
-
-### `threads_deleted`
-
-Informs that threads from specific time window were deleted.
-
-<CodeResponse title={'Sample push payload'}>
-
-```json
-{
-  "date_from": "2017-10-12T15:19:21.010200Z",
-  "date_to": "2019-10-12T15:19:21.010200Z",
-  "tag": "bug_report"
-}
-```
-
-</CodeResponse>
-
-#### Specifics
-
-|                        |                     |
-| ---------------------- | --------------------|
-| **Action**             | `threads_deleted`   |                                                   |
-| **Webhook equivalent** | -                   |
 
 ## Thread tags
 

--- a/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
@@ -3651,11 +3651,12 @@ Here's what you need to know about **pushes**:
 
 |                 |                                                                                                                                                                                                                                                                                                                                                 |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                       |
+| **Chats**       | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated) [`chat_deleted`](#chat_deleted)                                                                                                                                                                                                                                                                       |
 | **Chat access** | [`chat_access_granted`](#chat_access_granted) [`chat_access_revoked`](#chat_access_revoked) [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                             |
 | **Chat users**  | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                 |
 | **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                        |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
+| **Threads**     | [`thread_deleted`](#thread_deleted) [`threads_deleted`](#threads_deleted)                                                                                                                                                                                                                                                                         |
 | **Thread tags** | [`thread_tagged`](#thread_tagged) [`thread_untagged`](#thread_untagged)                                                                                                                                                                                                                                                                         |
 | **Customers**   | [`incoming_customers`](#incoming_customers) [`incoming_customer`](#incoming_customer) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_banned`](#customer_banned) [`customer_transferred`](#customer_transferred) [`customer_left`](#customer_left)                                         |
 | **Status**      | [`routing_status_set`](#routing_status_set) [`agent_disconnected`](#agent_disconnected)                                                                                                                                                                                                                                                         |
@@ -3862,6 +3863,28 @@ Informs that a chat was transferred to a different group or to an agent.
 
 **\*)**
 Possible reasons: `manual`, `inactive`, `assigned`, `unassigned`, `other`.
+
+### `chat_deleted`
+
+Informs that a chat was deleted.
+
+<CodeResponse title={'Sample push payload'}>
+
+```json
+{
+  "chat_id": "PJ0MRSHTDG",
+  "thread_id": "K600PKZON8"
+}
+```
+
+</CodeResponse>
+
+#### Specifics
+
+|                        |                     |
+| ---------------------- | --------------------|
+| **Action**             | `chat_deleted`      |                                                   |
+| **Webhook equivalent** | -                   |
 
 ## Chat users
 
@@ -4227,6 +4250,53 @@ Informs about those event properties that were deleted.
 | Field        | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
 | `properties` | This is not a full `properties` object. This push shows only the properties that have been recently updated. |
+
+## Threads
+
+### `thread_deleted`
+
+Informs that a thread was deleted.
+
+<CodeResponse title={'Sample push payload'}>
+
+```json
+{
+  "chat_id": "PJ0MRSHTDG",
+  "thread_id": "K600PKZON8"
+}
+```
+
+</CodeResponse>
+
+#### Specifics
+
+|                        |                     |
+| ---------------------- | --------------------|
+| **Action**             | `thread_deleted`    |                                                   |
+| **Webhook equivalent** | -                   |
+
+### `threads_deleted`
+
+Informs that a threads were deleted.
+
+<CodeResponse title={'Sample push payload'}>
+
+```json
+{
+  "date_from": "2017-10-12T15:19:21.010200Z",
+  "date_to": "2019-10-12T15:19:21.010200Z",
+  "tag": "bug_report"
+}
+```
+
+</CodeResponse>
+
+#### Specifics
+
+|                        |                     |
+| ---------------------- | --------------------|
+| **Action**             | `threads_deleted`   |                                                   |
+| **Webhook equivalent** | -                   |
 
 ## Thread tags
 

--- a/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
@@ -3757,6 +3757,28 @@ Informs that a chat was deactivated by closing the currently open thread.
 | --------- | --------------------------------------------- |
 | `user_id` | Missing if a thread was closed by the router. |
 
+### `chat_deleted`
+
+Informs that a chat was deleted.
+
+<CodeResponse title={'Sample push payload'}>
+
+```json
+{
+  "chat_id": "PJ0MRSHTDG",
+  "thread_id": "K600PKZON8"
+}
+```
+
+</CodeResponse>
+
+#### Specifics
+
+|                        |                     |
+| ---------------------- | --------------------|
+| **Action**             | `chat_deleted`      |                                                   |
+| **Webhook equivalent** | -                   |
+
 ## Chat access
 
 ### `chat_access_granted`
@@ -3863,28 +3885,6 @@ Informs that a chat was transferred to a different group or to an agent.
 
 **\*)**
 Possible reasons: `manual`, `inactive`, `assigned`, `unassigned`, `other`.
-
-### `chat_deleted`
-
-Informs that a chat was deleted.
-
-<CodeResponse title={'Sample push payload'}>
-
-```json
-{
-  "chat_id": "PJ0MRSHTDG",
-  "thread_id": "K600PKZON8"
-}
-```
-
-</CodeResponse>
-
-#### Specifics
-
-|                        |                     |
-| ---------------------- | --------------------|
-| **Action**             | `chat_deleted`      |                                                   |
-| **Webhook equivalent** | -                   |
 
 ## Chat users
 

--- a/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
@@ -4276,7 +4276,7 @@ Informs that a thread was deleted.
 
 ### `threads_deleted`
 
-Informs that a threads were deleted.
+Informs that threads from specific time window were deleted.
 
 <CodeResponse title={'Sample push payload'}>
 


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-8750-new-pushes-documentation)
- [Jira](https://livechatinc.atlassian.net/browse/API-8750)

## 📓 Description

Information on new pushes in 3.4 -> thread_deleted, threads_deleted, chat_deleted
No much info about them, are props seem self-explanatory. Change only i Agent-Chat-API.
Didn't found info about pushes in changelog, so no changes there 

### Content

- New content
- Proofreading/content fixes
