### PR TITLE
Separate JS API from Customer SDK

### DIFF
--- a/content/extending-chat-widget/chat-widget-moments/index.mdx
+++ b/content/extending-chat-widget/chat-widget-moments/index.mdx
@@ -5,7 +5,6 @@ subcategory: "chat-widget-moments"
 title: "Chat Widget Moments"
 tagline: "Use Moments to show any web application during a chat."
 desc: "Showing any web application during a chat is possible - all you need to do is use Moments."
-versionGroup: "chat-widget"
 ---
 
 # Introduction

--- a/content/extending-chat-widget/customer-sdk/index.mdx
+++ b/content/extending-chat-widget/customer-sdk/index.mdx
@@ -5,7 +5,7 @@ subcategory: "customer-sdk"
 title: "Customer SDK"
 tagline: "Build your own Chat Widget."
 desc: "If our default widget is not enough, feel free to build your own. Customer JS SDK is your way to go."
-versionGroup: "chat-widget"
+versionGroup: "customer-sdk"
 apiVersion: "2.0"
 ---
 

--- a/content/extending-chat-widget/customer-sdk/v1.0/index.mdx
+++ b/content/extending-chat-widget/customer-sdk/v1.0/index.mdx
@@ -5,7 +5,7 @@ subcategory: "customer-sdk"
 title: "Customer SDK"
 tagline: "Build your own Chat Widget."
 desc: "If our default widget is not enough, feel free to build your own. Customer JS SDK is your way to go."
-versionGroup: "chat-widget"
+versionGroup: "customer-sdk"
 apiVersion: "1.0"
 ---
 

--- a/content/extending-chat-widget/index.mdx
+++ b/content/extending-chat-widget/index.mdx
@@ -4,7 +4,6 @@ category: "extending-chat-widget"
 title: "Overview"
 tagline: "Extend the LiveChat Chat Widget."
 desc: "Extend the Chat Widget with new features. Make use of Moments and rich messages, and build custom solutions."
-versionGroup: "chat-widget"
 ---
 
 # Mobile Chat Widgets

--- a/content/extending-chat-widget/javascript-api/index.mdx
+++ b/content/extending-chat-widget/javascript-api/index.mdx
@@ -5,7 +5,7 @@ subcategory: "javascript-api"
 title: "Chat Widget JS API"
 tagline: "Customize the behavior of the Chat Widget."
 desc: "Adjust the mechanics of the widget or leverage the API to pass additional details on the Customer."
-versionGroup: "chat-widget"
+versionGroup: "js-api"
 apiVersion: "2.0"
 ---
 

--- a/content/extending-chat-widget/javascript-api/v1.0/index.mdx
+++ b/content/extending-chat-widget/javascript-api/v1.0/index.mdx
@@ -5,7 +5,7 @@ subcategory: "javascript-api"
 title: "Chat Widget JS API"
 tagline: "Customize the behavior of the Chat Widget."
 desc: "Adjust the mechanics of the widget or leverage the API to pass additional details on the Customer."
-versionGroup: "chat-widget"
+versionGroup: "js-api"
 apiVersion: "1.0"
 ---
 

--- a/content/extending-chat-widget/rich-messages/index.mdx
+++ b/content/extending-chat-widget/rich-messages/index.mdx
@@ -5,7 +5,6 @@ subcategory: "rich-messages"
 title: "Rich Messages"
 tagline: "Enrich your messages."
 desc: "Engage better with your Customers using interactive and visually appealing Rich Messages."
-versionGroup: "chat-widget"
 ---
 
 # Introduction

--- a/content/extending-chat-widget/visitor-sdk/index.mdx
+++ b/content/extending-chat-widget/visitor-sdk/index.mdx
@@ -5,7 +5,6 @@ subcategory: "visitor-sdk"
 title: "Visitor SDK"
 tagline: "Build your own Chat Widget."
 desc: "LiveChat Visitor SDK allows you to a chat as a visitor. You can use Visitor SDK to create your own chat widget."
-versionGroup: "chat-widget"
 hidden: true
 ---
 

--- a/src/constant/index.js
+++ b/src/constant/index.js
@@ -5,7 +5,13 @@ const VERSIONS_GROUPS = {
     DEV_PREVIEW_VERSION: "3.4",
     ALL_VERSIONS: ["3.4", "3.3", "3.2", "3.1", "2.0"],
   },
-  "chat-widget": {
+  "js-api": {
+    STABLE_VERSION: "2.0",
+    LEGACY_VERSIONS: ["1.0"],
+    DEV_PREVIEW_VERSION: "",
+    ALL_VERSIONS: ["1.0", "2.0"],
+  },
+  "customer-sdk": {
     STABLE_VERSION: "2.0",
     LEGACY_VERSIONS: ["1.0"],
     DEV_PREVIEW_VERSION: "",


### PR DESCRIPTION
## 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/separate-js-api-from-customer-sdk)

## 📓 Description
I was trying to replace the `chat-widget` version group with these two: `js-api` and `customer-sdk`. Versions for these two documents will change at different times. (Customer SDK will have stable v3.0, but JS API stable v2.0). But I'm afraid we would need version subgroups or something like that.

## 👷 Type of change (remove not needed)

  
### Features (for the website)

- New feature

