### PR TITLE
API-9179: no access change in inactive chat

### DIFF
--- a/content/management/changelog/index.mdx
+++ b/content/management/changelog/index.mdx
@@ -52,6 +52,7 @@ The developer preview version provides a preview of the upcoming changes to the 
   - [**group_created**](/management/configuration-api/v3.4/#group_created)
   - [**group_deleted**](/management/configuration-api/v3.4/#group_deleted)
   - [**group_updated**](/management/configuration-api/v3.4/#group_updated)
+- The **chat_access_granted** and **chat_access_revoked** webhooks were replaced by the [**chat_access_updated**](/management/configuration-api/v3.4/#chat_access_updated) webhook.
 
 ## [v3.3] - 2021-03-30
 

--- a/content/management/configuration-api/index.mdx
+++ b/content/management/configuration-api/index.mdx
@@ -2949,7 +2949,7 @@ Informs that new, single access to a chat was granted. The existing access isn't
 
 | Field | Notes   |
 | ----- | ------- |
-| `id`  | Chat id |
+| `id`  | Chat ID |
 
 </Text>
 

--- a/content/management/configuration-api/v3.2/index.mdx
+++ b/content/management/configuration-api/v3.2/index.mdx
@@ -2257,7 +2257,7 @@ Informs that new, single access to a chat was granted. The existing access isn't
 
 | Field | Notes   |
 | ----- | ------- |
-| `id`  | Chat id |
+| `id`  | Chat ID |
 
 </Text>
 

--- a/content/management/configuration-api/v3.4/index.mdx
+++ b/content/management/configuration-api/v3.4/index.mdx
@@ -2462,8 +2462,7 @@ __*__ The table below presents the possible values for the `action` parameter.
 | --------------------------------------------------------------------- | ----------------------------------------------: |
 | [`incoming_chat`](#incoming_chat)                                     |                `chat_presence`, `only_my_chats` |
 | [`chat_deactivated`](#chat_deactivated)                               |                `chat_presence`, `only_my_chats` |
-| [`chat_access_granted`](#chat_access_granted)                         |                `chat_presence`, `only_my_chats` |
-| [`chat_access_revoked`](#chat_access_revoked)                         |                `chat_presence`, `only_my_chats` |
+| [`chat_access_updated`](#chat_access_updated)                         | `chat_presence`, `only_my_chats`, `source_type` |
 | [`user_added_to_chat`](#user_added_to_chat)                           |                `chat_presence`, `only_my_chats` |
 | [`user_removed_from_chat`](#user_removed_from_chat)                   |                `chat_presence`, `only_my_chats` |
 | [`incoming_event`](#incoming_event)                                   | `chat_presence`, `author_type`, `only_my_chats` |
@@ -2787,7 +2786,7 @@ curl -X POST \
 |                   |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Chats**         | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| **Chat access**   | [`chat_access_granted`](#chat_access_granted) [`chat_access_revoked`](#chat_access_revoked) [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **Chat access**   | [`chat_access_updated`](#chat_access_updated) [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | **Chat users**    | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | **Events**        | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated) [`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | **Properties**    | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_deleted`](#thread_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted)                                                                                                                                                                                                                 |
@@ -2926,22 +2925,23 @@ Informs that a chat was deactivated by closing the currently open thread.
 
 <Text>
 
-### `chat_access_granted`
+### `chat_access_updated`
 
-Informs that new, single access to a chat was granted. The existing access isn't overwritten.
+Informs that a chat's access was changed. It contains full access of the chat.
 
 #### Specifics
 
 |                        |                                                                                       |
 | ---------------------- | ------------------------------------------------------------------------------------- |
-| **Action**             | `chat_access_granted`                                                                 |
-| **Push equivalent in** | [`Agent Chat API`](/messaging/agent-chat-api/v3.4/rtm-reference/#chat_access_granted) |
+| **Action**             | `chat_access_updated`                                                                 |
+| **Push equivalent in** | [`Agent Chat API`](/messaging/agent-chat-api/v3.4/rtm-reference/#chat_access_updated) |
 
 #### Webhook payload
 
-| Field | Notes   |
-| ----- | ------- |
-| `id`  | Chat id |
+| Field    | Notes                   |
+| -------- | ----------------------- |
+| `id`     | Chat id                 |
+| `access` | Full access of the chat |
 
 </Text>
 
@@ -2953,68 +2953,12 @@ Informs that new, single access to a chat was granted. The existing access isn't
 {
   "webhook_id": "<webhook_id>",
   "secret_key": "<secret_key>",
-  "action": "chat_access_granted",
+  "action": "chat_access_updated",
   "license_id": 104130623,
   "payload": {
     "id": "PJ0MRSHTDG",
     "access": {
-      "group_ids": [1]
-    }
-  },
-  "additional_data": {
-    "chat_properties": { //optional
-        // chat properties
-    },
-    "chat_presence_user_ids": [ //optional
-      // User IDs
-    ]
-  }
-}
-```
-
-</CodeResponse>
-
-</Code>
-
-</Section>
-
-<Section>
-
-<Text>
-
-### `chat_access_revoked`
-
-Informs that access to a certain chat was revoked.
-
-#### Specifics
-
-|                        |                                                                                       |
-| ---------------------- | ------------------------------------------------------------------------------------- |
-| **Action**             | `chat_access_revoked`                                                                 |
-| **Push equivalent in** | [`Agent Chat API`](/messaging/agent-chat-api/v3.4/rtm-reference/#chat_access_revoked) |
-
-#### Webhook payload
-
-| Field | Notes   |
-| ----- | ------- |
-| `id`  | Chat Id |
-
-</Text>
-
-<Code>
-
-<CodeResponse title={'Sample webhook'}>
-
-```json
-{
-  "webhook_id": "<webhook_id>",
-  "secret_key": "<secret_key>",
-  "action": "chat_access_revoked",
-  "license_id": 104130623,
-  "payload": {
-    "id": "PJ0MRSHTDG",
-    "access": {
-      "group_ids": [1]
+      "group_ids": [0, 1]
     }
   },
   "additional_data": {

--- a/content/management/configuration-api/v3.4/index.mdx
+++ b/content/management/configuration-api/v3.4/index.mdx
@@ -3015,7 +3015,7 @@ Possible reasons: `manual`, `inactive`, `assigned`, `unassigned`, `other`.
 {
   "webhook_id": "<webhook_id>",
   "secret_key": "<secret_key>",
-  "action": "chat_access_revoked",
+  "action": "chat_transferred",
   "license_id": 104130623,
   "payload": {
     "chat_id": "PJ0MRSHTDG",

--- a/content/management/configuration-api/v3.4/index.mdx
+++ b/content/management/configuration-api/v3.4/index.mdx
@@ -2457,30 +2457,44 @@ Registers a webhook for the Client ID (application) provided in the request. To 
 #### Triggering actions
 
 __*__ The table below presents the possible values for the `action` parameter.
-
-| Possible action                                                       |                               Available filters |
-| --------------------------------------------------------------------- | ----------------------------------------------: |
-| [`incoming_chat`](#incoming_chat)                                     |                `chat_presence`, `only_my_chats` |
-| [`chat_deactivated`](#chat_deactivated)                               |                `chat_presence`, `only_my_chats` |
-| [`chat_access_updated`](#chat_access_updated)                         | `chat_presence`, `only_my_chats`, `source_type` |
-| [`user_added_to_chat`](#user_added_to_chat)                           |                `chat_presence`, `only_my_chats` |
-| [`user_removed_from_chat`](#user_removed_from_chat)                   |                `chat_presence`, `only_my_chats` |
-| [`incoming_event`](#incoming_event)                                   | `chat_presence`, `author_type`, `only_my_chats` |
-| [`event_updated`](#event_updated)                                     | `chat_presence`, `author_type`, `only_my_chats` |
-| [`incoming_rich_message_postback`](#incoming_rich_message_postback)   |                `chat_presence`, `only_my_chats` |
-| [`chat_properties_updated`](#chat_properties_updated)                 |                `chat_presence`, `only_my_chats` |
-| [`chat_properties_deleted`](#chat_properties_deleted)                 |                `chat_presence`, `only_my_chats` |
-| [`thread_properties_updated`](#thread_properties_updated)             |                `chat_presence`, `only_my_chats` |
-| [`thread_properties_deleted`](#thread_properties_deleted)             |                `chat_presence`, `only_my_chats` |
-| [`event_properties_updated`](#event_properties_updated)               |                `chat_presence`, `only_my_chats` |
-| [`event_properties_deleted`](#event_properties_deleted)               |                `chat_presence`, `only_my_chats` |
-| [`thread_tagged`](#thread_tagged)                                     |                `chat_presence`, `only_my_chats` |
-| [`thread_untagged`](#thread_untagged)                                 |                `chat_presence`, `only_my_chats` |
-| [`routing_status_set`](#routing_status_set)                           |                                               - |
-| [`agent_deleted`](#agent_deleted)                                     |                                     `agent_ids` |
-| [`incoming_customer`](#incoming_customer)                             |                                               - |
-| [`customer_session_fields_updated`](#customer_session_fields_updated) |                                 `chat_presence` |
-| [`events_marked_as_seen`](#events_marked_as_seen)                     |                `chat_presence`, `only_my_chats` |
+| Possible action                                                       |                                              Available filters |
+| --------------------------------------------------------------------- | -------------------------------------------------------------: |
+| [`incoming_chat`](#incoming_chat)                                     |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`chat_deactivated`](#chat_deactivated)                               |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`chat_access_updated`](#chat_access_updated)                         |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`chat_transferred`](#chat_transferred)                               |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`user_added_to_chat`](#user_added_to_chat)                           |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`user_removed_from_chat`](#user_removed_from_chat)                   |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`incoming_event`](#incoming_event)                                   | `chat_presence`, `author_type`, `only_my_chats`, `source_type` |
+| [`event_updated`](#event_updated)                                     | `chat_presence`, `author_type`, `only_my_chats`, `source_type` |
+| [`incoming_rich_message_postback`](#incoming_rich_message_postback)   |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`chat_properties_updated`](#chat_properties_updated)                 |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`chat_properties_deleted`](#chat_properties_deleted)                 |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`thread_properties_updated`](#thread_properties_updated)             |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`thread_properties_deleted`](#thread_properties_deleted)             |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`event_properties_updated`](#event_properties_updated)               |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`event_properties_deleted`](#event_properties_deleted)               |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`thread_tagged`](#thread_tagged)                                     |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`thread_untagged`](#thread_untagged)                                 |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`routing_status_set`](#routing_status_set)                           |                                     `agent_ids`, `source_type` |
+| [`incoming_customer`](#incoming_customer)                             |                                                  `source_type` |
+| [`customer_session_fields_updated`](#customer_session_fields_updated) |                                 `chat_presence`, `source_type` |
+| [`events_marked_as_seen`](#events_marked_as_seen)                     |                `chat_presence`, `only_my_chats`, `source_type` |
+| [`group_created`](#group_created)                                     |                                                  `source_type` |
+| [`group_updated`](#group_updated)                                     |                                                  `source_type` |
+| [`group_deleted`](#group_deleted)                                     |                                                  `source_type` |
+| [`agent_created`](#agent_created)                                     |                                                  `source_type` |
+| [`agent_updated`](#agent_updated)                                     |                                                  `source_type` |
+| [`agent_deleted`](#agent_deleted)                                     |                                                  `source_type` |
+| [`agent_suspended`](#agent_suspended)                                 |                                                  `source_type` |
+| [`agent_unsuspended`](#agent_unsuspended)                             |                                                  `source_type` |
+| [`agent_approved`](#agent_approved)                                   |                                                  `source_type` |
+| [`bot_created`](#bot_created)                                         |                                                  `source_type` |
+| [`bot_updated`](#bot_updated)                                         |                                                  `source_type` |
+| [`bot_deleted`](#bot_deleted)                                         |                                                  `source_type` |
+| [`auto_access_created`](#auto_access_created)                         |                                                  `source_type` |
+| [`auto_access_updated`](#auto_access_updated)                         |                                                  `source_type` |
+| [`auto_access_deleted`](#auto_access_deleted)                         |                                                  `source_type` |
 
 </Text>
 

--- a/content/management/configuration-api/v3.4/index.mdx
+++ b/content/management/configuration-api/v3.4/index.mdx
@@ -2941,7 +2941,7 @@ Informs that a chat was deactivated by closing the currently open thread.
 
 ### `chat_access_updated`
 
-Informs about the update of a user's access to a particular chat. It contains the updated [access](/messaging/agent-chat-api/v3.4/#access) data structure.
+Informs about the update of a user's access to a particular chat. It contains the updated [access](/messaging/agent-chat-api/v3.4/#access-1) data structure.
 
 #### Specifics
 
@@ -2955,7 +2955,7 @@ Informs about the update of a user's access to a particular chat. It contains th
 | Field    | Notes                                                                            |
 | -------- | -------------------------------------------------------------------------------- |
 | `id`     | Chat ID                                                                          |
-| `access` | The updated chat [access](/messaging/agent-chat-api/v3.4/#access) data structure |
+| `access` | The updated chat [access](/messaging/agent-chat-api/v3.4/#access-1) data structure |
 
 </Text>
 

--- a/content/management/configuration-api/v3.4/index.mdx
+++ b/content/management/configuration-api/v3.4/index.mdx
@@ -2941,7 +2941,7 @@ Informs that a chat was deactivated by closing the currently open thread.
 
 ### `chat_access_updated`
 
-Informs that a chat's access was changed. It contains full access of the chat.
+Informs about the update of a user's access to a particular chat. It contains the updated [access](/messaging/agent-chat-api/v3.4/#access) data structure.
 
 #### Specifics
 
@@ -2952,10 +2952,10 @@ Informs that a chat's access was changed. It contains full access of the chat.
 
 #### Webhook payload
 
-| Field    | Notes                   |
-| -------- | ----------------------- |
-| `id`     | Chat id                 |
-| `access` | Full access of the chat |
+| Field    | Notes                                                                            |
+| -------- | -------------------------------------------------------------------------------- |
+| `id`     | Chat ID                                                                          |
+| `access` | The updated chat [access](/messaging/agent-chat-api/v3.4/#access) data structure |
 
 </Text>
 

--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -30,11 +30,11 @@ The developer preview version provides a preview of the upcoming changes to the 
 ### Chats users
 
 - Users now have a new field, `visibility`.
-- The **Add User To Chat** method ([Web](/messaging/agent-chat-api/v3.4/#add-user-to-chat) & [RTM](/messaging/agent-chat-api/v3.4/rtm-reference/#add-user-to-chat)) always requires an active thread. The `require_active_thread` flag was removed.
+- The **Add User To Chat** method ([Web](/messaging/agent-chat-api/v3.4/#add-user-to-chat) & [RTM](/messaging/agent-chat-api/v3.4/rtm-reference/#add-user-to-chat)) now requires an active thread. The `require_active_thread` flag was removed.
 
 ### Chat access
-- The **Transfer Chat** method ([Web](/messaging/agent-chat-api/v3.4/#transfer-chat) & [RTM](/messaging/agent-chat-api/v3.4/rtm-reference/#transfer-chat)) always requires an active thread.
-- The **Grant Chat Access** and **Revoke Chat Access** methods were removed. Its use cases are now covered by **Transfer Chat** ([Web](/messaging/agent-chat-api/v3.4/#transfer-chat) & [RTM](/messaging/agent-chat-api/v3.4/rtm-reference/#transfer-chat)). The corresponding pushes, **chat_access_granted** and **chat_access_revoked**, were also removed.
+- The **Transfer Chat** method ([Web](/messaging/agent-chat-api/v3.4/#transfer-chat) & [RTM](/messaging/agent-chat-api/v3.4/rtm-reference/#transfer-chat)) now requires an active thread.
+- The **Grant Chat Access** and **Revoke Chat Access** methods were removed. Their use cases are now covered by **Transfer Chat** ([Web](/messaging/agent-chat-api/v3.4/#transfer-chat) & [RTM](/messaging/agent-chat-api/v3.4/rtm-reference/#transfer-chat)). The corresponding pushes, **chat_access_granted** and **chat_access_revoked**, were also removed and replaced by the [**chat_access_updated**](/messaging/agent-chat-api/v3.4/#chat-access-updated) push.
 
 ### Configuration
 

--- a/content/messaging/agent-chat-api/changelog/index.mdx
+++ b/content/messaging/agent-chat-api/changelog/index.mdx
@@ -32,6 +32,10 @@ The developer preview version provides a preview of the upcoming changes to the 
 - Users now have a new field, `visibility`.
 - The **Add User To Chat** method ([Web](/messaging/agent-chat-api/v3.4/#add-user-to-chat) & [RTM](/messaging/agent-chat-api/v3.4/rtm-reference/#add-user-to-chat)) always requires an active thread. The `require_active_thread` flag was removed.
 
+### Chat access
+- The **Transfer Chat** method ([Web](/messaging/agent-chat-api/v3.4/#transfer-chat) & [RTM](/messaging/agent-chat-api/v3.4/rtm-reference/#transfer-chat)) always requires an active thread.
+- The **Grant Chat Access** and **Revoke Chat Access** methods were removed. Its use cases are now covered by **Transfer Chat** ([Web](/messaging/agent-chat-api/v3.4/#transfer-chat) & [RTM](/messaging/agent-chat-api/v3.4/rtm-reference/#transfer-chat)). The corresponding pushes, **chat_access_granted** and **chat_access_revoked**, were also removed.
+
 ### Configuration
 
 - Updating license resources in [the Configuration API v3](/management/configuration-api/) now results in pushes informing agents about applied changes. These pushes are as follows:

--- a/content/messaging/agent-chat-api/index.mdx
+++ b/content/messaging/agent-chat-api/index.mdx
@@ -1449,7 +1449,7 @@ Transfers a chat to an agent or a group. When transferring directly to an agent,
 | Parameter     | Required | Data ype | Notes                                                                                                                           |
 | ------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `id`          | Yes      | `string` | Chat Id                                                                                                                         |
-| `target`      | No       | `object` | If missing, chat will be transferred within the current group.                                                                  |
+| `target`      | No       | `object` | If missing, the chat will be transferred within the current group.                                                              |
 | `target.type` | Yes      | `string` | `group` or `agent`                                                                                                              |
 | `target.ids`  | Yes      | `array`  | `group` or `agent` IDs array                                                                                                    |
 | `force`       | No       | `bool`   | If `true`, always transfers chats. Otherwise, fails when unable to assign any agent from the requested groups; default `false`. |

--- a/content/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -3789,7 +3789,7 @@ Informs that new, single access to a chat was granted. The existing access isn't
 
 | Field | Notes   |
 | ----- | ------- |
-| `id`  | Chat id |
+| `id`  | Chat ID |
 
 ### `chat_access_revoked`
 

--- a/content/messaging/agent-chat-api/v3.1/index.mdx
+++ b/content/messaging/agent-chat-api/v3.1/index.mdx
@@ -1659,7 +1659,7 @@ Transfers a chat to an Agent or a group. When transferring directly to an agent,
 | Parameter     | Required | Data ype | Notes                                                                                                                           |
 | ------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `chat_id`     | Yes      | `string` | Resource Id                                                                                                                     |
-| `target`      | No       | `object` | If missing, chat will be transferred within the current group.                                                                  |
+| `target`      | No       | `object` | If missing, the chat will be transferred within the current group.                                                              |
 | `target.type` | Yes      | `string` | `group` or `agent`                                                                                                              |
 | `target.ids`  | Yes      | `array`  | `group` or `agent` IDs array                                                                                                    |
 | `force`       | No       | `bool`   | If `true`, always transfers chats. Otherwise. fails when unable to assign any Agent from the requested groups; default `false`. |

--- a/content/messaging/agent-chat-api/v3.2/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/index.mdx
@@ -1366,7 +1366,7 @@ Transfers a chat to an Agent or a group. When transferring directly to an agent,
 | Parameter     | Required | Data ype | Notes                                                                                                                           |
 | ------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `chat_id`     | Yes      | `string` | Chat Id                                                                                                                         |
-| `target`      | No       | `object` | If missing, chat will be transferred within the current group.                                                                  |
+| `target`      | No       | `object` | If missing, the chat will be transferred within the current group.                                                              |
 | `target.type` | Yes      | `string` | `group` or `agent`                                                                                                              |
 | `target.ids`  | Yes      | `array`  | `group` or `agent` IDs array                                                                                                    |
 | `force`       | No       | `bool`   | If `true`, always transfers chats. Otherwise. fails when unable to assign any Agent from the requested groups; default `false`. |

--- a/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.2/rtm-reference/index.mdx
@@ -3568,7 +3568,7 @@ Informs that new, single access to a chat was granted. The existing access isn't
 
 | Field | Notes   |
 | ----- | ------- |
-| `id`  | Chat id |
+| `id`  | Chat ID |
 
 ### `chat_access_revoked`
 

--- a/content/messaging/agent-chat-api/v3.4/index.mdx
+++ b/content/messaging/agent-chat-api/v3.4/index.mdx
@@ -1361,7 +1361,7 @@ Transfers a chat to an agent or a group. The transferred chat must be active. Wh
 | Parameter     | Required | Data ype | Notes                                                                                                                                  |
 | ------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `id`          | Yes      | `string` | Chat Id                                                                                                                                |
-| `target`      | No       | `object` | If missing, chat will be transferred within the current group.                                                                         |
+| `target`      | No       | `object` | If missing, the chat will be transferred within the current group.                                                                     |
 | `target.type` | Yes      | `string` | `group` or `agent`                                                                                                                     |
 | `target.ids`  | Yes      | `array`  | `group` or `agent` IDs array                                                                                                           |
 | `force`       | No       | `bool`   | If `true`, always transfers active chats. Otherwise, fails when unable to assign any agent from the requested groups; default `false`. |

--- a/content/messaging/agent-chat-api/v3.4/index.mdx
+++ b/content/messaging/agent-chat-api/v3.4/index.mdx
@@ -560,7 +560,7 @@ curl -X POST \
 |                 |                                                                                                                                                                                                                                                                                                                                     |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`resume_chat`](#resume-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                                               |
-| **Chat access** | [`grant_chat_access`](#grant-chat-access) [`revoke_chat_access`](#revoke-chat-access) [`transfer_chat`](#transfer-chat)                                                                                                                                                                                                             |
+| **Chat access** | [`transfer_chat`](#transfer-chat)                                                                                                                                                                                                             |
 | **Chat users**  | [`add_user_to_chat`](#add-user-to-chat) [`remove_user_from_chat`](#remove-user-from-chat)                                                                                                                                                                                                                                           |
 | **Events**      | [`send_event`](#send-event) [`upload_file`](#upload-file) [`send_rich_message_postback`](#send-rich-message-postback)                                                                                                                                                                                                               |
 | **Properties**  | [`update_chat_properties`](#update-chat-properties) [`delete_chat_properties`](#delete-chat-properties) [`update_thread_properties`](#update-thread-properties) [`delete_thread_properties`](#delete-thread-properties) [`update_event_properties`](#update-event-properties) [`delete_event_properties`](#delete-event-properties) |
@@ -1343,109 +1343,9 @@ https://api.livechatinc.com/v3.4/agent/action/unfollow_chat \
 <Section>
 <Text>
 
-### Grant Chat Access
-
-Grants access to a new chat without overwriting the existing ones.
-
-#### Specifics
-
-|                        |                                                                                  |
-| ---------------------- | -------------------------------------------------------------------------------- |
-| **Method URL**         | `https://api.livechatinc.com/v3.4/agent/action/grant_chat_access`                |
-| **Required scopes**    | `chats--all:rw` `chats--access:rw`                                               |
-| **RTM API equivalent** | [`grant_chat_access`](rtm-reference/#grant-chat-access)                          |
-| **Webhook**            | [`chat_access_granted`](/management/configuration-api/v3.4/#chat_access_granted) |
-
-#### Request
-
-| Parameter     | Required | Data ype | Notes   |
-| ------------- | -------- | -------- | ------- |
-| `id`          | Yes      | `string` | Chat Id |
-| `access`      | Yes      | `object` |         |
-| `access.type` | Yes      | `string` | `group` |
-| `access.id`   | Yes      | any      |         |
-
-#### Response
-
-No response payload (`200 OK`).
-
-</Text>
-<Code>
-<CodeSample path={'REQUEST'}>
-
-```shell
-curl -X POST \
-https://api.livechatinc.com/v3.4/agent/action/grant_chat_access \
--H 'Authorization: Bearer <your_access_token>' \
--H 'Content-Type: application/json' \
--d '{
-  "id": "PW94SJTGW6",
-  "access": {
-    "type": "group",
-    "id": 19
-    }
-  }'
-```
-
-</CodeSample>
-</Code>
-</Section>
-
-<Section>
-<Text>
-
-### Revoke Chat Access
-
-#### Specifics
-
-|                        |                                                                                  |
-| ---------------------- | -------------------------------------------------------------------------------- |
-| **Method URL**         | `https://api.livechatinc.com/v3.4/agent/action/revoke_chat_access`               |
-| **Required scopes**    | `chats--all:rw` `chats--access:rw`                                               |
-| **RTM API equivalent** | [`revoke_chat_access`](rtm-reference/#revoke-chat-access)                        |
-| **Webhook**            | [`chat_access_revoked`](/management/configuration-api/v3.4/#chat_access_revoked) |
-
-#### Request
-
-| Parameter     | Required | Data type | Notes              |
-| ------------- | -------- | --------- | ------------------ |
-| `id`          | Yes      | `string`  | Chat Id            |
-| `access`      | Yes      | `object`  |                    |
-| `access.type` | Yes      | `string`  | `group` or `agent` |
-| `access.id`   | Yes      | `number`  |                    |
-
-#### Response
-
-No response payload (`200 OK`).
-
-</Text>
-<Code>
-<CodeSample path={'REQUEST'}>
-
-```shell
-curl -X POST \
-https://api.livechatinc.com/v3.4/agent/action/revoke_chat_access \
--H 'Authorization: Bearer <your_access_token>' \
--H 'Content-Type: application/json' \
--d '{
-   "id": "PW94SJTGW6",
-   "access": {
-     "type": "group",
-     "id": 19
-     }
-   }'
-```
-
-</CodeSample>
-</Code>
-</Section>
-
-<Section>
-<Text>
-
 ### Transfer Chat
 
-Transfers a chat to an agent or a group. When transferring directly to an agent, the agent must have access to the transferred chat.
+Transfers a chat to an agent or a group. The transferred chat must be active. When transferring directly to an agent, the agent must have access to the transferred chat.
 
 #### Specifics
 
@@ -1458,13 +1358,13 @@ Transfers a chat to an agent or a group. When transferring directly to an agent,
 
 #### Request
 
-| Parameter     | Required | Data ype | Notes                                                                                                                           |
-| ------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `id`          | Yes      | `string` | Chat Id                                                                                                                         |
-| `target`      | No       | `object` | If missing, chat will be transferred within the current group.                                                                  |
-| `target.type` | Yes      | `string` | `group` or `agent`                                                                                                              |
-| `target.ids`  | Yes      | `array`  | `group` or `agent` IDs array                                                                                                    |
-| `force`       | No       | `bool`   | If `true`, always transfers chats. Otherwise, fails when unable to assign any agent from the requested groups; default `false`. |
+| Parameter     | Required | Data ype | Notes                                                                                                                                  |
+| ------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`          | Yes      | `string` | Chat Id                                                                                                                                |
+| `target`      | No       | `object` | If missing, chat will be transferred within the current group.                                                                         |
+| `target.type` | Yes      | `string` | `group` or `agent`                                                                                                                     |
+| `target.ids`  | Yes      | `array`  | `group` or `agent` IDs array                                                                                                           |
+| `force`       | No       | `bool`   | If `true`, always transfers active chats. Otherwise, fails when unable to assign any agent from the requested groups; default `false`. |
 
 #### Response
 

--- a/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
@@ -3733,7 +3733,7 @@ Informs that several threads from a specific date range or with the same tag wer
 
 ### `chat_access_updated`
 
-Informs about the update of a user's access to a particular chat. It contains the updated [access](#access) data structure.
+Informs about the update of a user's access to a particular chat. It contains the updated [access](#access-1) data structure.
 
 <CodeResponse title={'Sample push payload'}>
 
@@ -3760,7 +3760,7 @@ Informs about the update of a user's access to a particular chat. It contains th
 | Field    | Notes                                             |
 | -------- | ------------------------------------------------- |
 | `id`     | Chat ID                                           |
-| `access` | The updated chat [access](#access) data structure |
+| `access` | The updated chat [access](#access-1) data structure |
 
 ### `chat_transferred`
 

--- a/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
@@ -571,7 +571,7 @@ Properties are **key-value storages**. They can be set within a chat, a thread, 
 |                 |                                                                                                                                                                                                                                                                                                                                     |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Chats**       | [`list_chats`](#list-chats) [`list_threads`](#list-threads) [`get_chat`](#get-chat) [`list_archives`](#list-archives) [`start_chat`](#start-chat) [`resume_chat`](#resume-chat) [`deactivate_chat`](#deactivate-chat) [`follow_chat`](#follow-chat) [`unfollow_chat`](#unfollow-chat)                                               |
-| **Chat access** | [`grant_chat_access`](#grant-chat-access) [`revoke_chat_access`](#revoke-chat-access) [`transfer_chat`](#transfer-chat)                                                                                                                                                                                                             |
+| **Chat access** | [`transfer_chat`](#transfer-chat)                                                                                                                                                                                                             |
 | **Chat users**  | [`add_user_to_chat`](#add-user-to-chat) [`remove_user_from_chat`](#remove-user-from-chat)                                                                                                                                                                                                                                           |
 | **Events**      | [`send_event`](#send-event) [`send_rich_message_postback`](#send-rich-message-postback)                                                                                                                                                                                                                                             |
 | **Properties**  | [`update_chat_properties`](#update-chat-properties) [`delete_chat_properties`](#delete-chat-properties) [`update_thread_properties`](#update-thread-properties) [`delete_thread_properties`](#delete-thread-properties) [`update_event_properties`](#update-event-properties) [`delete_event_properties`](#delete-event-properties) |
@@ -1458,131 +1458,9 @@ Removes the requester from the chat followers. After that, only key changes to t
 <Section>
 <Text>
 
-### Grant Chat Access
-
-Grants access to a new chat without overwriting the existing ones.
-
-#### Specifics
-
-|                        |                                               |
-| ---------------------- | --------------------------------------------- |
-| **Action**             | `grant_chat_access`                           |
-| **Required scopes**    | `chats--all:rw` `chats--access:rw`            |
-| **Web API equivalent** | [`grant_chat_access`](../#grant-chat-access)  |
-| **Push message**       | [`chat_access_granted`](#chat_access_granted) |
-
-#### Request
-
-| Parameter     | Required | Data ype | Notes   |
-| ------------- | -------- | -------- | ------- |
-| `id`          | Yes      | `string` | Chat Id |
-| `access`      | Yes      | `object` |         |
-| `access.type` | Yes      | `string` | `group` |
-| `access.id`   | Yes      | any      |         |
-
-</Text>
-<Code>
-<CodeSample path={'REQUEST'}>
-
-```json
-{
-  "action": "grant_chat_access",
-  "payload": {
-  "id": "PW94SJTGW6",
-  "access": {
-    "type": "group",
-    "id": 19
-  }
-  }
-}
-```
-
-</CodeSample>
-
-<CodeResponse>
-
-```json
-{
-  "request_id": "<request_id>", // optional
-  "action": "grant_chat_access",
-  "type": "response",
-  "success": true,
-  "payload": {
-  // no response payload
-  }
-}
-```
-
-</CodeResponse>
-</Code>
-</Section>
-
-<Section>
-<Text>
-
-### Revoke Chat Access
-
-#### Specifics
-
-|                        |                                                |
-| ---------------------- | ---------------------------------------------- |
-| **Action**             | `revoke_chat_access`                           |
-| **Required scopes**    | `chats--all:rw` `chats--access:rw`             |
-| **Web API equivalent** | [`revoke_chat_access`](../#revoke-chat-access) |
-| **Push message**       | [`chat_access_revoked`](#chat_access_revoked)  |
-
-#### Request
-
-| Parameter     | Required | Data type | Notes              |
-| ------------- | -------- | --------- | ------------------ |
-| `id`          | Yes      | `string`  | Chat Id            |
-| `access`      | Yes      | `object`  |                    |
-| `access.type` | Yes      | `string`  | `group` or `agent` |
-| `access.id`   | Yes      | `number`  |                    |
-
-</Text>
-<Code>
-<CodeSample path={'REQUEST'}>
-
-```json
-{
-  "action": "revoke_chat_access",
-  "payload": {
-  "id": "PW94SJTGW6",
-  "access": {
-    "type": "group",
-    "id": 19
-  }
-  }
-}
-```
-
-</CodeSample>
-
-<CodeResponse>
-
-```json
-{
-  "request_id": "<request_id>", // optional
-  "action": "revoke_chat_access",
-  "type": "response",
-  "success": true,
-  "payload": {
-  // no response payload
-  }
-}
-```
-
-</CodeResponse>
-</Code>
-</Section>
-
-<Section>
-<Text>
-
 ### Transfer Chat
 
-Transfers a chat to an agent or a group. When transferring directly to an agent, the agent must have access to the transferred chat.
+Transfers a chat to an agent or a group. The transferred chat must be active. When transferring directly to an agent, the agent must have access to the transferred chat.
 
 #### Specifics
 
@@ -3680,7 +3558,7 @@ Here's what you need to know about **pushes**:
 |                   |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Chats**         | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated) [`chat_deleted`](#chat_deleted) [`thread_deleted`](#thread_deleted) [`threads_deleted`](#threads_deleted)                                                                                                                                                                                                                                                                                                                                                                             |
-| **Chat access**   | [`chat_access_granted`](#chat_access_granted) [`chat_access_revoked`](#chat_access_revoked) [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **Chat access**   | [`chat_access_updated`](#chat_access_updated) [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | **Chat users**    | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | **Events**        | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | **Properties**    | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted)                                                                                                                                                                                                                 |
@@ -3853,9 +3731,9 @@ Informs that several threads from a specific date range or with the same tag wer
 
 ## Chat access
 
-### `chat_access_granted`
+### `chat_access_updated`
 
-Informs that new, single access to a chat was granted. The existing access isn't overwritten.
+Informs that a chat's access was changed. It contains full access of the chat.
 
 <CodeResponse title={'Sample push payload'}>
 
@@ -3863,7 +3741,7 @@ Informs that new, single access to a chat was granted. The existing access isn't
 {
   "id": "PJ0MRSHTDG",
   "access": {
-  "group_ids": [1]
+    "group_ids": [0, 1]
   }
 }
 ```
@@ -3874,44 +3752,15 @@ Informs that new, single access to a chat was granted. The existing access isn't
 
 |                        |                                                                                  |
 | ---------------------- | -------------------------------------------------------------------------------- |
-| **Action**             | `chat_access_granted`                                                            |
-| **Webhook equivalent** | [`chat_access_granted`](/management/configuration-api/v3.4/#chat_access_granted) |
+| **Action**             | `chat_access_updated`                                                            |
+| **Webhook equivalent** | [`chat_access_updated`](/management/configuration-api/v3.4/#chat_access_updated) |
 
 #### Push payload
 
-| Field | Notes   |
-| ----- | ------- |
-| `id`  | Chat id |
-
-### `chat_access_revoked`
-
-Informs that access to a certain chat was revoked.
-
-<CodeResponse title={'Sample push payload'}>
-
-```json
-{
-  "id": "PJ0MRSHTDG",
-  "access": {
-  "group_ids": [1]
-  }
-}
-```
-
-</CodeResponse>
-
-#### Specifics
-
-|                        |                                                                                  |
-| ---------------------- | -------------------------------------------------------------------------------- |
-| **Action**             | `chat_access_revoked`                                                            |
-| **Webhook equivalent** | [`chat_access_revoked`](/management/configuration-api/v3.4/#chat_access_revoked) |
-
-#### Push payload
-
-| Field | Notes   |
-| ----- | ------- |
-| `id`  | Chat Id |
+| Field    | Notes                   |
+| -------- | ----------------------- |
+| `id`     | Chat id                 |
+| `access` | Full access of the chat |
 
 ### `chat_transferred`
 

--- a/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
+++ b/content/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
@@ -3733,7 +3733,7 @@ Informs that several threads from a specific date range or with the same tag wer
 
 ### `chat_access_updated`
 
-Informs that a chat's access was changed. It contains full access of the chat.
+Informs about the update of a user's access to a particular chat. It contains the updated [access](#access) data structure.
 
 <CodeResponse title={'Sample push payload'}>
 
@@ -3757,10 +3757,10 @@ Informs that a chat's access was changed. It contains full access of the chat.
 
 #### Push payload
 
-| Field    | Notes                   |
-| -------- | ----------------------- |
-| `id`     | Chat id                 |
-| `access` | Full access of the chat |
+| Field    | Notes                                             |
+| -------- | ------------------------------------------------- |
+| `id`     | Chat ID                                           |
+| `access` | The updated chat [access](#access) data structure |
 
 ### `chat_transferred`
 

--- a/payloads/management/v3.4/configuration-api/responses/webhooks/listWebhookNames.json
+++ b/payloads/management/v3.4/configuration-api/responses/webhooks/listWebhookNames.json
@@ -6,7 +6,7 @@
         ]
     },
     {
-        "action": "chat_access_granted",
+        "action": "chat_access_updated",
         "filters": [
             "chat_presence",
             "only_my_chats"


### PR DESCRIPTION
# 🚀 Links

- [Feature branch](https://developers.labs.livechat.com/docs/feature/API-9179-no-access-change-inactive-chat)
- [Jira](https://livechatinc.atlassian.net/browse/API-9179)

# 📓 Description
Update methods/pushes/webhooks that modify chat access (`(grant|revoke)_chat_access`, `chat_access_(granted|revoked)`, new `chat_access_updated`).
Note that `transfer_chat` works only for active chats.
Fix available webhooks and their filters.
Fix payload of `chat_transferred` push.