### PR TITLE
Fix path to image in Global Accounts doc

### DIFF
--- a/src/pages/authorization/global-accounts/index.mdx
+++ b/src/pages/authorization/global-accounts/index.mdx
@@ -21,7 +21,7 @@ An [organization](#organization) must have at least one account assigned to it. 
 
 An account has individual [roles](#roles) in each organization it belongs to.
 
-![Global Accounts Flow](/images/livechat-global-accounts-flow.png)
+![Global Accounts Flow](/images/authorization/livechat-global-accounts-flow.png)
 
 # Organization
 


### PR DESCRIPTION
# 📓 Description

Fix for: 
https://developers.livechat.com/docs/authorization/global-accounts#account
![image](https://user-images.githubusercontent.com/42515529/128021338-e7a14747-dc7d-415b-8abf-3c8511d14195.png)

