### PR TITLE
[CW-2639] Emphasise the need of parsing the data from endpoint in Custom Identity Provider

### DIFF
--- a/src/pages/extending-chat-widget/custom-identity-provider/index.mdx
+++ b/src/pages/extending-chat-widget/custom-identity-provider/index.mdx
@@ -59,7 +59,10 @@ LiveChat authorization token you want to resolve in functions should contain the
 
 In order to get a Chat Widget token, you need to implement a function that calls the `https://accounts.livechat.com/customer/token` endpoint. To do so, you can follow [customer authorization flows](https://developers.livechat.com/docs/authorization/authorizing-api-calls/#customer-authorization-flows) or have a look at our [example](https://github.com/livechat/identity-provider-example/blob/master/lib/get-customer-token.ts) that uses cookies.
 
-The first time you execute this logic, the connection between our `customer_id` (`entity_id`) and the identity from your service doesn't exist yet. Start by creating a new customer identity. Next time you execute this logic, you'll be able to provide `entity_id`, and therefore, you will only need to refresh the token. Mind the fact that the [data](https://developers.livechat.com/docs/authorization/authorizing-api-calls/#response-4) returned from the endpoint is not 1:1 with the token shape described above. You'll have to make the following adjustments to your token before passing it further:
+The first time you execute this logic, the connection between our `customer_id` (`entity_id`) and the identity from your service doesn't exist yet. Start by creating a new customer identity. Next time you execute this logic, you'll be able to provide `entity_id`, and therefore, you will only need to refresh the token.
+
+**Mind the fact that the [data](https://developers.livechat.com/docs/authorization/authorizing-api-calls/#response-4) returned from the endpoint is not 1:1 with the token shape described above.** You'll have to make the following adjustments to your token before passing it further:
+- Rename all the keys from `snake_case` to `camelCase`
 - Add the `creationDate` and `licenseId` fields.
 - Multiply `expiresIn` by 1000. It's because we expect `expiresIn` to be expressed in milliseconds while the endpoint operates in seconds.
 

--- a/src/pages/extending-chat-widget/custom-identity-provider/index.mdx
+++ b/src/pages/extending-chat-widget/custom-identity-provider/index.mdx
@@ -61,7 +61,7 @@ In order to get a Chat Widget token, you need to implement a function that calls
 
 The first time you execute this logic, the connection between our `customer_id` (`entity_id`) and the identity from your service doesn't exist yet. Start by creating a new customer identity. Next time you execute this logic, you'll be able to provide `entity_id`, and therefore, you will only need to refresh the token.
 
-**Mind the fact that the [data](https://developers.livechat.com/docs/authorization/authorizing-api-calls/#response-4) returned from the endpoint is not 1:1 with the token shape described above.** You'll have to make the following adjustments to your token before passing it further:
+💡 **Mind the fact that the [data](https://developers.livechat.com/docs/authorization/authorizing-api-calls/#response-4) returned from the endpoint is not 1:1 with the token shape described above.** You'll have to make the following adjustments to your token before passing it further:
 - Rename all the keys from `snake_case` to `camelCase`
 - Add the `creationDate` and `licenseId` fields.
 - Multiply `expiresIn` by 1000. It's because we expect `expiresIn` to be expressed in milliseconds while the endpoint operates in seconds.


### PR DESCRIPTION
# ❗️ Feature branch / Deploy Preview

We suggest to name your branch with `feature/`, for example, `feature/DPS-2947`. See below notifications from **Netlify** about the url.

# 🚀 Links

Replace the placeholder data in links 👇

- [Jira](https://livechatinc.atlassian.net/browse/CW-2639)

# 📓 Description

Customers seems to miss the information about the need of data parsing before passing it to the widget. I've tried to catch more attention on that sentence by making it **bold**. Additionally, I've noticed that we don't mention the required shift from snake_case to camelCase explicitly.
