### PR TITLE
Mention base64 in PAT auth

### DIFF
--- a/src/pages/authorization/authorizing-api-calls/index.mdx
+++ b/src/pages/authorization/authorizing-api-calls/index.mdx
@@ -65,7 +65,7 @@ Start in <a href="https://developers.livechat.com/console/" target="_blank">Deve
 
 ### Step 2: Use your credentials to send the request
 
-Personal Access Tokens use the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#Basic_authentication_scheme/" target="_blank">Basic authentication scheme</a>. For that reason, you need a username and a password.
+Personal Access Tokens use the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#Basic_authentication_scheme/" target="_blank">Basic authentication scheme</a>. For that reason, you need a username and a password. Please note that with the BasicAuth, you need to encode your credentials using **base64**.
 
 Use:
 
@@ -1078,19 +1078,19 @@ URIs are composed of several parts:
 
 ## Examples
 
-|     | client redirect configuration | authorization redirect URI         | is valid |
-| --- | ----------------------------- | ---------------------------------- | -------- |
-| 1   | http://livechat.com           | http://livechat.com                | yes      |
-| 2   | http://livechat.com           | http://livechat.com/archives       | yes      |
-| 3   | http://livechat.com           | http://livechat.com/archives/../   | no       |
-| 4   | http://livechat.com/archives  | http://livechat.com                | no       |
-| 5   | http://livechat.com/archives  | http://livechat.com/archives       | yes      |
-| 6   | http://livechat.com/archives  | http://livechat.com/archives/chats | yes      |
-| 7   | <a href="http://localhost:3000">http://localhost:3000</a>         |  <a href="http://localhost:3000">http://localhost:3000</a>              | yes      |
-| 8   | http://127.0.0.1:3000         | http://127.0.0.1:3000              | yes      |
-| 9   |   <a href="http://localhost:3000">http://localhost:3000</a>        |   <a href="http://localhost:4000">http://localhost:4000</a>             | no       |
-| 10  | https://livechat.com          | http://livechat.com                | no       |
-| 11  | http://livechat.com           | https://livechat.com               | no       |
+|     | client redirect configuration                             | authorization redirect URI                                | is valid |
+| --- | --------------------------------------------------------- | --------------------------------------------------------- | -------- |
+| 1   | http://livechat.com                                       | http://livechat.com                                       | yes      |
+| 2   | http://livechat.com                                       | http://livechat.com/archives                              | yes      |
+| 3   | http://livechat.com                                       | http://livechat.com/archives/../                          | no       |
+| 4   | http://livechat.com/archives                              | http://livechat.com                                       | no       |
+| 5   | http://livechat.com/archives                              | http://livechat.com/archives                              | yes      |
+| 6   | http://livechat.com/archives                              | http://livechat.com/archives/chats                        | yes      |
+| 7   | <a href="http://localhost:3000">http://localhost:3000</a> | <a href="http://localhost:3000">http://localhost:3000</a> | yes      |
+| 8   | http://127.0.0.1:3000                                     | http://127.0.0.1:3000                                     | yes      |
+| 9   | <a href="http://localhost:3000">http://localhost:3000</a> | <a href="http://localhost:4000">http://localhost:4000</a> | no       |
+| 10  | https://livechat.com                                      | http://livechat.com                                       | no       |
+| 11  | http://livechat.com                                       | https://livechat.com                                      | no       |
 
 # Errors
 

--- a/src/pages/authorization/authorizing-api-calls/index.mdx
+++ b/src/pages/authorization/authorizing-api-calls/index.mdx
@@ -65,7 +65,7 @@ Start in <a href="https://developers.livechat.com/console/" target="_blank">Deve
 
 ### Step 2: Use your credentials to send the request
 
-Personal Access Tokens use the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#Basic_authentication_scheme/" target="_blank">Basic authentication scheme</a>. For that reason, you need a username and a password. Please note that with the BasicAuth, you need to encode your credentials using **base64**.
+Personal Access Tokens use the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#Basic_authentication_scheme/" target="_blank">Basic authentication scheme</a>. For that reason, you need a username and a password. Please note that with Basic Auth, you need to encode your credentials using **base64**.
 
 Use:
 


### PR DESCRIPTION
# 📓 Description

As suggested on #platform-docs we're adding information about encoding account ID and PAT into base64.