### PR TITLE
Mention PATs in Reports API

### DIFF
--- a/src/pages/authorization/sign-in-with-livechat/index.mdx
+++ b/src/pages/authorization/sign-in-with-livechat/index.mdx
@@ -506,7 +506,7 @@ If the authorization process fails, the promise will be rejected with an error. 
 
 Possible values:
 
-- `unauthorized` – The resource owner identity is uknown or the consent is missing.
+- `unauthorized` – The resource owner identity is unknown or the consent is missing.
 
 #### Authorization errors
 

--- a/src/pages/data-reporting/reports-api/index.mdx
+++ b/src/pages/data-reporting/reports-api/index.mdx
@@ -19,7 +19,10 @@ This document describes the **LiveChat Reports API v3.3**. This is the latest st
 
 ## Authorization
 
-To call the Reports API, you need to use a Bearer access token. [Learn how to get it.](/authorization/authorizing-api-calls/#implicit-grant)
+You can authorize your calls to the Reports API using one of the following methods:
+
+- [Bearer Token](/authorization/authorizing-api-calls/#implicit-grant)
+- [Basic Auth (Personal Access Tokens)](/authorization/authorizing-api-calls/#personal-access-tokens)
 
 ## Postman collection
 

--- a/src/pages/data-reporting/reports-api/v3.2/index.mdx
+++ b/src/pages/data-reporting/reports-api/v3.2/index.mdx
@@ -19,7 +19,10 @@ This document describes the **LiveChat Reports API v3.2**. This is the legacy ve
 
 ## Authorization
 
-To call the Reports API, you need to use a Bearer access token. [Learn how to get it.](/authorization/authorizing-api-calls/#implicit-grant)
+You can authorize your calls to the Reports API using one of the following methods:
+
+- [Bearer Token](/authorization/authorizing-api-calls/#implicit-grant)
+- [Basic Auth (Personal Access Tokens)](/authorization/authorizing-api-calls/#personal-access-tokens)
 
 ## Postman Collection
 

--- a/src/pages/data-reporting/reports-api/v3.4/index.mdx
+++ b/src/pages/data-reporting/reports-api/v3.4/index.mdx
@@ -21,7 +21,10 @@ This document describes the **LiveChat Reports API v3.4**. This is the developer
 
 ## Authorization
 
-To call the Reports API, you need to use a Bearer access token. [Learn how to get it.](/authorization/authorizing-api-calls/#implicit-grant)
+You can authorize your calls to the Reports API using one of the following methods:
+
+- [Bearer Token](/authorization/authorizing-api-calls/#implicit-grant)
+- [Basic Auth (Personal Access Tokens)](/authorization/authorizing-api-calls/#personal-access-tokens)
 
 # Methods
 
@@ -49,10 +52,10 @@ To call the Reports API, you need to use a Bearer access token. [Learn how to ge
 
 ## Available methods
 
-|            |                                                                                                                                                   |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+|            |                                                                                                                                                                               |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Chats**  | [`agents_chatting_duration`](#agents-chatting-duration) [`tags`](#tags) [`total_chats`](#total-chats) [`ratings`](#ratings) [`ranking`](#ranking) [`engagement`](#engagement) |
-| **Agents** | [`availability`](#availability)                                                                                                                   |
+| **Agents** | [`availability`](#availability)                                                                                                                                               |
 
 ## Available parameters and filters
 
@@ -439,11 +442,11 @@ Shows the distribution of chats based on [engagement](https://www.livechat.com/h
 
 #### Specifics
 
-|                     |                                                              |
-| ------------------- | ------------------------------------------------------------ |
+|                     |                                                             |
+| ------------------- | ----------------------------------------------------------- |
 | **Method URL**      | `https://api.livechatinc.com/v3.4/reports/chats/engagement` |
-| **HTTP method**     | POST, GET                                                    |
-| **Required scopes** | `reports_read`                                               |
+| **HTTP method**     | POST, GET                                                   |
+| **Required scopes** | `reports_read`                                              |
 
 #### Request
 
@@ -452,7 +455,7 @@ See [available parameters and filters](#available-parameters-and-filters).
 #### Response
 
 | Field                         | Notes                                                                            |
-|-------------------------------|----------------------------------------------------------------------------------|
+| ----------------------------- | -------------------------------------------------------------------------------- |
 | `total`                       | The total number of chats in the specified date range.                           |
 | `records`                     | Contains the `distribution` objects, for example, `day`.                         |
 | `records.day.total`           | The total number of chats that `day`.                                            |

--- a/src/pages/messaging/chat-sdk/index.mdx
+++ b/src/pages/messaging/chat-sdk/index.mdx
@@ -268,8 +268,7 @@ Here's what you can listen for:
 
 # Simple Agent
 
-To show you **Chat SDK** in action, we've prepared a sample app, **Simple Agent** . It's primary function is to send text messages. Apart from that, it gives you access to previous conversations, 
-as well as the info about the current Agent.
+To show you **Chat SDK** in action, we've prepared a sample app, **Simple Agent** . Its primary function is to send text messages. Apart from that, it gives you access to previous conversations, as well as the info about the current Agent.
 
 <img alt="LiveChat Chat SDK" src="/images/messaging/livechat-chat-sdk.png" width="800px" height="585px"/>
 


### PR DESCRIPTION
# 📓 Description
- Users can now use PATs to authorize calls to Reports API.
- A couple typo/link fixes
