### PR TITLE
Fixed example code with token caching

### DIFF
--- a/src/pages/extending-chat-widget/custom-identity-provider/index.mdx
+++ b/src/pages/extending-chat-widget/custom-identity-provider/index.mdx
@@ -144,7 +144,7 @@ window.__lc.custom_identity_provider = () => {
 
     const isExpired = ({ creationDate, expiresIn }) => Date.now() >= creationDate + expiresIn
 
-    let token = window.sessionStorage.getItem(cacheKey)
+    const token = window.sessionStorage.getItem(cacheKey)
     if (token) {
         cachedToken = JSON.parse(token)
     }


### PR DESCRIPTION
* Fixed incorrect `.then()` on `sessionStorage.getItem` which isn't a promise-based API
* Removed unneeded `retrievingToken` state flag
* Fixed whitespace