### PR TITLE
Fixed invalidate() method in cached token example

### DIFF
--- a/src/pages/extending-chat-widget/custom-identity-provider/index.mdx
+++ b/src/pages/extending-chat-widget/custom-identity-provider/index.mdx
@@ -179,15 +179,15 @@ window.__lc.custom_identity_provider = () => {
     const hasToken = () => Promise.resolve(!!cachedToken)
 
     const invalidate = () => {
-	cachedToken = null
-	return storage.removeItem(cacheKey)
+        cachedToken = null
+        window.sessionStorage.removeItem(cacheKey)
     }
 
     return {
-	getToken,
+        getToken,
         getFreshToken,
-	hasToken,
-	invalidate,
+        hasToken,
+        invalidate,
     }
  }
 ```


### PR DESCRIPTION
* fixed `invalidate()` method (it used inexistent `storage` object)
* fixed whitespace