### PR TITLE
Fix copy explaining token prefixes and update OAuth2.0 to 2.1

### DIFF
--- a/src/pages/extending-agent-app/agent-app-sdk/index.mdx
+++ b/src/pages/extending-agent-app/agent-app-sdk/index.mdx
@@ -391,7 +391,7 @@ If you're building your own widget and you need to interact with the Agent App, 
 
 ## Accessing LiveChat data
 
-You can leverage the OAuth2.0 authorization flow to use all of LiveChat APIs. Head to [Sign in with LiveChat](/getting-started/authorization/sign-in-with-livechat/) docs for more information.
+You can leverage the OAuth 2.1 authorization flow to use all of LiveChat APIs. Head to [Sign in with LiveChat](/getting-started/authorization/sign-in-with-livechat/) docs for more information.
 
 ## Layout and Styling
 

--- a/src/pages/getting-started/livechat-apps/index.mdx
+++ b/src/pages/getting-started/livechat-apps/index.mdx
@@ -73,7 +73,7 @@ Agenda:
 
 An app is anything that LiveChat Platform is able to interpret. It could be an integration with a 3rd party service, a custom plugin to display additional visitor details or a chat widget theme. We constantly work to introduce new types of apps and ways of integrating with LiveChat.
 
-- **From developer perspective:** <br/>Technically speaking, every app a set of attributes (you can think of it as a JSON file). These attributes define the type and meta details of the app. Every app can also have a OAuth2.0 Client associated. Every app instance (installation) is associated with dedicated authorization entities.
+- **From developer perspective:** <br/>Technically speaking, every app a set of attributes (you can think of it as a JSON file). These attributes define the type and meta details of the app. Every app can also have a OAuth 2.1 Client associated. Every app instance (installation) is associated with dedicated authorization entities.
 
 - **From business perspective:** <br/>The primary goal of an app is to abstract some functionality in an installable package, which can be published and distributed at the [Apps Marketplace](https://my.livechatinc.com/marketplace). App can also remain private and available only for the license it was created on.
 

--- a/src/pages/management/configuration-api/index.mdx
+++ b/src/pages/management/configuration-api/index.mdx
@@ -24,9 +24,9 @@ Authentication for Configuration API is handled by access tokens. Find out how t
 
 LiveChat system operates in two data centers: `dal` (USA) and `fra` (Europe). The default data center is `dal`.
 
-All the LiveChat OAuth2.0 access tokens have a prefix: `dal-` or `fra-`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
+All the LiveChat OAuth 2.1 access tokens have a prefix: `dal:` or `fra:`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
 
-Summing up, if the user token starts with `fra-`, you should add the `X-Region: fra header`. If the token starts with `dal-`, you don’t have to specify the header.
+Summing up, if the user token starts with `fra`, you should add the `X-Region: fra` header. If the token starts with `dal`, you don’t have to specify the header.
 
 ## Propagation delay
 

--- a/src/pages/management/configuration-api/v2.0/index.mdx
+++ b/src/pages/management/configuration-api/v2.0/index.mdx
@@ -41,9 +41,9 @@ The next segment of the URL path depends on the type of your request. For exampl
 
 LiveChat system operates in two data centers: `dal` and `fra`. The default data center is `dal`.
 
-All the LiveChat OAuth2.0 access tokens have a prefix: `dal-` or `fra-`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
+All the LiveChat OAuth 2.1 access tokens have a prefix: `dal:` or `fra:`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
 
-For example: if the user token starts with `fra-`, you should add `X-Region: fra` header. If the token starts with `dal-` you don't have to specify the header.
+For example: if the user token starts with `fra`, you should add `X-Region: fra` header. If the token starts with `dal` you don't have to specify the header.
 
 ## Authentication
 

--- a/src/pages/management/configuration-api/v3.1/index.mdx
+++ b/src/pages/management/configuration-api/v3.1/index.mdx
@@ -24,9 +24,9 @@ Authentication for Configuration API is handled by access tokens. Find out how t
 
 LiveChat system operates in two data centers: `dal` (USA) and `fra` (Europe). The default data center is `dal`.
 
-All the LiveChat OAuth2.0 access tokens have a prefix: `dal-` or `fra-`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
+All the LiveChat OAuth 2.1 access tokens have a prefix: `dal:` or `fra:`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
 
-Summing up, if the user token starts with `fra-`, you should add the `X-Region: fra header`. If the token starts with `dal-`, you don’t have to specify the header.
+Summing up, if the user token starts with `fra`, you should add the `X-Region: fra` header. If the token starts with `dal`, you don’t have to specify the header.
 
 ## Propagation delay
 

--- a/src/pages/management/configuration-api/v3.2/index.mdx
+++ b/src/pages/management/configuration-api/v3.2/index.mdx
@@ -24,9 +24,9 @@ Authentication for Configuration API is handled by access tokens. Find out how t
 
 LiveChat system operates in two data centers: `dal` (USA) and `fra` (Europe). The default data center is `dal`.
 
-All the LiveChat OAuth2.0 access tokens have a prefix: `dal-` or `fra-`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
+All the LiveChat OAuth 2.1 access tokens have a prefix: `dal:` or `fra:`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
 
-Summing up, if the user token starts with `fra-`, you should add the `X-Region: fra header`. If the token starts with `dal-`, you don’t have to specify the header.
+Summing up, if the user token starts with `fra`, you should add the `X-Region: fra` header. If the token starts with `dal`, you don’t have to specify the header.
 
 ## Propagation delay
 

--- a/src/pages/management/configuration-api/v3.4/index.mdx
+++ b/src/pages/management/configuration-api/v3.4/index.mdx
@@ -26,9 +26,9 @@ Authentication for Configuration API is handled by access tokens. Find out how t
 
 LiveChat system operates in two data centers: `dal` (USA) and `fra` (Europe). The default data center is `dal`.
 
-All the LiveChat OAuth2.0 access tokens have a prefix: `dal-` or `fra-`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
+All the LiveChat OAuth 2.1 access tokens have a prefix: `dal:` or `fra:`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
 
-Summing up, if the user token starts with `fra-`, you should add the `X-Region: fra header`. If the token starts with `dal-`, you don’t have to specify the header.
+Summing up, if the user token starts with `fra`, you should add the `X-Region: fra` header. If the token starts with `dal`, you don’t have to specify the header.
 
 ## Propagation delay
 

--- a/src/pages/messaging/agent-chat-api/index.mdx
+++ b/src/pages/messaging/agent-chat-api/index.mdx
@@ -42,9 +42,9 @@ All authorization scopes are listed in the [Scopes](/getting-started/authorizati
 
 LiveChat system operates in two data centers: `dal` (USA) and `fra` (Europe). The default data center is `dal`.
 
-All the LiveChat OAuth2.0 access tokens have a prefix: `dal-` or `fra-`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
+All the LiveChat OAuth 2.1 access tokens have a prefix: `dal:` or `fra:`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
 
-Summing up, if the user token starts with `fra-`, you should add the `X-Region: fra` header. If the token starts with `dal-`, you don’t have to specify the header.
+Summing up, if the user token starts with `fra`, you should add the `X-Region: fra` header. If the token starts with `dal`, you don’t have to specify the header.
 
 ## Rate limits
 

--- a/src/pages/messaging/agent-chat-api/v3.1/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.1/index.mdx
@@ -42,9 +42,9 @@ All authorization scopes are listed in the [Scopes](/getting-started/authorizati
 
 LiveChat system operates in two data centers: `dal` (USA) and `fra` (Europe). The default data center is `dal`.
 
-All the LiveChat OAuth2.0 access tokens have a prefix: `dal-` or `fra-`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
+All the LiveChat OAuth 2.1 access tokens have a prefix: `dal:` or `fra:`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
 
-Summing up, if the user token starts with `fra-`, you should add the `X-Region: fra` header. If the token starts with `dal-`, you don’t have to specify the header.
+Summing up, if the user token starts with `fra`, you should add the `X-Region: fra` header. If the token starts with `dal`, you don’t have to specify the header.
 
 ## Rate limits
 

--- a/src/pages/messaging/agent-chat-api/v3.2/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.2/index.mdx
@@ -42,9 +42,9 @@ All authorization scopes are listed in the [Scopes](/getting-started/authorizati
 
 LiveChat system operates in two data centers: `dal` (USA) and `fra` (Europe). The default data center is `dal`.
 
-All the LiveChat OAuth2.0 access tokens have a prefix: `dal-` or `fra-`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
+All the LiveChat OAuth 2.1 access tokens have a prefix: `dal:` or `fra:`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
 
-Summing up, if the user token starts with `fra-`, you should add the `X-Region: fra` header. If the token starts with `dal-`, you don’t have to specify the header.
+Summing up, if the user token starts with `fra`, you should add the `X-Region: fra` header. If the token starts with `dal`, you don’t have to specify the header.
 
 ## Rate limits
 

--- a/src/pages/messaging/agent-chat-api/v3.4/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.4/index.mdx
@@ -44,9 +44,9 @@ All authorization scopes are listed in the [Scopes](/getting-started/authorizati
 
 LiveChat system operates in two data centers: `dal` (USA) and `fra` (Europe). The default data center is `dal`.
 
-All the LiveChat OAuth2.0 access tokens have a prefix: `dal-` or `fra-`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
+All the LiveChat OAuth 2.1 access tokens have a prefix: `dal:` or `fra:`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
 
-Summing up, if the user token starts with `fra-`, you should add the `X-Region: fra` header. If the token starts with `dal-`, you don’t have to specify the header.
+Summing up, if the user token starts with `fra`, you should add the `X-Region: fra` header. If the token starts with `dal`, you don’t have to specify the header.
 
 ## Rate limits
 
@@ -470,7 +470,7 @@ The list classification is based on threads; 1 chat per 1 thread. Thus, the same
 | `filters.goals.<filter_type>`                                    | No       | `any`     |                                                                                                                       |
 | `filters.surveys.<survey>`                                       | No       | `array`   | **\*\*\*** **described below**                                                                                        |
 | `filters.event_types.<event_type_filter_type>`                   | No       | `any`     | **\*\*\*\*** **described below**                                                                                      |
-| `filters.greetings.<greetings_filter_type>`                      | No       | `any`     | **\*\*\*\*\*\*** **described below**                                                                                      |
+| `filters.greetings.<greetings_filter_type>`                      | No       | `any`     | **\*\*\*\*\*\*** **described below**                                                                                  |
 | `page_id`                                                        | No       | `string`  |                                                                                                                       |
 | `sort_order` **\*\*\*\*\***                                      | No       | `string`  | Default: `desc`                                                                                                       |
 | `limit`                                                          | No       | `number`  | Default: 10, min: 1, max: 100                                                                                         |

--- a/src/pages/messaging/customer-chat-api/index.mdx
+++ b/src/pages/messaging/customer-chat-api/index.mdx
@@ -34,9 +34,9 @@ If you're wondering which API to use - Customer Chat **RTM API** or **Web API**,
 
 LiveChat system operates in two data centers: `dal` (USA) and `fra` (Europe). The default data center is `dal`.
 
-All the LiveChat OAuth2.0 access tokens have a prefix: `dal-` or `fra-`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
+All the LiveChat OAuth 2.1 access tokens have a prefix: `dal:` or `fra:`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
 
-Summing up, if the user token starts with `fra-`, you should add the `X-Region: fra` header. If the token starts with, `dal-` you don’t have to specify the header.
+Summing up, if the user token starts with `fra`, you should add the `X-Region: fra` header. If the token starts with, `dal:` you don’t have to specify the header.
 
 ## Pagination
 

--- a/src/pages/messaging/customer-chat-api/v3.1/index.mdx
+++ b/src/pages/messaging/customer-chat-api/v3.1/index.mdx
@@ -34,9 +34,9 @@ If you're wondering which API to use - Customer Chat **RTM API** or **Web API**,
 
 LiveChat system operates in two data centers: `dal` (USA) and `fra` (Europe). The default data center is `dal`.
 
-All the LiveChat OAuth2.0 access tokens have a prefix: `dal-` or `fra-`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
+All the LiveChat OAuth 2.1 access tokens have a prefix: `dal:` or `fra:`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
 
-Summing up, if the user token starts with `fra-`, you should add the `X-Region: fra` header. If the token starts with, `dal-` you don’t have to specify the header.
+Summing up, if the user token starts with `fra`, you should add the `X-Region: fra` header. If the token starts with, `dal:` you don’t have to specify the header.
 
 ## Postman Collection
 

--- a/src/pages/messaging/customer-chat-api/v3.2/index.mdx
+++ b/src/pages/messaging/customer-chat-api/v3.2/index.mdx
@@ -34,9 +34,9 @@ If you're wondering which API to use - Customer Chat **RTM API** or **Web API**,
 
 LiveChat system operates in two data centers: `dal` (USA) and `fra` (Europe). The default data center is `dal`.
 
-All the LiveChat OAuth2.0 access tokens have a prefix: `dal-` or `fra-`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
+All the LiveChat OAuth 2.1 access tokens have a prefix: `dal:` or `fra:`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
 
-Summing up, if the user token starts with `fra-`, you should add the `X-Region: fra` header. If the token starts with, `dal-` you don’t have to specify the header.
+Summing up, if the user token starts with `fra`, you should add the `X-Region: fra` header. If the token starts with, `dal:` you don’t have to specify the header.
 
 ## Postman Collection
 

--- a/src/pages/messaging/customer-chat-api/v3.4/index.mdx
+++ b/src/pages/messaging/customer-chat-api/v3.4/index.mdx
@@ -36,9 +36,9 @@ If you're wondering which API to use - Customer Chat **RTM API** or **Web API**,
 
 LiveChat system operates in two data centers: `dal` (USA) and `fra` (Europe). The default data center is `dal`.
 
-All the LiveChat OAuth2.0 access tokens have a prefix: `dal-` or `fra-`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
+All the LiveChat OAuth 2.1 access tokens have a prefix: `dal:` or `fra:`. This prefix indicates the data center they belong to. If you need to specify the data center while making an API call, simply add the `X-Region: <token_prefix>` optional header.
 
-Summing up, if the user token starts with `fra-`, you should add the `X-Region: fra` header. If the token starts with, `dal-` you don’t have to specify the header.
+Summing up, if the user token starts with `fra`, you should add the `X-Region: fra` header. If the token starts with, `dal:` you don’t have to specify the header.
 
 ## Pagination
 


### PR DESCRIPTION
# 📓 Description
- Fix copy explaining token prefixes
- Update OAuth2.0 to 2.1