### PR TITLE
API-9908: check redirect_uri only in grant_type=cookie; don't validat…

### DIFF
--- a/src/configs/redoc/customer-accounts-api/spec.yml
+++ b/src/configs/redoc/customer-accounts-api/spec.yml
@@ -76,8 +76,6 @@ paths:
                       - invalid_request
                       - unauthorized_client
                       - access_denied
-                      - unsupported_response_type
-                      - invalid_scope
                       - server_error
                       - temporarily_unavailable
                       - unsupported_grant_type
@@ -118,12 +116,6 @@ paths:
                     - identity_token
                   example: agent_token
                   description: Grant type
-                response_type:
-                  type: string
-                  enum:
-                    - token
-                  example: token
-                  description: Response type
                 client_id:
                   type: string
                   format: hex
@@ -134,7 +126,7 @@ paths:
                   format: url
                   example: https://my-application.com
                   description: >-
-                    Redirect URI; default: the value of the `Origin` header; required only if `grant_type=cookie`
+                    Redirect URI; default: the value of the `Origin` header; it can be used only for `grant_type=cookie`
                 license_id:
                   type: integer
                   format: uint64
@@ -165,7 +157,6 @@ paths:
 
               required:
                 - grant_type
-                - response_type
                 - client_id
       responses:
         '200':

--- a/src/configs/redoc/customer-accounts-api/specv2.yml
+++ b/src/configs/redoc/customer-accounts-api/specv2.yml
@@ -76,8 +76,6 @@ paths:
                       - invalid_request
                       - unauthorized_client
                       - access_denied
-                      - unsupported_response_type
-                      - invalid_scope
                       - server_error
                       - temporarily_unavailable
                       - unsupported_grant_type
@@ -118,12 +116,6 @@ paths:
                     - identity_token
                   example: agent_token
                   description: Grant type
-                response_type:
-                  type: string
-                  enum:
-                    - token
-                  example: token
-                  description: Response type
                 client_id:
                   type: string
                   format: hex
@@ -134,7 +126,7 @@ paths:
                   format: url
                   example: https://my-application.com
                   description: >-
-                    Redirect URI; default: the value of the `Origin` header; required only if `grant_type=cookie`
+                    Redirect URI; default: the value of the `Origin` header; it can be used only for `grant_type=cookie`
                 organization_id:
                   type: string
                   format: uuid
@@ -165,7 +157,6 @@ paths:
 
               required:
                 - grant_type
-                - response_type
                 - client_id
       responses:
         '200':
@@ -354,12 +345,6 @@ paths:
                     - identity_token
                   example: agent_token
                   description: Grant type
-                response_type:
-                  type: string
-                  enum:
-                    - token
-                  example: token
-                  description: Response type
                 client_id:
                   type: string
                   format: hex
@@ -370,7 +355,7 @@ paths:
                   format: url
                   example: https://my-application.com
                   description: >-
-                    Redirect URI; default: the value of the `Origin` header; required only if `grant_type=cookie`
+                    Redirect URI; default: the value of the `Origin` header; it can be used only for `grant_type=cookie`
                 license_id:
                   type: integer
                   format: uint64
@@ -401,7 +386,6 @@ paths:
 
               required:
                 - grant_type
-                - response_type
                 - client_id
       responses:
         '200':
@@ -467,8 +451,6 @@ paths:
                       - invalid_request
                       - unauthorized_client
                       - access_denied
-                      - unsupported_response_type
-                      - invalid_scope
                       - server_error
                       - temporarily_unavailable
                       - unsupported_grant_type

--- a/src/pages/authorization/authorizing-api-calls/index.mdx
+++ b/src/pages/authorization/authorizing-api-calls/index.mdx
@@ -851,6 +851,7 @@ curl "https://accounts.livechat.com/customer/token" \
   -H "Authorization: Bearer <access_token>" \
   -X POST
   -d '{
+    "grant_type": "agent_token",
     "client_id": "9cbf3a968289727cb3cdfe83ab1d9836",
     "response_type": "token"
       }'

--- a/src/pages/authorization/authorizing-api-calls/index.mdx
+++ b/src/pages/authorization/authorizing-api-calls/index.mdx
@@ -724,7 +724,6 @@ https://accounts.livechat.com/customer/token
 | --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `grant_type`    | yes      | Use `cookie` for this authorization flow                                                                                                                                                                                  |
 | `client_id`     | yes      | Client ID of your application                                                                                                                                                                                             |
-| `response_type` | yes      | Value: `token`                                                                                                                                                                                                            |
 | `license_id`    | yes      | License ID for which the token is being issued                                                                                                                                                                            |
 | `redirect_uri`  | no       | One of the URIs defined in the Authorization block during app configuration. The LiveChat OAuth Server will redirect the user back to this URI after successful authorization. Default: the value of the `Origin` header. |
 
@@ -762,7 +761,6 @@ curl "https://accounts.livechat.com/customer/token" \
   -d '{
     "grant_type": "cookie",
     "client_id": "9cbf3a968289727cb3cdfe83ab1d9836",
-    "response_type": "token",
     "license_id": 2491303,
     "redirect_uri": "https://my-application.com"
       }'
@@ -828,8 +826,6 @@ Remember to authorize your request using the `Authorization` header with an **ag
 | --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `grant_type`    | yes      | Use `agent_token` for this authorization flow.                                                                                                                                             |
 | `client_id`     | yes      | Client ID of your application                                                                                                                                                              |
-| `response_type` | yes      | Value: `token`                                                                                                                                                                             |
-| `redirect_uri`  | yes      | One of the URIs defined in the Authorization block during app configuration in Developer Console. This URI will receive the `access_token`.                                                |
 | `entity_id`     | no       | Customer ID. If you don't specify it, new customer identity will be created. Specify it if you want to [acquire a new token for an existing customer identity](#case-existing-customer-1). |
 
 #### Response
@@ -855,10 +851,8 @@ curl "https://accounts.livechat.com/customer/token" \
   -H "Authorization: Bearer <access_token>" \
   -X POST
   -d '{
-    "grant_type": "agent_token",
     "client_id": "9cbf3a968289727cb3cdfe83ab1d9836",
-    "response_type": "token",
-    "redirect_uri": "https://my-application.com"
+    "response_type": "token"
       }'
 ```
 
@@ -899,7 +893,6 @@ curl "https://accounts.livechat.com/customer/token" \
   -d '{
     "grant_type": "agent_token",
     "client_id": "9cbf3a968289727cb3cdfe83ab1d9836",
-    "response_type": "token",
     "entity_id: "bf18d1a8-1afe-4a3e-4cc0-a3148f1143db"
       }'
 ```
@@ -1012,7 +1005,6 @@ No authorization is required for this call.
 | --------------- | -------- | ----------------------------------------------------------------- |
 | `grant_type`    | yes      | Use `identity_token` for this authorization flow.                 |
 | `client_id`     | yes      | Client ID of your application                                     |
-| `response_type` | yes      | Value: `token`                                                    |
 | `code`          | yes      | **identity transfer token**                                       |
 | `code_verifier` | no       | Code verifier; as described in [PKCE extension](#pkce-extension). |
 
@@ -1038,7 +1030,6 @@ curl "https://accounts.livechat.com/customer/token" \
   -d '{
     "grant_type": "identity_token",
     "client_id": "9cbf3a968289727cb3cdfe83ab1d9836",
-    "response_type": "token",
     "code": "dal:test_SZhSSbShcZxrv580FA"
 }'
 ```


### PR DESCRIPTION
…e response_type anymore

[Jira](https://livechatinc.atlassian.net/browse/API-9908)

# 📓 Description

Two changes:
* check `redirect_uri` only when `grant_type=cookie`
* don't require and validate `response_type` anymore - it was stupid to require a param with only 1 value possible