### PR TITLE
Fix code sample in Customer Identity Provider

### DIFF
--- a/src/pages/extending-chat-widget/custom-identity-provider/index.mdx
+++ b/src/pages/extending-chat-widget/custom-identity-provider/index.mdx
@@ -117,6 +117,7 @@ If you don't need to cache the token, the fetching logic shall occur on every re
                 tokenPromise = null
                 return response
             })
+        return tokenPromise
     }
 
     return {


### PR DESCRIPTION
# Deploy preview

Scroll down for the link to the deploy preview.

# Links

Replace the placeholder data in links 👇
n/a
- [Jira](https://livechatinc.atlassian.net/browse/XXX-XXX)

# Description

@bolchowka noticed that the code example in [Customer Identity Provider](https://developers.livechat.com/docs/extending-chat-widget/custom-identity-provider#without-caching) (w/o caching) won't work because `fetchToken()` function does not return a promise - it only assigns one. The additional return should resolve the confusion 😉
