### PR TITLE
Improve copy in Register Webhooks

### DIFF
--- a/src/pages/management/configuration-api/index.mdx
+++ b/src/pages/management/configuration-api/index.mdx
@@ -2462,7 +2462,7 @@ For `bot` webhooks, you need to [create a bot](#create-bot), [register webhooks]
 | Method URL                             | `https://api.livechatinc.com/v3.4/configuration/action/register_webhook` |
 | Required token scopes <sup>**1**</sup> | `webhooks.configuration:rw`                                              |
 
-**1)** Token scopes are assigned to an access token, not to an application (Client ID). For this method, we recommend authorizing with a [Personal Access Token (PAT)](/authorization/authorizing-api-calls/#personal-access-tokens).  your PAT has the `webhooks.configuration:rw` scope.
+**1)** Token scopes are assigned to an access token, not to an application (Client ID). For this method, we recommend authorizing with a [Personal Access Token (PAT)](/authorization/authorizing-api-calls/#personal-access-tokens). Make sure your PAT has the `webhooks.configuration:rw` scope.
 
 | Parameter                                       | Required | Data type  | Notes                                                                                                                                                                                                                                             |
 | ----------------------------------------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/pages/management/configuration-api/v3.5/index.mdx
+++ b/src/pages/management/configuration-api/v3.5/index.mdx
@@ -2456,7 +2456,7 @@ For `bot` webhooks, you need to [create a bot](#create-bot), [register webhooks]
 | Method URL                             | `https://api.livechatinc.com/v3.5/configuration/action/register_webhook` |
 | Required token scopes <sup>**1**</sup> | `webhooks.configuration:rw`                                              |
 
-**1)** Token scopes are assigned to an access token, not to an application (Client ID). For this method, we recommend authorizing with a [Personal Access Token (PAT)](/authorization/authorizing-api-calls/#personal-access-tokens).  your PAT has the `webhooks.configuration:rw` scope.
+**1)** Token scopes are assigned to an access token, not to an application (Client ID). For this method, we recommend authorizing with a [Personal Access Token (PAT)](/authorization/authorizing-api-calls/#personal-access-tokens). Make sure your PAT has the `webhooks.configuration:rw` scope.
 
 | Parameter                                       | Required | Data type  | Notes                                                                                                                                                                                                                                             |
 | ----------------------------------------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
# Links

Link your Jira ticket.

- [Jira]()

# Description
In v3.5 and v3.4, Register Webhook's description missed the "Make sure" phrase.

