### PR TITLE
[DED-113] Fix 404 and broken links in the docs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -38,7 +38,20 @@
 /getting-started/guides/*    /docs/getting-started/livechat-apps/:splat  301 
 /authorization/livechat-accounts/*    /docs/authorization/global-accounts/:splat  301 
 /authorization/livechat-accounts-api/*    /docs/authorization/global-accounts-api/:splat  301 
-/messaging/apple-business-chat/*    /docs/messaging/apple-messages-for-business/:splat  301 
+/messaging/apple-business-chat/*    /docs/messaging/apple-messages-for-business/:splat  301
+/changelog/  /docs/messaging/ 301
+/chat-widget-moments/   /docs/extending-chat-widget/chat-widget-moments/ 301
+/chat-widget-themes/   /docs/extending-chat-widget-customer-sdk 301
+/management/getting-started/guides/webhook-apps/*    /docs/getting-started/livechat-apps/webhook-apps/:splat 301
+/management/webhooks/changelog/*    /docs/management/changelog/:splat 301
+/management/webhooks/v3.3/changelog/*    /docs/management/changelog/:splat 301
+/messaging/rtm-reference/   /docs/messaging/ 301
+/messaging/agent-chat-api/v3.3/rtm-reference/messaging/agent-chat-api/rtm-pushes/    /docs/messaging/agent-chat-api/rtm-pushes 301 
+/messaging/agent-chat-api/v3.3/messaging/*    /docs/messaging/:splat 301
+/messaging/agent-chat-api/rtm-reference/messaging/agent-chat-api/v3.4/*   /docs/messaging/agent-chat-api/:splat 301
+/messaging/agent-chat-api/rtm-pushes/messaging/agent-chat-api/v3.4/*   /docs/messaging/agent-chat-api/:splat 301
+/messaging/agent-chat-api/messaging/agent-chat-api/v3.4/*    /docs/messaging/agent-chat-api/:splat 301
+/extending-chat-widget/chat-widget-adapters/chat-widget-adapters/angular-adapter    /docs/extending-chat-widget/chat-widget-adapters/angular-adapter 301
 
 # Redirect images so can work on netlify and /docs domain
 /docs/images/*  /images/:splat  200

--- a/_redirects
+++ b/_redirects
@@ -52,6 +52,7 @@
 /messaging/agent-chat-api/rtm-pushes/messaging/agent-chat-api/v3.4/*   /docs/messaging/agent-chat-api/:splat 301
 /messaging/agent-chat-api/messaging/agent-chat-api/v3.4/*    /docs/messaging/agent-chat-api/:splat 301
 /extending-chat-widget/chat-widget-adapters/chat-widget-adapters/angular-adapter    /docs/extending-chat-widget/chat-widget-adapters/angular-adapter 301
+/agent-app-extension/    /docs/extending-agent-app/agent-app-sdk 301
 
 # Redirect images so can work on netlify and /docs domain
 /docs/images/*  /images/:splat  200

--- a/src/pages/extending-chat-widget/chat-widget-moments/index.mdx
+++ b/src/pages/extending-chat-widget/chat-widget-moments/index.mdx
@@ -74,7 +74,7 @@ Network tester - app written in React, performing a test of the connection statu
 
 # Moments in LiveChat
 
-Moments can be triggered only by [rich message's](https://www.livechat.com/help/rich-messages/) buttons. Currently, LiveChat supports rich messages delivered by chatbots using our [ChatBot](https://chatbot.com) product, a [MessageBox](/extending-ui/extending-agent-app/agent-app-sdk/#messagebox) integration in Agent App, or by sending a rich message using our [Agent Chat API](/content/messaging/agent-chat-api/).
+Moments can be triggered only by [rich message's](https://www.livechat.com/help/rich-messages/) buttons. Currently, LiveChat supports rich messages delivered by chatbots using our [ChatBot](https://chatbot.com) product, a [MessageBox](/extending-ui/extending-agent-app/agent-app-sdk/#messagebox) integration in Agent App, or by sending a rich message using our [Agent Chat API](/messaging/agent-chat-api/).
 
 # Moments SDK
 

--- a/src/pages/extending-chat-widget/visitor-sdk/index.mdx
+++ b/src/pages/extending-chat-widget/visitor-sdk/index.mdx
@@ -41,7 +41,7 @@ Chat Widget Visitor SDK is promise-based; all asynchronous methods return a prom
 
 ## Tools
 
-- [React Chat UI Kit](https://developers.livechat.com/docs/react-chat-ui-kit/) - set of **React components** to easily build nice-looking chat windows
+- [React Chat UI Kit](https://developers.livechat.com/docs/extending-chat-widget/chat-widget-adapters/react-adapter/) - set of **React components** to easily build nice-looking chat windows
 
 ## Examples
 

--- a/src/pages/management/webhooks/v3.1/index.mdx
+++ b/src/pages/management/webhooks/v3.1/index.mdx
@@ -49,7 +49,7 @@ Informs about a new thread coming in the chat. The webhook payload contains not 
 
 | Field  | Notes                                                                       |
 | ------ | --------------------------------------------------------------------------- |
-| `chat` | [Chat data structure](/messaging/agent-chat-api/v3.1/data-structure/#chats) |
+| `chat` | [Chat data structure](/messaging/agent-chat-api/v3.1/data-structures/#chats) |
 
 </Text>
 

--- a/src/pages/messaging/agent-chat-api/index.mdx
+++ b/src/pages/messaging/agent-chat-api/index.mdx
@@ -1930,7 +1930,7 @@ Creates a new [Customer](/messaging/agent-chat-api/v3.4/data-structures/#custome
 | **Method URL**         | `https://api.livechatinc.com/v3.4/agent/action/create_customer`    |
 | **Required scopes**    | `customers:rw`                                                     |
 | **RTM API equivalent** | [`create_customer`](rtm-reference/#create-customer)                |
-| **Webhook**            | [`incoming_customer`](/management/webhook/v3.4/#incoming_customer) |
+| **Webhook**            | [`incoming_customer`](/management/webhooks/v3.4/#incoming_customer) |
 
 #### Request
 

--- a/src/pages/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.3/rtm-reference/index.mdx
@@ -1116,12 +1116,12 @@ Transfers a chat to an agent or a group. When transferring directly to an agent,
 
 #### Specifics
 
-|                        |                                                                             |
-| ---------------------- | --------------------------------------------------------------------------- |
-| **Action**             | `transfer_chat`                                                             |
-| **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw`                           |
-| **Web API equivalent** | [`transfer_chat`](../#transfer-chat)                                        |
-| **Push message**       | [`chat_transferred`](/messaging/agent-chat-api/rtm-pushes/chat_transferred) |
+|                        |                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| **Action**             | `transfer_chat`                                                              |
+| **Required scopes**    | `chats--all:rw` `chats--access:rw` `chats--my:rw`                            |
+| **Web API equivalent** | [`transfer_chat`](../#transfer-chat)                                         |
+| **Push message**       | [`chat_transferred`](/messaging/agent-chat-api/rtm-pushes/#chat_transferred) |
 
 #### Request
 


### PR DESCRIPTION
# Deploy preview
For the time being, deploy previews are generated using the Nelify CLI. More info on Slack (#plaform-docs).

# Links
- [Jira](https://livechatinc.atlassian.net/browse/DED-113)

# Description
Added redirects for 404 links from [this document](https://docs.google.com/spreadsheets/d/1l863BPCevayKOfGl7QGgTdLNV_XospMpFy2I6BfMPFk/edit#gid=0) and fixed broken links in the docs.
