### PR TITLE
API-10657: add info about bugfix of groups limits of bots in v3.4+ to…

### DIFF
--- a/src/pages/data-reporting/changelog/index.mdx
+++ b/src/pages/data-reporting/changelog/index.mdx
@@ -11,6 +11,8 @@ import { openChatWindow } from "utils/index";
 
 This document is the record of all the changes in [**the Reports API**](/data-reporting/reports-api/) starting from **version 3.2**.
 
+We use the 🛠️ emoji to mark bug fixes. We also specify the date of introducing the fix in the YYYY-MM-DD format.
+
 <Warning>
 
 The developer preview version provides a preview of the upcoming changes to the API. **It's not open to public use.** However, if you want to test some features, contact us at developers@livechat.com or <a href="#open-chat" onClick={openChatWindow}>ask on the chat</a>, and we'll give you access.

--- a/src/pages/management/changelog/index.mdx
+++ b/src/pages/management/changelog/index.mdx
@@ -46,6 +46,7 @@ The developer preview version provides a preview of the upcoming changes to the 
 ### Bots
 
 - Added support for the `supervisor` priority for the `groups[].priority` parameter. This applies to all **v3.x** versions of *the Configuration API*.
+- 🛠️ (2022-04-04): Increased possible size of `groups[]` parameter when adding or updating a bot.
 
 ### Groups
 

--- a/src/pages/management/changelog/index.mdx
+++ b/src/pages/management/changelog/index.mdx
@@ -15,6 +15,8 @@ Switching from v2.0 to v3.0 was more than an upgrade - it was rather a migration
 
 Since the migration is still ongoing, different parts will be successively moved from **the Configuration API v2.0** to **v3.x**.
 
+We use the 🛠️ emoji to mark bug fixes. We also specify the date of introducing the fix in the YYYY-MM-DD format.
+
 <Warning>
 
 The developer preview version provides a preview of the upcoming changes to the API. **It's not open to public use.** However, if you want to test some features, contact us at developers@livechat.com or <a href="#open-chat" onClick={openChatWindow}>ask on the chat</a>, and we'll give you access.
@@ -46,7 +48,7 @@ The developer preview version provides a preview of the upcoming changes to the 
 ### Bots
 
 - Added support for the `supervisor` priority for the `groups[].priority` parameter. This applies to all **v3.x** versions of *the Configuration API*.
-- 🛠️ (2022-04-04): Increased possible size of `groups[]` parameter when adding or updating a bot.
+- 🛠️ (2022-04-04): Increased the maximum size of the `groups[]` parameter when adding or updating a bot.
 
 ### Groups
 

--- a/src/pages/messaging/agent-chat-api/changelog/index.mdx
+++ b/src/pages/messaging/agent-chat-api/changelog/index.mdx
@@ -11,6 +11,8 @@ import { openChatWindow } from "utils/index";
 
 This document is the record of all the changes in the **Agent Chat API**, Web and RTM references, starting from **version 3.0**.
 
+We use the 🛠️ emoji to mark bug fixes. We also specify the date of introducing the fix in the YYYY-MM-DD format.
+
 <Warning>
 
 The developer preview version provides a preview of the upcoming changes to the API. **It's not open to public use.** However, if you want to test some features, contact us at developers@livechat.com or <a href="#open-chat" onClick={openChatWindow}>ask on the chat</a>, and we'll give you access.

--- a/src/pages/messaging/customer-chat-api/changelog/index.mdx
+++ b/src/pages/messaging/customer-chat-api/changelog/index.mdx
@@ -11,6 +11,8 @@ import { openChatWindow } from "utils/index";
 
 This document is the record of all the changes in the **Customer Chat API**, Web and RTM, starting from **version 3.0**.
 
+We use the 🛠️ emoji to mark bug fixes. We also specify the date of introducing the fix in the YYYY-MM-DD format.
+
 <Warning>
 
 The developer preview version provides a preview of the upcoming changes to the API. **It's not open to public use.** However, if you want to test some features, contact us at developers@livechat.com or <a href="#open-chat" onClick={openChatWindow}>ask on the chat</a>, and we'll give you access.


### PR DESCRIPTION
# Links
- [Jira](https://livechatinc.atlassian.net/browse/API-10657)

# Description

This PR introduces a bugfix in the changelog for the first time. I'm not sure about the format and description 🤔 I think we should inform users about the date because the bugfix was introduced to the released version of API. Also, I'm not sure about the icon - if this is self-descriptive 🤔.