### PR TITLE
Fixed ContentSideNav Wrapper height

### DIFF
--- a/src/components/core/SideNav/ContentSideNav.js
+++ b/src/components/core/SideNav/ContentSideNav.js
@@ -22,7 +22,7 @@ const Wrapper = styled.div`
   padding-left: 10px;
   margin: 195px 0px 50px 0px;
   overflow-y: scroll;
-  height: calc(100vh - 70px);
+  height: calc(100vh - ${({ isVersioned }) => (isVersioned ? "130px" : "100px")});
   top: ${({ isVersioned }) => (isVersioned ? "130px" : "100px")};
   right: 20px;
   position: sticky;


### PR DESCRIPTION
# Deploy preview

Scroll down to the checks section for the link to the deploy preview of your branch.

# Links

- [Jira](https://livechatinc.atlassian.net/browse/DED-205)

# Description

While digging in the docs I have noticed that the floating sidebar is overflowing the viewport height thus not allowing me to browse through all the sections until I scroll the whole page to the very bottom (for example on the Configuration API page). Tested it in Chrome on Mac and Windows.

cc: @arturfracala

# Review and release

Apply changes and resolve conflicts. Once the described functionality lands on prod, let us know on #platform-docs-releases that your PR is ready for release. We will **merge** and **publish** the changes.
