### PR TITLE
API-10726: update scopes required by list_group_properties and list_license_properties

### DIFF
--- a/src/pages/management/configuration-api/index.mdx
+++ b/src/pages/management/configuration-api/index.mdx
@@ -2135,9 +2135,9 @@ For properties without an explicit value assignment, the method will return the 
 | Method URL      | `https://api.livechatinc.com/v3.4/configuration/action/list_license_properties` |
 | Required scopes | `properties.license.value--my:ro`*, `properties.license.value--all:ro`**        |
 
-__*)__ The scope `properties.license.value--my:ro` allows to access all properties from your namespace only.
+__*)__ The `properties.license.value--my:ro` scope allows you to access all properties from your namespace only.
 
-__**)__ The scope `properties.license.value--all:ro` allows to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
+__**)__ The `properties.license.value--all:ro` scope allows you to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
 
 #### Request
 
@@ -2307,9 +2307,9 @@ For properties without an explicit value assignment, the method will return the 
 | Method URL      | `https://api.livechatinc.com/v3.4/configuration/action/list_group_properties` |
 | Required scopes | `properties.group.value--my:ro`*, `properties.group.value--all:ro`**        |
 
-__*)__ The scope `properties.group.value--my:ro` allows to access all properties from your namespace only.
+__*)__ The `properties.group.value--my:ro` scope allows you to access all properties from your namespace only.
 
-__**)__ The scope `properties.group.value--all:ro` allows to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
+__**)__ The `properties.group.value--all:ro` scope allows you to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
 
 #### Request
 

--- a/src/pages/management/configuration-api/index.mdx
+++ b/src/pages/management/configuration-api/index.mdx
@@ -2133,10 +2133,11 @@ For properties without an explicit value assignment, the method will return the 
 |                 |                                                                                 |
 | --------------- | ------------------------------------------------------------------------------- |
 | Method URL      | `https://api.livechatinc.com/v3.4/configuration/action/list_license_properties` |
-| Required scopes | `properties.license.value--all:rw`*                                             |
+| Required scopes | `properties.license.value--my:ro`*, `properties.license.value--all:ro`**        |
 
-__*)__ The method doesn’t require any scopes if the requester’s client ID matches the namespace. If it doesn't, retrieving license properties requires `properties.license.value--all:rw`. The scope allows to
-access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
+__*)__ The scope `properties.license.value--my:ro` allows to access all properties from your namespace only.
+
+__**)__ The scope `properties.license.value--all:ro` allows to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
 
 #### Request
 
@@ -2304,10 +2305,11 @@ For properties without an explicit value assignment, the method will return the 
 |                 |                                                                               |
 | --------------- | ----------------------------------------------------------------------------- |
 | Method URL      | `https://api.livechatinc.com/v3.4/configuration/action/list_group_properties` |
-| Required scopes | `properties.group.value--all:rw`*                                             |
+| Required scopes | `properties.group.value--my:ro`*, `properties.group.value--all:ro`**        |
 
-__*)__ If the requester's Client ID doesn't match the namespace, retrieving group properties requires `properties.license.value--all:rw`. The scope allows to
-access all properties from your namespace and [public properties](#public-properties) from other namespaces.
+__*)__ The scope `properties.group.value--my:ro` allows to access all properties from your namespace only.
+
+__**)__ The scope `properties.group.value--all:ro` allows to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
 
 #### Request
 

--- a/src/pages/management/configuration-api/v3.3/index.mdx
+++ b/src/pages/management/configuration-api/v3.3/index.mdx
@@ -2138,9 +2138,9 @@ For properties without an explicit value assignment, the method will return the 
 | Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/list_license_properties` |
 | Required scopes | `properties.license.value--my:ro`*, `properties.license.value--all:ro`**        |
 
-__*)__ The scope `properties.license.value--my:ro` allows to access all properties from your namespace only.
+__*)__ The `properties.license.value--my:ro` scope allows you to access all properties from your namespace only.
 
-__**)__ The scope `properties.license.value--all:ro` allows to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
+__**)__ The `properties.license.value--all:ro` scope allows you to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
 
 #### Request
 
@@ -2310,9 +2310,9 @@ For properties without an explicit value assignment, the method will return the 
 | Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/list_group_properties` |
 | Required scopes | `properties.group.value--my:ro`*, `properties.group.value--all:ro`**        |
 
-__*)__ The scope `properties.group.value--my:ro` allows to access all properties from your namespace only.
+__*)__ The `properties.group.value--my:ro` scope allows you to access all properties from your namespace only.
 
-__**)__ The scope `properties.group.value--all:ro` allows to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
+__**)__ The `properties.group.value--all:ro` scope allows you to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
 
 #### Request
 

--- a/src/pages/management/configuration-api/v3.3/index.mdx
+++ b/src/pages/management/configuration-api/v3.3/index.mdx
@@ -2136,10 +2136,11 @@ For properties without an explicit value assignment, the method will return the 
 |                 |                                                                                 |
 | --------------- | ------------------------------------------------------------------------------- |
 | Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/list_license_properties` |
-| Required scopes | `properties.license.value--all:rw`*                                             |
+| Required scopes | `properties.license.value--my:ro`*, `properties.license.value--all:ro`**        |
 
-__*)__ The method doesn’t require any scopes if the requester’s client ID matches the namespace. If it doesn't, retrieving license properties requires `properties.license.value--all:rw`. The scope allows to
-access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
+__*)__ The scope `properties.license.value--my:ro` allows to access all properties from your namespace only.
+
+__**)__ The scope `properties.license.value--all:ro` allows to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
 
 #### Request
 
@@ -2307,10 +2308,11 @@ For properties without an explicit value assignment, the method will return the 
 |                 |                                                                               |
 | --------------- | ----------------------------------------------------------------------------- |
 | Method URL      | `https://api.livechatinc.com/v3.3/configuration/action/list_group_properties` |
-| Required scopes | `properties.group.value--all:rw`*                                             |
+| Required scopes | `properties.group.value--my:ro`*, `properties.group.value--all:ro`**        |
 
-__*)__ If the requester's Client ID doesn't match the namespace, retrieving group properties requires `properties.group.value--all:rw`. The scope allows to
-access all properties from your namespace and [public properties](#public-properties) from other namespaces.
+__*)__ The scope `properties.group.value--my:ro` allows to access all properties from your namespace only.
+
+__**)__ The scope `properties.group.value--all:ro` allows to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
 
 #### Request
 

--- a/src/pages/management/configuration-api/v3.5/index.mdx
+++ b/src/pages/management/configuration-api/v3.5/index.mdx
@@ -2128,10 +2128,11 @@ For properties without an explicit value assignment, the method will return the 
 |                 |                                                                                 |
 | --------------- | ------------------------------------------------------------------------------- |
 | Method URL      | `https://api.livechatinc.com/v3.5/configuration/action/list_license_properties` |
-| Required scopes | `properties.license.value--all:rw`*                                             |
+| Required scopes | `properties.license.value--my:ro`*, `properties.license.value--all:ro`**        |
 
-__*)__ The method doesn’t require any scopes if the requester’s client ID matches the namespace. If it doesn't, retrieving license properties requires `properties.license.value--all:rw`. The scope allows to
-access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
+__*)__ The scope `properties.license.value--my:ro` allows to access all properties from your namespace only.
+
+__**)__ The scope `properties.license.value--all:ro` allows to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
 
 #### Request
 
@@ -2299,10 +2300,11 @@ For properties without an explicit value assignment, the method will return the 
 |                 |                                                                               |
 | --------------- | ----------------------------------------------------------------------------- |
 | Method URL      | `https://api.livechatinc.com/v3.5/configuration/action/list_group_properties` |
-| Required scopes | `properties.group.value--all:rw`*                                             |
+| Required scopes | `properties.group.value--my:ro`*, `properties.group.value--all:ro`**        |
 
-__*)__ If the requester's Client ID doesn't match the namespace, retrieving group properties requires `properties.license.value--all:rw`. The scope allows to
-access all properties from your namespace and [public properties](#public-properties) from other namespaces.
+__*)__ The scope `properties.group.value--my:ro` allows to access all properties from your namespace only.
+
+__**)__ The scope `properties.group.value--all:ro` allows to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
 
 #### Request
 

--- a/src/pages/management/configuration-api/v3.5/index.mdx
+++ b/src/pages/management/configuration-api/v3.5/index.mdx
@@ -2130,9 +2130,9 @@ For properties without an explicit value assignment, the method will return the 
 | Method URL      | `https://api.livechatinc.com/v3.5/configuration/action/list_license_properties` |
 | Required scopes | `properties.license.value--my:ro`*, `properties.license.value--all:ro`**        |
 
-__*)__ The scope `properties.license.value--my:ro` allows to access all properties from your namespace only.
+__*)__ The `properties.license.value--my:ro` scope allows you to access all properties from your namespace only.
 
-__**)__ The scope `properties.license.value--all:ro` allows to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
+__**)__ The `properties.license.value--all:ro` scope allows you to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
 
 #### Request
 
@@ -2302,9 +2302,9 @@ For properties without an explicit value assignment, the method will return the 
 | Method URL      | `https://api.livechatinc.com/v3.5/configuration/action/list_group_properties` |
 | Required scopes | `properties.group.value--my:ro`*, `properties.group.value--all:ro`**        |
 
-__*)__ The scope `properties.group.value--my:ro` allows to access all properties from your namespace only.
+__*)__ The `properties.group.value--my:ro` scope allows you to access all properties from your namespace only.
 
-__**)__ The scope `properties.group.value--all:ro` allows to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
+__**)__ The `properties.group.value--all:ro` scope allows you to access all properties from your namespace and [public properties](#public-properties) from `core` and other namespaces.
 
 #### Request
 


### PR DESCRIPTION
# Deploy preview

https://62c80388346cb770fac880a4--livechat-public-docs.netlify.app

# Links

- [Jira](https://livechatinc.atlassian.net/browse/API-10726)

# Description

Two changes:
1. adding new scope `--my:ro` for reading properties from your own namespace
2. reverting the `--all:ro` scopes instead of `--all:rw` (temporary problem in the past)

# Review and release

The changes in the code are already deployed to the production (this morning) - we had to act very quickly when it comes to requiring additional scopes.