### PR TITLE
API-11012 add note about from/to filters

### DIFF
--- a/src/pages/data-reporting/reports-api/index.mdx
+++ b/src/pages/data-reporting/reports-api/index.mdx
@@ -91,7 +91,7 @@ You can find all the requests from the Reports API v3.4 in Postman. In our colle
 | `filters.agent_response.agents.<string_filter_type>`<sup>**2**</sup>  | No       | `any`     | Described below. Works only if the `agent_response.first` filter is set to `true`.                                                                                                                                                                                                                                |
 | `filters.agent_response.groups.<integer_filter_type>`<sup>**3**</sup> | No       | `any`     | Described below. Works only if the `agent_response.first` filter is set to `true`.                                                                                                                                                                                                                                |
 
-If filters are provided, they must contain exactly one pair of time-based filters (`filters.from/to`, `filters.greetings.from/to`,  or `filters.surveys.from/to`).
+If filters are provided, they must contain exactly one pair of time-based filters (`filters.from/to`, `filters.greetings.from/to`, or `filters.surveys.from/to`).
 
 ### For the Agents reports
 

--- a/src/pages/data-reporting/reports-api/index.mdx
+++ b/src/pages/data-reporting/reports-api/index.mdx
@@ -91,6 +91,8 @@ You can find all the requests from the Reports API v3.4 in Postman. In our colle
 | `filters.agent_response.agents.<string_filter_type>`<sup>**2**</sup>  | No       | `any`     | Described below. Works only if the `agent_response.first` filter is set to `true`.                                                                                                                                                                                                                                |
 | `filters.agent_response.groups.<integer_filter_type>`<sup>**3**</sup> | No       | `any`     | Described below. Works only if the `agent_response.first` filter is set to `true`.                                                                                                                                                                                                                                |
 
+If filters are provided, they must contain exactly one pair of time-based filters (`filters.from/to`, `filters.greetings.from/to`, `filters.surveys.from/to`)
+
 ### For the Agents reports
 
 | Parameter                                             | Required | Data type | Notes                                                                                                                                                                                                                                                                                                             |
@@ -102,6 +104,8 @@ You can find all the requests from the Reports API v3.4 in Postman. In our colle
 | `filters.to`                                          | No       | `string`  | Date & time format compatible with RFC3339 with optional resolution of microseconds, `YYYY-MM-DDTHH:MM:SS.ssssssZHH:MM`.                                                                                                                                                                                          |
 | `filters.agents.<string_filter_type>`<sup>**2**</sup> | No       | `any`     | Described below.                                                                                                                                                                                                                                                                                                  |
 | `filters.groups.values`                               | No       | `array`   | Array of group IDs.                                                                                                                                                                                                                                                                                               |
+
+If filters are provided, they must contain exactly one pair of time-based filters (`filters.from/to`)
 
 </Text>
 <Code>

--- a/src/pages/data-reporting/reports-api/index.mdx
+++ b/src/pages/data-reporting/reports-api/index.mdx
@@ -91,7 +91,7 @@ You can find all the requests from the Reports API v3.4 in Postman. In our colle
 | `filters.agent_response.agents.<string_filter_type>`<sup>**2**</sup>  | No       | `any`     | Described below. Works only if the `agent_response.first` filter is set to `true`.                                                                                                                                                                                                                                |
 | `filters.agent_response.groups.<integer_filter_type>`<sup>**3**</sup> | No       | `any`     | Described below. Works only if the `agent_response.first` filter is set to `true`.                                                                                                                                                                                                                                |
 
-If filters are provided, they must contain exactly one pair of time-based filters (`filters.from/to`, `filters.greetings.from/to`, `filters.surveys.from/to`)
+If filters are provided, they must contain exactly one pair of time-based filters (`filters.from/to`, `filters.greetings.from/to`,  or `filters.surveys.from/to`).
 
 ### For the Agents reports
 
@@ -105,7 +105,7 @@ If filters are provided, they must contain exactly one pair of time-based filter
 | `filters.agents.<string_filter_type>`<sup>**2**</sup> | No       | `any`     | Described below.                                                                                                                                                                                                                                                                                                  |
 | `filters.groups.values`                               | No       | `array`   | Array of group IDs.                                                                                                                                                                                                                                                                                               |
 
-If filters are provided, they must contain exactly one pair of time-based filters (`filters.from/to`)
+If filters are provided, they must contain exactly one time-based filter (`filters.from/to`).
 
 </Text>
 <Code>

--- a/src/pages/data-reporting/reports-api/v3.5/index.mdx
+++ b/src/pages/data-reporting/reports-api/v3.5/index.mdx
@@ -87,7 +87,7 @@ You can authorize your calls to the Reports API using one of the following metho
 | `filters.agent_response.groups.<integer_filter_type>`<sup>**3**</sup> | No       | `any`     | Described below. Works only if the `agent_response.first` filter is set to `true`.                                                                                                                                                                                                                                |
 | `filters.customer_countries.<string_filter_type>`<sup>**2**</sup>     | No       | `any`     | Described below. It supports country codes with the `ISO 3166-1 Alpha-2` format.                                                                                                                                                                                                                                  |
 
-If filters are provided, they must contain exactly one pair of time-based filters (`filters.from/to`, `filters.greetings.from/to`, `filters.surveys.from/to`)
+If filters are provided, they must contain exactly one pair of time-based filters (`filters.from/to`, `filters.greetings.from/to`, or `filters.surveys.from/to`).
 
 ### For the Agents reports
 
@@ -101,7 +101,7 @@ If filters are provided, they must contain exactly one pair of time-based filter
 | `filters.agents.<string_filter_type>`<sup>**2**</sup> | No       | `any`     | Described below.                                                                                                                                                                                                                                                                                                  |
 | `filters.groups.values`                               | No       | `array`   | Array of group IDs.                                                                                                                                                                                                                                                                                               |
 
-If filters are provided, they must contain exactly one pair of time-based filters (`filters.from/to`)
+If filters are provided, they must contain exactly one time-based filter (`filters.from/to`).
 
 </Text>
 <Code>

--- a/src/pages/data-reporting/reports-api/v3.5/index.mdx
+++ b/src/pages/data-reporting/reports-api/v3.5/index.mdx
@@ -99,6 +99,8 @@ You can authorize your calls to the Reports API using one of the following metho
 | `filters.agents.<string_filter_type>`<sup>**2**</sup> | No       | `any`     | Described below.                                                                                                                                                                                                                                                                                                  |
 | `filters.groups.values`                               | No       | `array`   | Array of group IDs.                                                                                                                                                                                                                                                                                               |
 
+If filters are provided they must contain exacly one pair of time based filters (`filters.from/to`, `filters.greetings.from/to`, `filters.surveys.from/to`)
+
 </Text>
 <Code>
 </Code>

--- a/src/pages/data-reporting/reports-api/v3.5/index.mdx
+++ b/src/pages/data-reporting/reports-api/v3.5/index.mdx
@@ -87,6 +87,8 @@ You can authorize your calls to the Reports API using one of the following metho
 | `filters.agent_response.groups.<integer_filter_type>`<sup>**3**</sup> | No       | `any`     | Described below. Works only if the `agent_response.first` filter is set to `true`.                                                                                                                                                                                                                                |
 | `filters.customer_countries.<string_filter_type>`<sup>**2**</sup>     | No       | `any`     | Described below. It supports country codes with the `ISO 3166-1 Alpha-2` format.                                                                                                                                                                                                                                  |
 
+If filters are provided, they must contain exactly one pair of time-based filters (`filters.from/to`, `filters.greetings.from/to`, `filters.surveys.from/to`)
+
 ### For the Agents reports
 
 | Parameter                                             | Required | Data type | Notes                                                                                                                                                                                                                                                                                                             |
@@ -99,7 +101,7 @@ You can authorize your calls to the Reports API using one of the following metho
 | `filters.agents.<string_filter_type>`<sup>**2**</sup> | No       | `any`     | Described below.                                                                                                                                                                                                                                                                                                  |
 | `filters.groups.values`                               | No       | `array`   | Array of group IDs.                                                                                                                                                                                                                                                                                               |
 
-If filters are provided they must contain exacly one pair of time based filters (`filters.from/to`, `filters.greetings.from/to`, `filters.surveys.from/to`)
+If filters are provided, they must contain exactly one pair of time-based filters (`filters.from/to`)
 
 </Text>
 <Code>


### PR DESCRIPTION
# Links

Link your Jira ticket.

- [Jira](https://livechatinc.atlassian.net/browse/API-11012)

# Description

Note about filters validation - we don't say anywhere that if filters are provided, some kind of from/to filter must be provided (and we can provide only one). We didn't have an explicit error for this (we returned: `RFC3339 date format required for %s.from`), but it's going to change and ``filters` must contain `filters.from/to` or `filters.greetings.from/to` or `filters.surveys.from/to`` will be returned in such situation 

# Review and release

Apply changes and resolve conflicts. Once the described functionality lands on prod, let us know on #platform-docs-releases that your PR is ready for release. We will **merge** and **publish** the changes.
