### PR TITLE
Cache npm dependencies for preview gh action

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,19 +13,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+          cache: "npm"
 
       - name: Install Dependencies
-        run: npm install
-
-      - name: Install Netlify CLI
-        run: npm install netlify-cli -g
+        run: npm ci
 
       - name: Create Preview
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           BRANCH_NAME: $(echo ${{github.head_ref || github.ref_name}} | sed -e 's/\//-/g' | tr '[:upper:]' '[:lower:]')
-        run: netlify build --context deploy-preview  && netlify deploy --dir=.next --alias ${{ env.BRANCH_NAME }}
+        run: npx netlify build --context deploy-preview && npx netlify deploy --dir=.next --alias ${{ env.BRANCH_NAME }}
 
       - name: Status check
         env:


### PR DESCRIPTION
# Deploy preview

N/A

# Links

N/A

# Description

- Use additional `actions/setup-node@v2` for preview gh action to always use specific node version and take advantage of npm dependencies caching
- Install dependencies using `npm ci` to always resolve deps tree from package-lock.json which is used for cache fingerprinting
- Use already installed `netlify-cli` and remove the redundant installation

Example results show a ~2 minute drop in action executing time. Still, the main bottleneck is 15-17 minutes of build time, but hey, its stilll a little bit faster 😄 

#### Before
<img width="1324" alt="image" src="https://user-images.githubusercontent.com/9700566/180946499-af0e31bd-9544-4f8e-aca6-24d9298924e2.png">

#### After
<img width="1324" alt="image" src="https://user-images.githubusercontent.com/9700566/180946660-7fd665a1-aa2c-4072-ae08-5cc6ec41357a.png">


# Review and release

Apply changes and resolve conflicts. Once the described functionality lands on prod, let us know on #platform-docs-releases that your PR is ready for release. We will **merge** and **publish** the changes.
