### PR TITLE
Fix: preview action details url format

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Status check
         env:
-          BRANCH_NAME: ${{github.head_ref || github.ref_name}}
+          BRANCH_NAME: $(echo ${{github.head_ref || github.ref_name}} | sed -e 's/\//-/g' | tr '[:upper:]' '[:lower:]')
         uses: Sibz/github-status-action@v1.1.1
         with:
           authToken: ${{ secrets.AUTH_TOKEN }}


### PR DESCRIPTION
# Description

Doing a code review of this PR https://github.com/livechat/livechat-public-docs/pull/1215 from our team, I have noticed that the URL on "Details" link in the summary of the check was wrongly constructed without postprocessing the branch name the same way as it is done for deployment alias. In such a case, if someone uses a "/" character or upper case, the link will guide you to a nonexisting URL.

<img width="1451" alt="image" src="https://user-images.githubusercontent.com/9700566/185099686-df1cebe3-dd80-4946-a745-ca15c75d08ee.png">
