### PR TITLE
fix: removed duplicated agent_deleted webhook in v3.4+

### DIFF
--- a/src/pages/management/webhooks/index.mdx
+++ b/src/pages/management/webhooks/index.mdx
@@ -8,7 +8,7 @@ desc: "The refrence of available LiveChat webhooks. Use webhooks to build automa
 apiVersion: "3.4"
 ---
 
-This document contains a reference of available webhooks. Webhooks are helpful for building applications that execute particular behavior in response to various actions, allowing you to create automated flows. 
+This document contains a reference of available webhooks. Webhooks are helpful for building applications that execute particular behavior in response to various actions, allowing you to create automated flows.
 In order to receive webhooks, you need to [register](/management/configuration-api/v3.4/#register-webhook) them first.
 
 💡 Not what you're looking for? Try these instead:
@@ -27,7 +27,7 @@ In order to receive webhooks, you need to [register](/management/configuration-a
 | **Events**        | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated) [`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | **Properties**    | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_deleted`](#thread_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted)                                                                                                                                                                                                                 |
 | **Thread tags**   | [`thread_tagged`](#thread_tagged) [`thread_untagged`](#thread_untagged)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| **Status**        | [`routing_status_set`](#routing_status_set) [`agent_deleted`](#agent_deleted)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| **Status**        | [`routing_status_set`](#routing_status_set)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | **Customers**     | [`incoming_customer`](#incoming_customer) [`customer_session_fields_updated`](#customer_session_fields_updated)                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | **Configuration** | [`agent_created`](#agent_created) [`agent_approved`](#agent_approved) [`agent_updated`](#agent_updated) [`agent_suspended`](#agent_suspended) [`agent_unsuspended`](#agent_unsuspended) [`agent_deleted`](#agent_deleted) [`auto_access_added`](#auto_access_added) [`auto_access_updated`](#auto_access_updated) [`auto_access_deleted`](#auto_access_deleted) [`bot_created`](#bot_created) [`bot_updated`](#bot_updated) [`bot_deleted`](#bot_deleted) [`group_created`](#group_created) [`group_updated`](#group_updated) [`group_deleted`](#group_deleted) |
 | **Other**         | [`events_marked_as_seen`](#events_marked_as_seen)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
@@ -1045,53 +1045,6 @@ Informs that an Agent's or Bot's status has changed.
   "payload": {
     "agent_id":"agent1@example.com",
     "status": "accepting chats"
-  },
-  "additional_data": {
-    "chat_properties": { //optional
-        // chat properties
-    },
-    "chat_presence_user_ids": [ //optional
-      // User IDs
-    ]
-  }
-}
-```
-
-</CodeResponse>
-
-</Code>
-
-</Section>
-
-<Section>
-
-<Text>
-
-### `agent_deleted`
-
-Informs that an Agent's account was deleted.
-
-#### Specifics
-
-|                        |                 |
-| ---------------------- | --------------- |
-| **Action**             | `agent_deleted` |
-| **Push equivalent in** | -               |
-
-</Text>
-
-<Code>
-
-<CodeResponse title={'Sample webhook'}>
-
-```json
-{
-  "webhook_id": "<webhook_id>",
-  "secret_key": "<secret_key>",
-  "action": "agent_deleted",
-  "organization_id": "390e44e6-f1e6-0368c-z6ddb-74g14508c2ex",
-  "payload": {
-    "agent_id": "agent1@example.com"
   },
   "additional_data": {
     "chat_properties": { //optional

--- a/src/pages/management/webhooks/v3.5/index.mdx
+++ b/src/pages/management/webhooks/v3.5/index.mdx
@@ -27,7 +27,7 @@ In order to receive webhooks, you need to [register](/management/configuration-a
 | **Events**        | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated) [`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | **Properties**    | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_deleted`](#thread_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted)                                                                                                                                                                                                                 |
 | **Thread tags**   | [`thread_tagged`](#thread_tagged) [`thread_untagged`](#thread_untagged)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| **Status**        | [`routing_status_set`](#routing_status_set) [`agent_deleted`](#agent_deleted)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| **Status**        | [`routing_status_set`](#routing_status_set)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | **Customers**     | [`incoming_customer`](#incoming_customer) [`customer_session_fields_updated`](#customer_session_fields_updated)                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | **Configuration** | [`agent_created`](#agent_created) [`agent_approved`](#agent_approved) [`agent_updated`](#agent_updated) [`agent_suspended`](#agent_suspended) [`agent_unsuspended`](#agent_unsuspended) [`agent_deleted`](#agent_deleted) [`auto_access_added`](#auto_access_added) [`auto_access_updated`](#auto_access_updated) [`auto_access_deleted`](#auto_access_deleted) [`bot_created`](#bot_created) [`bot_updated`](#bot_updated) [`bot_deleted`](#bot_deleted) [`group_created`](#group_created) [`group_updated`](#group_updated) [`group_deleted`](#group_deleted) [`tag_created`](#tag_created) [`tag_deleted`](#tag_deleted) [`tag_updated`](#tag_updated) |
 | **Other**         | [`events_marked_as_seen`](#events_marked_as_seen)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
@@ -1045,53 +1045,6 @@ Informs that an Agent's or Bot's status has changed.
   "payload": {
     "agent_id":"agent1@example.com",
     "status": "accepting chats"
-  },
-  "additional_data": {
-    "chat_properties": { //optional
-        // chat properties
-    },
-    "chat_presence_user_ids": [ //optional
-      // User IDs
-    ]
-  }
-}
-```
-
-</CodeResponse>
-
-</Code>
-
-</Section>
-
-<Section>
-
-<Text>
-
-### `agent_deleted`
-
-Informs that an Agent's account was deleted.
-
-#### Specifics
-
-|                        |                 |
-| ---------------------- | --------------- |
-| **Action**             | `agent_deleted` |
-| **Push equivalent in** | -               |
-
-</Text>
-
-<Code>
-
-<CodeResponse title={'Sample webhook'}>
-
-```json
-{
-  "webhook_id": "<webhook_id>",
-  "secret_key": "<secret_key>",
-  "action": "agent_deleted",
-  "organization_id": "390e44e6-f1e6-0368c-z6ddb-74g14508c2ex",
-  "payload": {
-    "agent_id": "agent1@example.com"
   },
   "additional_data": {
     "chat_properties": { //optional


### PR DESCRIPTION
# Description

New entry for `agent_deleted` webhook was added in the docs for v3.4+ but the old description of this webhook still exists so I suggest to remove it. Wdyt?
![Screenshot 2022-08-25 at 17 12 15](https://user-images.githubusercontent.com/28757872/186703456-297b23e9-6df2-4370-9109-81858b3669a4.png)

