### PR TITLE
API-11290: document agent's `login-status`

### DIFF
--- a/src/pages/management/configuration-api/index.mdx
+++ b/src/pages/management/configuration-api/index.mdx
@@ -349,12 +349,12 @@ Updates the properties of an Agent specified by `id`.
 | -------------------------------------- | ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `id`                                   | `string`   | Yes      | Agent ID                                                                                                                          |
 | `name`                                 | `string`   | No       | Agent name                                                                                                                        |
-| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal`                                                |
+| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal`.                                               |
 | `avatar`                               | `string`   | No       | Avatar URL                                                                                                                        |
 | `login_status`                         | `string`   | No       | Agent's default status right after the login, should be one of the following: `accepting chats`, `not accepting chats` (default). |
 | `job_title`                            | `string`   | No       | Agent's job title                                                                                                                 |
 | `mobile`                               | `string`   | No       | Agent's mobile number                                                                                                             |
-| `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent. Limited to 100. chats                                                                       |
+| `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent chats. Limited to 100.                                                                       |
 | `groups`                               | `object[]` | No       | Groups an Agent belongs to.                                                                                                       |
 | `groups[].id`                          | `uint`     | Yes      | Group ID; required only when `group`'s included.                                                                                  |
 | `groups[].priority` __*__              | `string`   | Yes      | Agent's priority in a group; required only when `group`'s included.                                                               |

--- a/src/pages/management/configuration-api/index.mdx
+++ b/src/pages/management/configuration-api/index.mdx
@@ -81,6 +81,7 @@ Creates a new agent with specified parameters within a license.
 | `name`                                 | `string`   | Yes      | Agent name                                                                                                                                            |
 | `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal` (default).                                                         |
 | `avatar`                               | `string`   | No       | Avatar URL                                                                                                                                            |
+| `login_status`                         | `string`   | No       | Agent's default status right after the login, should be one of the following: `accepting chats`, `not accepting chats` (default).                     |
 | `job_title`                            | `string`   | No       | Agent's job title                                                                                                                                     |
 | `mobile`                               | `string`   | No       | Agent's mobile number                                                                                                                                 |
 | `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent chats; default: 6. Limited to 100.                                                                               |
@@ -344,22 +345,23 @@ Updates the properties of an Agent specified by `id`.
 
 #### Request
 
-| Parameter                              | Data type  | Required | Notes                                                                              |
-| -------------------------------------- | ---------- | -------- | ---------------------------------------------------------------------------------- |
-| `id`                                   | `string`   | Yes      | Agent ID                                                                           |
-| `name`                                 | `string`   | No       | Agent name                                                                         |
-| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal` |
-| `avatar`                               | `string`   | No       | Avatar URL                                                                         |
-| `job_title`                            | `string`   | No       | Agent's job title                                                                  |
-| `mobile`                               | `string`   | No       | Agent's mobile number                                                              |
-| `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent. Limited to 100. chats                        |
-| `groups`                               | `object[]` | No       | Groups an Agent belongs to.                                                        |
-| `groups[].id`                          | `uint`     | Yes      | Group ID; required only when `group`'s included.                                   |
-| `groups[].priority` __*__              | `string`   | Yes      | Agent's priority in a group; required only when `group`'s included.                |
-| `notifications`__**__                  | `string[]` | No       | Represents which Agent notifications are turned on.                                |
-| `email_subscriptions`__***__           | `string[]` | No       | Represents which subscriptions will be send to an Agent via email.                 |
-| `work_scheduler`                       | `object`   | No       | Work scheduler options to set for a new Agent                                      |
-| `work_scheduler.****.<work_scheduler>` | `object`   | No       | `<work_scheduler>` values __\*\*\*\*\*__                                           |
+| Parameter                              | Data type  | Required | Notes                                                                                                                             |
+| -------------------------------------- | ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                                   | `string`   | Yes      | Agent ID                                                                                                                          |
+| `name`                                 | `string`   | No       | Agent name                                                                                                                        |
+| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal`                                                |
+| `avatar`                               | `string`   | No       | Avatar URL                                                                                                                        |
+| `login_status`                         | `string`   | No       | Agent's default status right after the login, should be one of the following: `accepting chats`, `not accepting chats` (default). |
+| `job_title`                            | `string`   | No       | Agent's job title                                                                                                                 |
+| `mobile`                               | `string`   | No       | Agent's mobile number                                                                                                             |
+| `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent. Limited to 100. chats                                                                       |
+| `groups`                               | `object[]` | No       | Groups an Agent belongs to.                                                                                                       |
+| `groups[].id`                          | `uint`     | Yes      | Group ID; required only when `group`'s included.                                                                                  |
+| `groups[].priority` __*__              | `string`   | Yes      | Agent's priority in a group; required only when `group`'s included.                                                               |
+| `notifications`__**__                  | `string[]` | No       | Represents which Agent notifications are turned on.                                                                               |
+| `email_subscriptions`__***__           | `string[]` | No       | Represents which subscriptions will be send to an Agent via email.                                                                |
+| `work_scheduler`                       | `object`   | No       | Work scheduler options to set for a new Agent                                                                                     |
+| `work_scheduler.****.<work_scheduler>` | `object`   | No       | `<work_scheduler>` values __\*\*\*\*\*__                                                                                          |
 
 __*__ Possible values for the `groups[].priority` parameter:
 

--- a/src/pages/management/configuration-api/v3.2/index.mdx
+++ b/src/pages/management/configuration-api/v3.2/index.mdx
@@ -90,6 +90,7 @@ Creates a new agent with specified parameters within a license.
 | `name`                                 | `string`   | Yes      | Agent name                                                                                                                                            |
 | `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal` (default).                                                         |
 | `avatar_path`                          | `string`   | No       | Avatar URL                                                                                                                                            |
+| `login_status`                         | `string`   | No       | Agent's default status right after the login, should be one of the following: `accepting chats`, `not accepting chats` (default).                     |
 | `job_title`                            | `string`   | No       | Agent's job title                                                                                                                                     |
 | `mobile`                               | `string`   | No       | Agent's mobile number                                                                                                                                 |
 | `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent chats; default: 6. Limited to 100.                                                                               |
@@ -352,22 +353,23 @@ Updates the properties of an Agent specified by `id`.
 
 #### Request
 
-| Parameter                              | Data type  | Required | Notes                                                                              |
-| -------------------------------------- | ---------- | -------- | ---------------------------------------------------------------------------------- |
-| `id`                                   | `string`   | Yes      | Agent ID                                                                           |
-| `name`                                 | `string`   | No       | Agent name                                                                         |
-| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal` |
-| `avatar_path`                          | `string`   | No       | Avatar URL                                                                         |
-| `job_title`                            | `string`   | No       | Agent's job title                                                                  |
-| `mobile`                               | `string`   | No       | Agent's mobile number                                                              |
-| `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent chats. Limited to 100.                        |
-| `groups`                               | `object[]` | No       | Groups an Agent belongs to.                                                        |
-| `groups[].id`                          | `uint`     | Yes      | Group ID; required only when `group`'s included.                                   |
-| `groups[].priority` __*__              | `string`   | Yes      | Agent's priority in a group; required only when `group`'s included.                |
-| `notifications`__**__                  | `string[]` | No       | Represents which Agent notifications are turned on.                                |
-| `email_subscriptions`__***__           | `string[]` | No       | Represents which subscriptions will be send to an Agent via email.                 |
-| `work_scheduler`                       | `object`   | No       | Work scheduler options to set for a new Agent                                      |
-| `work_scheduler.****.<work_scheduler>` | `object`   | No       | `<work_scheduler>` values __\*\*\*\*\*__                                           |
+| Parameter                              | Data type  | Required | Notes                                                                                                                             |
+| -------------------------------------- | ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                                   | `string`   | Yes      | Agent ID                                                                                                                          |
+| `name`                                 | `string`   | No       | Agent name                                                                                                                        |
+| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal`                                                |
+| `avatar_path`                          | `string`   | No       | Avatar URL                                                                                                                        |
+| `login_status`                         | `string`   | No       | Agent's default status right after the login, should be one of the following: `accepting chats`, `not accepting chats` (default). |
+| `job_title`                            | `string`   | No       | Agent's job title                                                                                                                 |
+| `mobile`                               | `string`   | No       | Agent's mobile number                                                                                                             |
+| `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent chats. Limited to 100.                                                                       |
+| `groups`                               | `object[]` | No       | Groups an Agent belongs to.                                                                                                       |
+| `groups[].id`                          | `uint`     | Yes      | Group ID; required only when `group`'s included.                                                                                  |
+| `groups[].priority` __*__              | `string`   | Yes      | Agent's priority in a group; required only when `group`'s included.                                                               |
+| `notifications`__**__                  | `string[]` | No       | Represents which Agent notifications are turned on.                                                                               |
+| `email_subscriptions`__***__           | `string[]` | No       | Represents which subscriptions will be send to an Agent via email.                                                                |
+| `work_scheduler`                       | `object`   | No       | Work scheduler options to set for a new Agent                                                                                     |
+| `work_scheduler.****.<work_scheduler>` | `object`   | No       | `<work_scheduler>` values __\*\*\*\*\*__                                                                                          |
 
 __*__ Possible values for the `groups[].priority` parameter:
 

--- a/src/pages/management/configuration-api/v3.2/index.mdx
+++ b/src/pages/management/configuration-api/v3.2/index.mdx
@@ -357,7 +357,7 @@ Updates the properties of an Agent specified by `id`.
 | -------------------------------------- | ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `id`                                   | `string`   | Yes      | Agent ID                                                                                                                          |
 | `name`                                 | `string`   | No       | Agent name                                                                                                                        |
-| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal`                                                |
+| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal`.                                               |
 | `avatar_path`                          | `string`   | No       | Avatar URL                                                                                                                        |
 | `login_status`                         | `string`   | No       | Agent's default status right after the login, should be one of the following: `accepting chats`, `not accepting chats` (default). |
 | `job_title`                            | `string`   | No       | Agent's job title                                                                                                                 |

--- a/src/pages/management/configuration-api/v3.3/index.mdx
+++ b/src/pages/management/configuration-api/v3.3/index.mdx
@@ -351,7 +351,7 @@ Updates the properties of an Agent specified by `id`.
 | -------------------------------------- | ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `id`                                   | `string`   | Yes      | Agent ID                                                                                                                          |
 | `name`                                 | `string`   | No       | Agent name                                                                                                                        |
-| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal`                                                |
+| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal`.                                               |
 | `avatar_path`                          | `string`   | No       | Avatar URL                                                                                                                        |
 | `login_status`                         | `string`   | No       | Agent's default status right after the login, should be one of the following: `accepting chats`, `not accepting chats` (default). |
 | `job_title`                            | `string`   | No       | Agent's job title                                                                                                                 |

--- a/src/pages/management/configuration-api/v3.3/index.mdx
+++ b/src/pages/management/configuration-api/v3.3/index.mdx
@@ -83,6 +83,7 @@ Creates a new agent with specified parameters within a license.
 | `name`                                 | `string`   | Yes      | Agent name                                                                                                                                            |
 | `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal` (default).                                                         |
 | `avatar_path`                          | `string`   | No       | Avatar URL                                                                                                                                            |
+| `login_status`                         | `string`   | No       | Agent's default status right after the login, should be one of the following: `accepting chats`, `not accepting chats` (default).                     |
 | `job_title`                            | `string`   | No       | Agent's job title                                                                                                                                     |
 | `mobile`                               | `string`   | No       | Agent's mobile number                                                                                                                                 |
 | `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent chats; default: 6. Limited to 100.                                                                               |
@@ -346,22 +347,23 @@ Updates the properties of an Agent specified by `id`.
 
 #### Request
 
-| Parameter                              | Data type  | Required | Notes                                                                              |
-| -------------------------------------- | ---------- | -------- | ---------------------------------------------------------------------------------- |
-| `id`                                   | `string`   | Yes      | Agent ID                                                                           |
-| `name`                                 | `string`   | No       | Agent name                                                                         |
-| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal` |
-| `avatar_path`                          | `string`   | No       | Avatar URL                                                                         |
-| `job_title`                            | `string`   | No       | Agent's job title                                                                  |
-| `mobile`                               | `string`   | No       | Agent's mobile number                                                              |
-| `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent chats. Limited to 100.                        |
-| `groups`                               | `object[]` | No       | Groups an Agent belongs to.                                                        |
-| `groups[].id`                          | `uint`     | Yes      | Group ID; required only when `group`'s included.                                   |
-| `groups[].priority` __*__              | `string`   | Yes      | Agent's priority in a group; required only when `group`'s included.                |
-| `notifications`__**__                  | `string[]` | No       | Represents which Agent notifications are turned on.                                |
-| `email_subscriptions`__***__           | `string[]` | No       | Represents which subscriptions will be send to an Agent via email.                 |
-| `work_scheduler`                       | `object`   | No       | Work scheduler options to set for a new Agent                                      |
-| `work_scheduler.****.<work_scheduler>` | `object`   | No       | `<work_scheduler>` values __\*\*\*\*\*__                                           |
+| Parameter                              | Data type  | Required | Notes                                                                                                                             |
+| -------------------------------------- | ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                                   | `string`   | Yes      | Agent ID                                                                                                                          |
+| `name`                                 | `string`   | No       | Agent name                                                                                                                        |
+| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal`                                                |
+| `avatar_path`                          | `string`   | No       | Avatar URL                                                                                                                        |
+| `login_status`                         | `string`   | No       | Agent's default status right after the login, should be one of the following: `accepting chats`, `not accepting chats` (default). |
+| `job_title`                            | `string`   | No       | Agent's job title                                                                                                                 |
+| `mobile`                               | `string`   | No       | Agent's mobile number                                                                                                             |
+| `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent chats. Limited to 100.                                                                       |
+| `groups`                               | `object[]` | No       | Groups an Agent belongs to.                                                                                                       |
+| `groups[].id`                          | `uint`     | Yes      | Group ID; required only when `group`'s included.                                                                                  |
+| `groups[].priority` __*__              | `string`   | Yes      | Agent's priority in a group; required only when `group`'s included.                                                               |
+| `notifications`__**__                  | `string[]` | No       | Represents which Agent notifications are turned on.                                                                               |
+| `email_subscriptions`__***__           | `string[]` | No       | Represents which subscriptions will be send to an Agent via email.                                                                |
+| `work_scheduler`                       | `object`   | No       | Work scheduler options to set for a new Agent                                                                                     |
+| `work_scheduler.****.<work_scheduler>` | `object`   | No       | `<work_scheduler>` values __\*\*\*\*\*__                                                                                          |
 
 __*__ Possible values for the `groups[].priority` parameter:
 

--- a/src/pages/management/configuration-api/v3.5/index.mdx
+++ b/src/pages/management/configuration-api/v3.5/index.mdx
@@ -474,7 +474,7 @@ Updates the properties of an Agent specified by `id`.
 | `login_status`                         | `string`   | No       | Agent's default status right after the login, should be one of the following: `accepting chats`, `not accepting chats` (default). |
 | `job_title`                            | `string`   | No       | Agent's job title                                                                                                                 |
 | `mobile`                               | `string`   | No       | Agent's mobile number                                                                                                             |
-| `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent. Limited to 100. chats                                                                       |
+| `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent chats. Limited to 100.                                                                        |
 | `groups`                               | `object[]` | No       | Groups an Agent belongs to.                                                                                                       |
 | `groups[].id`                          | `uint`     | Yes      | Group ID; required only when `group`'s included.                                                                                  |
 | `groups[].priority` __*__              | `string`   | Yes      | Agent's priority in a group; required only when `group`'s included.                                                               |

--- a/src/pages/management/configuration-api/v3.5/index.mdx
+++ b/src/pages/management/configuration-api/v3.5/index.mdx
@@ -197,6 +197,7 @@ Creates a new agent with specified parameters within a license.
 | `name`                                 | `string`   | Yes      | Agent name                                                                                                                                            |
 | `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal` (default).                                                         |
 | `avatar`                               | `string`   | No       | Avatar URL                                                                                                                                            |
+| `login_status`                         | `string`   | No       | Agent's default status right after the login, should be one of the following: `accepting chats`, `not accepting chats` (default).                     |
 | `job_title`                            | `string`   | No       | Agent's job title                                                                                                                                     |
 | `mobile`                               | `string`   | No       | Agent's mobile number                                                                                                                                 |
 | `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent chats; default: 6. Limited to 100.                                                                               |
@@ -464,22 +465,23 @@ Updates the properties of an Agent specified by `id`.
 
 #### Request
 
-| Parameter                              | Data type  | Required | Notes                                                                              |
-| -------------------------------------- | ---------- | -------- | ---------------------------------------------------------------------------------- |
-| `id`                                   | `string`   | Yes      | Agent ID                                                                           |
-| `name`                                 | `string`   | No       | Agent name                                                                         |
-| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal` |
-| `avatar`                               | `string`   | No       | Avatar URL                                                                         |
-| `job_title`                            | `string`   | No       | Agent's job title                                                                  |
-| `mobile`                               | `string`   | No       | Agent's mobile number                                                              |
-| `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent. Limited to 100. chats                        |
-| `groups`                               | `object[]` | No       | Groups an Agent belongs to.                                                        |
-| `groups[].id`                          | `uint`     | Yes      | Group ID; required only when `group`'s included.                                   |
-| `groups[].priority` __*__              | `string`   | Yes      | Agent's priority in a group; required only when `group`'s included.                |
-| `notifications`__**__                  | `string[]` | No       | Represents which Agent notifications are turned on.                                |
-| `email_subscriptions`__***__           | `string[]` | No       | Represents which subscriptions will be send to an Agent via email.                 |
-| `work_scheduler`                       | `object`   | No       | Work scheduler options to set for a new Agent                                      |
-| `work_scheduler.****.<work_scheduler>` | `object`   | No       | `<work_scheduler>` values __\*\*\*\*\*__                                           |
+| Parameter                              | Data type  | Required | Notes                                                                                                                             |
+| -------------------------------------- | ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                                   | `string`   | Yes      | Agent ID                                                                                                                          |
+| `name`                                 | `string`   | No       | Agent name                                                                                                                        |
+| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal`                                                |
+| `avatar`                               | `string`   | No       | Avatar URL                                                                                                                        |
+| `login_status`                         | `string`   | No       | Agent's default status right after the login, should be one of the following: `accepting chats`, `not accepting chats` (default). |
+| `job_title`                            | `string`   | No       | Agent's job title                                                                                                                 |
+| `mobile`                               | `string`   | No       | Agent's mobile number                                                                                                             |
+| `max_chats_count`                      | `int`      | No       | Agent's maximum number of concurrent. Limited to 100. chats                                                                       |
+| `groups`                               | `object[]` | No       | Groups an Agent belongs to.                                                                                                       |
+| `groups[].id`                          | `uint`     | Yes      | Group ID; required only when `group`'s included.                                                                                  |
+| `groups[].priority` __*__              | `string`   | Yes      | Agent's priority in a group; required only when `group`'s included.                                                               |
+| `notifications`__**__                  | `string[]` | No       | Represents which Agent notifications are turned on.                                                                               |
+| `email_subscriptions`__***__           | `string[]` | No       | Represents which subscriptions will be send to an Agent via email.                                                                |
+| `work_scheduler`                       | `object`   | No       | Work scheduler options to set for a new Agent                                                                                     |
+| `work_scheduler.****.<work_scheduler>` | `object`   | No       | `<work_scheduler>` values __\*\*\*\*\*__                                                                                          |
 
 __*__ Possible values for the `groups[].priority` parameter:
 

--- a/src/pages/management/configuration-api/v3.5/index.mdx
+++ b/src/pages/management/configuration-api/v3.5/index.mdx
@@ -469,7 +469,7 @@ Updates the properties of an Agent specified by `id`.
 | -------------------------------------- | ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `id`                                   | `string`   | Yes      | Agent ID                                                                                                                          |
 | `name`                                 | `string`   | No       | Agent name                                                                                                                        |
-| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal`                                                |
+| `role`                                 | `string`   | No       | Agent role, should be one of the following: `viceowner`, `administrator`, `normal`.                                               |
 | `avatar`                               | `string`   | No       | Avatar URL                                                                                                                        |
 | `login_status`                         | `string`   | No       | Agent's default status right after the login, should be one of the following: `accepting chats`, `not accepting chats` (default). |
 | `job_title`                            | `string`   | No       | Agent's job title                                                                                                                 |


### PR DESCRIPTION
# Deploy preview

Scroll down to the checks section for the link to the deploy preview of your branch.

# Links

Link your Jira ticket.

- [Jira](https://livechatinc.atlassian.net/browse/API-11290)

# Description

Add missing documentation for agent's `login_status` field.

# Review and release

Apply changes and resolve conflicts. Once the described functionality lands on prod, let us know on #platform-docs-releases that your PR is ready for release. We will **merge** and **publish** the changes.
