### PR TITLE
API-11296: account_id in list_agents/get_agent

### DIFF
--- a/payloads/management/v3.5/configuration-api/responses/agents/getAgent.json
+++ b/payloads/management/v3.5/configuration-api/responses/agents/getAgent.json
@@ -1,5 +1,6 @@
 {
   "id": "smith@example.com",
+  "account_id": "d24fa41e-bc16-41b8-a15b-9ca45ff7e0cf",
   "name": "Agent Smith",
   "avatar": "https://domain.com/avatar.image.jpg",
   "role": "administrator",

--- a/payloads/management/v3.5/configuration-api/responses/agents/listAgents.json
+++ b/payloads/management/v3.5/configuration-api/responses/agents/listAgents.json
@@ -2,6 +2,7 @@
   {
     "avatar_path": "cdn.livechatinc.com/avatars/1.png",
     "id": "smith@example.com",
+    "account_id": "d24fa41e-bc16-41b8-a15b-9ca45ff7e0cf",
     "job_title": "Support Hero",
     "login_status": "not accepting chats",
     "name": "Smith",
@@ -15,6 +16,7 @@
   {
     "avatar_path": "cdn.livechatinc.com/avatars/2.png",
     "id": "jones@example.com",
+    "account_id": "2fca3315-f6b2-422f-8550-c84b649cef1a",
     "job_title": "Support Hero (Newbie)",
     "login_status": "accepting chats",
     "name": "Jones",

--- a/src/pages/management/changelog/index.mdx
+++ b/src/pages/management/changelog/index.mdx
@@ -34,6 +34,7 @@ The developer preview version provides a preview of the upcoming changes to the 
 - The [**List Agents**](/management/configuration-api/v3.5/#list-agents) method can now filter agents by their `suspended` status.
 - The following methods now support batch requests: [Create Agent](/management/configuration-api/v3.5/#create-agent), [Update Agent](/management/configuration-api/v3.5/#update-agent), [Delete Agent](/management/configuration-api/v3.5/#delete-agent), [Suspend Agent](/management/configuration-api/v3.5/#suspend-agent), [Unsuspend Agent](/management/configuration-api/v3.5/#unsuspend-agent), and [Approve Agent](/management/configuration-api/v3.5/#approve-agent).
 - The `work_scheduler` parameter in [**Create Agent**](/management/configuration-api/v3.5/#create-agent), [**Update Agent**](/management/configuration-api/v3.5/#update-agent), [**Create Bot**](/management/configuration-api/v3.5/#create-bot), and [**Update Bot**](/management/configuration-api/v3.5/#update-bot) methods has a new format. It is now possible to configure multiple working hours for each day.
+- The [**List Agents**](/management/configuration-api/v3.5/#list-agents) and [**Get Agent**](/management/configuration-api/v3.5/#get-agent) methods now return agent's `account_id`.
 
 ### Tags
 


### PR DESCRIPTION
# Deploy preview

Scroll down to the checks section for the link to the deploy preview of your branch.

# Links

- [Jira](https://livechatinc.atlassian.net/browse/API-11296)

# Description
we're exposing account_id in agent getters, i'm not sure if there's a place we can put a description of the field as it is not modyfiable.

# Review and release

Apply changes and resolve conflicts. Once the described functionality lands on prod, let us know on #platform-docs-releases that your PR is ready for release. We will **merge** and **publish** the changes.
