### PR TITLE
CW-3029: Update rich message buttons value description

### DIFF
--- a/src/pages/extending-chat-widget/rich-messages/index.mdx
+++ b/src/pages/extending-chat-widget/rich-messages/index.mdx
@@ -116,7 +116,7 @@ Let's go through each element:
         * `phone` - allows Customers to call the number given directly from the chat.
     * `elements.buttons.postback_id` - a description of the sent action.
     * `elements.buttons.user_ids` - an array of the users who clicked the button. It can be empty.
-    * `elements.buttons.value` - defines what value the button should have depending on its type. It's either a message to be sent, a URL to be opened in a Moment or in a new tab, or a phone number to call.
+    * `elements.buttons.value` - defines what value the button should have depending on its type. It's either a URL to be opened in a Moment or in a new tab, or a phone number to call. For `message` type it is not a message that would be sent after clicking, in this case the message is aways equal to the `label` property.
     * `elements.buttons.webview_height` - required only if the `type` of the button is set to `webview`. It defines the size of the Moment shown to the user. It might be set to `compact`, `tall` or `full`.
 
 Since most of these parameters are optional, you have a lot of freedom and a number of possibilities to unleash your creativity.


### PR DESCRIPTION
# Deploy preview

As described in the ticket, the docs for [rich message button's value](https://developers.livechat.com/docs/extending-chat-widget/rich-messages#getting-started) contain false information about how `value` is handled in button type `message` - it is not a value that woud be sent after clicking - for this specific case the message always equals to `label` prop so that it is transparent for end user 

# Links

Link your Jira ticket.

- [Jira](https://livechatinc.atlassian.net/browse/CW-3029)

# Description

# Review and release

Apply changes and resolve conflicts. Once the described functionality lands on prod, let us know on #platform-docs-releases that your PR is ready for release. We will **merge** and **publish** the changes.
