### PR TITLE
API-9670 add description for auto_accesses_updated

### DIFF
--- a/src/pages/management/changelog/index.mdx
+++ b/src/pages/management/changelog/index.mdx
@@ -57,6 +57,11 @@ The developer preview version provides a preview of the upcoming changes to the 
   - [**tag_deleted**](/management/webhooks/v3.5/#tag_deleted)
   - [**tag_updated**](/management/webhooks/v3.5/#tag_updated)
 - The `work_scheduler` field in [**agent_created**](/management/webhooks/v3.5/#agent_created), [**agent_updated**](/management/webhooks/v3.5/#agent_updated), [**bot_created**](/management/webhooks/v3.5/#bot_created), and [**bot_updated**](/management/webhooks/v3.5/#bot_updated) webhooks has a new format.
+- The **auto_access_added**, **auto_access_updated** and **auto_access_deleted** webhooks were replaced by the [**auto_accesses_updated**](/management/webhooks/v3.5/#auto_accesses_updated) webhook.
+
+### Pushes
+
+- The **auto_access_added**, **auto_access_updated** and **auto_access_deleted** pushes were replaced by the [**auto_accesses_updated**](/messaging/agent-chat-api/v3.5/rtm-pushes#auto_accesses_updated) push.
 
 ### Other
 

--- a/src/pages/management/configuration-api/v3.5/index.mdx
+++ b/src/pages/management/configuration-api/v3.5/index.mdx
@@ -2902,9 +2902,7 @@ For `bot` webhooks, you need to [create a bot](#create-bot), [register webhooks]
 | [`bot_created`](#bot_created)                                         |                                                  `source_type` |
 | [`bot_updated`](#bot_updated)                                         |                                                  `source_type` |
 | [`bot_deleted`](#bot_deleted)                                         |                                                  `source_type` |
-| [`auto_access_created`](#auto_access_created)                         |                                                  `source_type` |
-| [`auto_access_updated`](#auto_access_updated)                         |                                                  `source_type` |
-| [`auto_access_deleted`](#auto_access_deleted)                         |                                                  `source_type` |
+| [`auto_accesses_updated`](#auto_accesses_updated)                     |                                                  `source_type` |
 
 </Text>
 

--- a/src/pages/management/webhooks/v3.5/index.mdx
+++ b/src/pages/management/webhooks/v3.5/index.mdx
@@ -1572,6 +1572,12 @@ The resulting payload can contain multiple objects depending on the action:
 }
 ```
 
+</CodeResponse>
+
+</Code>
+
+<Code>
+
 <CodeResponse title={'Sample webhook after updating auto access rule'}>
 
 ```json
@@ -1619,6 +1625,12 @@ The resulting payload can contain multiple objects depending on the action:
   }
 }
 ```
+
+</CodeResponse>
+
+</Code>
+
+<Code>
 
 <CodeResponse title={'Sample webhook after deleting auto access rule'}>
 

--- a/src/pages/management/webhooks/v3.5/index.mdx
+++ b/src/pages/management/webhooks/v3.5/index.mdx
@@ -1497,9 +1497,9 @@ Informs that an agent's account was deleted.
 
 Informs that auto access rules were modified. The payload contains an array of all changes done as result of adding, updating, or deleting auto access rule.
 The resulting payload can contain multiple objects depending on the action:
-- for added auto access rule, the payload contains the complete state of the auto access rule data structure, including empty fields.
-- for updated auto access rule, contains only the updated properties
-- for deleted auto access rule, confirms deletion
+- for the added auto access rule, the payload contains the complete state of the auto access rule data structure, including empty fields.
+- for the updated auto access rule, the payload contains only the updated properties.
+- for the deleted auto access rule, the payload confirms the deletion.
 
 #### Specifics
 

--- a/src/pages/management/webhooks/v3.5/index.mdx
+++ b/src/pages/management/webhooks/v3.5/index.mdx
@@ -19,18 +19,18 @@ In order to receive webhooks, you need to [register](/management/configuration-a
 
 ## Available webhooks
 
-|                   |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**         | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| **Chat access**   | [`chat_access_updated`](#chat_access_updated) [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| **Chat users**    | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| **Events**        | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated) [`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| **Properties**    | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_deleted`](#thread_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted)                                                                                                                                                                                                                 |
-| **Thread tags**   | [`thread_tagged`](#thread_tagged) [`thread_untagged`](#thread_untagged)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| **Status**        | [`routing_status_set`](#routing_status_set)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| **Customers**     | [`incoming_customer`](#incoming_customer) [`customer_session_fields_updated`](#customer_session_fields_updated)                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| **Configuration** | [`agent_created`](#agent_created) [`agent_approved`](#agent_approved) [`agent_updated`](#agent_updated) [`agent_suspended`](#agent_suspended) [`agent_unsuspended`](#agent_unsuspended) [`agent_deleted`](#agent_deleted) [`auto_access_added`](#auto_access_added) [`auto_access_updated`](#auto_access_updated) [`auto_access_deleted`](#auto_access_deleted) [`bot_created`](#bot_created) [`bot_updated`](#bot_updated) [`bot_deleted`](#bot_deleted) [`group_created`](#group_created) [`group_updated`](#group_updated) [`group_deleted`](#group_deleted) [`tag_created`](#tag_created) [`tag_deleted`](#tag_deleted) [`tag_updated`](#tag_updated) |
-| **Other**         | [`events_marked_as_seen`](#events_marked_as_seen)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+|                   |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Chats**         | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **Chat access**   | [`chat_access_updated`](#chat_access_updated) [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| **Chat users**    | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| **Events**        | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated) [`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **Properties**    | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_deleted`](#thread_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted)                                                                                                                                                                                                                       |
+| **Thread tags**   | [`thread_tagged`](#thread_tagged) [`thread_untagged`](#thread_untagged)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| **Status**        | [`routing_status_set`](#routing_status_set)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| **Customers**     | [`incoming_customer`](#incoming_customer) [`customer_session_fields_updated`](#customer_session_fields_updated)                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| **Configuration** | [`agent_created`](#agent_created) [`agent_approved`](#agent_approved) [`agent_updated`](#agent_updated) [`agent_suspended`](#agent_suspended) [`agent_unsuspended`](#agent_unsuspended) [`agent_deleted`](#agent_deleted) [`auto_accesses_updated`](#auto_accesses_updated) [`bot_created`](#bot_created) [`bot_updated`](#bot_updated) [`bot_deleted`](#bot_deleted) [`group_created`](#group_created) [`group_updated`](#group_updated) [`group_deleted`](#group_deleted) [`tag_created`](#tag_created) [`tag_deleted`](#tag_deleted) [`tag_updated`](#tag_updated) |
+| **Other**         | [`events_marked_as_seen`](#events_marked_as_seen)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 
 ## Chats
 
@@ -1493,22 +1493,26 @@ Informs that an agent's account was deleted.
 
 <Text>
 
-### `auto_access_added`
+### `auto_accesses_updated`
 
-Informs that a new auto access rule was added. The payload contains the full state of the auto access rule data structure, including empty fields.
+Informs that auto access rules were modified. The payload contains an array of all changes done as result of adding, updating, or deleting auto access rule.
+The resulting payload can contain multiple objects depending on the action:
+- for added auto access rule, the payload contains the complete state of the auto access rule data structure, including empty fields.
+- for updated auto access rule, contains only the updated properties
+- for deleted auto access rule, confirms deletion
 
 #### Specifics
 
-|                        |                                                                                  |
-| ---------------------- | -------------------------------------------------------------------------------- |
-| **Action**             | `auto_access_added`                                                              |
-| **Push equivalent in** | [`Agent Chat API`](/messaging/agent-chat-api/v3.5/rtm-pushes/#auto_access_added) |
+|                        |                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------ |
+| **Action**             | `auto_accesses_updated`                                                              |
+| **Push equivalent in** | [`Agent Chat API`](/messaging/agent-chat-api/v3.5/rtm-pushes/#auto_accesses_updated) |
 
 </Text>
 
 <Code>
 
-<CodeResponse title={'Sample webhook'}>
+<CodeResponse title={'Sample webhook after adding auto access rule'}>
 
 ```json
 {
@@ -1516,21 +1520,82 @@ Informs that a new auto access rule was added. The payload contains the full sta
   "secret_key": "<secret_key>",
   "action": "auto_access_added",
   "organization_id": "390e44e6-f1e6-0368c-z6ddb-74g14508c2ex",
-  "payload": {
-    "id": "pqi8oasdjahuakndw9nsad9na",
-    "description": "Chats on livechat.com from United States",
-    "access": {
-      "groups": [ 1 ]
+  "payload": "payload": [
+    {
+        "id": "a2710c4680fa15700ae046940a11a329",
+        "next_id": "f65e41f43bbb2fefe3756698ba47caeb",
+        "status": "updated"
     },
-    "conditions": {
-      "domain": {
-        "values": [
-          {
-            "value": "livechat.com",
-            "exact_match": true
-          }
-        ]
+    {
+        "id": "f65e41f43bbb2fefe3756698ba47caeb",
+        "description": "",
+        "access": {
+            "groups": [
+                0
+            ]
+        },
+        "conditions": {
+            "url": {
+                "values": [
+                    {
+                        "value": "https://www.auto-access.test",
+                        "exact_match": false
+                    }
+                ]
+            },
+            "domain": {
+                "values": [
+                    {
+                        "value": "https://www.auto-access.test",
+                        "exact_match": true
+                    }
+                ]
+            },
+            "geolocation": {
+                "values": [
+                    {
+                        "country": "United States",
+                        "country_code": "US",
+                        "region": "California",
+                        "city": "Mountain View"
+                    }
+                ]
+            }
+        },
+        "next_id": "",
+        "status": "added"
+    }
+  ],
+  "additional_data": {
+    // no additional data
+  }
+}
+```
+
+<CodeResponse title={'Sample webhook after updating auto access rule'}>
+
+```json
+{
+  "webhook_id": "<webhook_id>",
+  "secret_key": "<secret_key>",
+  "action": "auto_access_added",
+  "organization_id": "390e44e6-f1e6-0368c-z6ddb-74g14508c2ex",
+  "payload": [
+    {
+      "id": "a2710c4680fa15700ae046940a11a329",
+      "description": "Chats on livechat.com from United States",
+      "access": {
+        "groups": [ 1 ]
       },
+      "conditions": {
+        "domain": {
+          "values": [
+            {
+              "value": "livechat.com",
+              "exact_match": true
+            }
+          ]
+        },
       "geolocation": {
         "values": [
           {
@@ -1539,96 +1604,41 @@ Informs that a new auto access rule was added. The payload contains the full sta
           }
         ]
       }
+      "next_id": "",
+      "status": "updated"
     },
-    "next_id": "1faad6f5f1d6e8fdf27e8af9839783b7"
-  },
-  "additional_data": {
-    // no additional data
-  }
-}
-```
-
-</CodeResponse>
-
-</Code>
-
-</Section>
-
-<Section>
-
-<Text>
-
-### `auto_access_updated`
-
-Informs that the configuration of an auto access rule changed. Contains only the updated properties.
-
-#### Specifics
-
-|                        |                                                                                    |
-| ---------------------- | ---------------------------------------------------------------------------------- |
-| **Action**             | `auto_access_updated`                                                              |
-| **Push equivalent in** | [`Agent Chat API`](/messaging/agent-chat-api/v3.5/rtm-pushes/#auto_access_updated) |
-
-</Text>
-
-<Code>
-
-<CodeResponse title={'Sample webhook'}>
-
-```json
-{
-  "webhook_id": "<webhook_id>",
-  "secret_key": "<secret_key>",
-  "action": "auto_access_updated",
-  "organization_id": "390e44e6-f1e6-0368c-z6ddb-74g14508c2ex",
-  "payload": {
-    "id": "pqi8oasdjahuakndw9nsad9na",
-    "access": {
-      "groups": [ 0, 42 ]
+    {
+        "id": "f65e41f43bbb2fefe3756698ba47caeb",
+        "description": "Auto access updated",
+        "next_id": "a2710c4680fa15700ae046940a11a329",
+        "status": "updated"
     }
-  },
+  ],
   "additional_data": {
     // no additional data
   }
 }
 ```
 
-</CodeResponse>
-
-</Code>
-
-</Section>
-
-<Section>
-
-<Text>
-
-### `auto_access_deleted`
-
-Informs that an autoaccess rule was deleted.
-
-#### Specifics
-
-|                        |                                                                                    |
-| ---------------------- | ---------------------------------------------------------------------------------- |
-| **Action**             | `auto_access_deleted`                                                              |
-| **Push equivalent in** | [`Agent Chat API`](/messaging/agent-chat-api/v3.5/rtm-pushes/#auto_access_deleted) |
-
-</Text>
-
-<Code>
-
-<CodeResponse title={'Sample webhook'}>
+<CodeResponse title={'Sample webhook after deleting auto access rule'}>
 
 ```json
 {
   "webhook_id": "<webhook_id>",
   "secret_key": "<secret_key>",
-  "action": "auto_access_deleted",
+  "action": "auto_access_added",
   "organization_id": "390e44e6-f1e6-0368c-z6ddb-74g14508c2ex",
-  "payload": {
-    "id": "pqi8oasdjahuakndw9nsad9na"
-  },
+  "payload": [
+    {
+        "id": "f65e41f43bbb2fefe3756698ba47caeb",
+        "next_id": "",
+        "status": "updated"
+    },
+    {
+        "id": "a2710c4680fa15700ae046940a11a329",
+        "status": "deleted"
+    }
+  ]
   "additional_data": {
     // no additional data
   }

--- a/src/pages/messaging/agent-chat-api/v3.5/rtm-pushes/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.5/rtm-pushes/index.mdx
@@ -891,9 +891,9 @@ Informs that an agent's account was deleted.
 
 Informs that auto access rules were modified. The payload contains an array of all changes done as result of adding, updating, or deleting auto access rule.
 The resulting payload can contain multiple objects depending on the action:
-- for added [auto access](/management/configuration-api/v3.5/#auto-access) rule, the payload contains the complete state of the auto access rule data structure, including empty fields.
-- for updated [auto access](/management/configuration-api/v3.5/#auto-access) rule, contains only the updated properties
-- for deleted [auto access](/management/configuration-api/v3.5/#auto-access) rule, confirms deletion
+- for the added [auto access](/management/configuration-api/v3.5/#auto-access) rule, the payload contains the complete state of the auto access rule data structure, including empty fields.
+- for the updated [auto access](/management/configuration-api/v3.5/#auto-access) rule, the payload contains only the updated properties.
+- for the deleted [auto access](/management/configuration-api/v3.5/#auto-access) rule, the payload confirms the deletion.
 
 <CodeResponse title={'Sample push payload after adding auto access rule'}>
 

--- a/src/pages/messaging/agent-chat-api/v3.5/rtm-pushes/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.5/rtm-pushes/index.mdx
@@ -26,18 +26,18 @@ Here's what you need to know about **pushes**:
 
 ## Available pushes
 
-|                   |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chats**         | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated) [`chat_deleted`](#chat_deleted) [`thread_deleted`](#thread_deleted) [`threads_deleted`](#threads_deleted)                                                                                                                                                                                                                                                                                                                                                                             |
-| **Chat access**   | [`chat_access_updated`](#chat_access_updated) [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| **Chat users**    | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| **Events**        | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| **Properties**    | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted)                                                                                                                                                                                                                 |
-| **Thread tags**   | [`thread_tagged`](#thread_tagged) [`thread_untagged`](#thread_untagged)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| **Customers**     | [`incoming_customers`](#incoming_customers) [`incoming_customer`](#incoming_customer) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_banned`](#customer_banned) [`customer_transferred`](#customer_transferred) [`customer_left`](#customer_left)                                                                                                                                                                                                                                                         |
-| **Status**        | [`routing_status_set`](#routing_status_set) [`agent_disconnected`](#agent_disconnected)                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| **Configuration** | [`agent_created`](#agent_created) [`agent_approved`](#agent_approved) [`agent_updated`](#agent_updated) [`agent_suspended`](#agent_suspended) [`agent_unsuspended`](#agent_unsuspended) [`agent_deleted`](#agent_deleted) [`auto_access_added`](#auto_access_added) [`auto_access_updated`](#auto_access_updated) [`auto_access_deleted`](#auto_access_deleted) [`bot_created`](#bot_created) [`bot_updated`](#bot_updated) [`bot_deleted`](#bot_deleted) [`group_created`](#group_created) [`group_updated`](#group_updated) [`group_deleted`](#group_deleted) [`tag_created`](#tag_created) [`tag_deleted`](#tag_deleted) [`tag_updated`](#tag_updated) [`groups_status_updated`](#groups_status_updated)|
-| **Other**         | [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_sneak_peek`](#incoming_sneak_peek) [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`chat_unfollowed`](#chat_unfollowed) [`queue_positions_updated`](#queue_positions_updated) [`customer_unfollowed`](#customer-unfollowed)                                                                                                                                                                                                                 |
+|                   |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Chats**         | [`incoming_chat`](#incoming_chat) [`chat_deactivated`](#chat_deactivated) [`chat_deleted`](#chat_deleted) [`thread_deleted`](#thread_deleted) [`threads_deleted`](#threads_deleted)                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| **Chat access**   | [`chat_access_updated`](#chat_access_updated) [`chat_transferred`](#chat_transferred)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| **Chat users**    | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| **Events**        | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| **Properties**    | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted)                                                                                                                                                                                                                                                                         |
+| **Thread tags**   | [`thread_tagged`](#thread_tagged) [`thread_untagged`](#thread_untagged)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| **Customers**     | [`incoming_customers`](#incoming_customers) [`incoming_customer`](#incoming_customer) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_banned`](#customer_banned) [`customer_transferred`](#customer_transferred) [`customer_left`](#customer_left)                                                                                                                                                                                                                                                                                                                 |
+| **Status**        | [`routing_status_set`](#routing_status_set) [`agent_disconnected`](#agent_disconnected)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| **Configuration** | [`agent_created`](#agent_created) [`agent_approved`](#agent_approved) [`agent_updated`](#agent_updated) [`agent_suspended`](#agent_suspended) [`agent_unsuspended`](#agent_unsuspended) [`agent_deleted`](#agent_deleted) [`auto_accesses_updated`](#auto_accesses_updated) [`bot_created`](#bot_created) [`bot_updated`](#bot_updated) [`bot_deleted`](#bot_deleted) [`group_created`](#group_created) [`group_updated`](#group_updated) [`group_deleted`](#group_deleted) [`tag_created`](#tag_created) [`tag_deleted`](#tag_deleted) [`tag_updated`](#tag_updated) [`groups_status_updated`](#groups_status_updated) |
+| **Other**         | [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_sneak_peek`](#incoming_sneak_peek) [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`chat_unfollowed`](#chat_unfollowed) [`queue_positions_updated`](#queue_positions_updated) [`customer_unfollowed`](#customer-unfollowed)                                                                                                                                                                                                                                                                         |
 
 </Text>
 
@@ -887,70 +887,102 @@ Informs that an agent's account was deleted.
 
 </CodeResponse>
 
-### `auto_access_added`
+### `auto_accesses_updated`
 
-Informs that a new [auto access](/management/configuration-api/v3.5/#auto-access) rule was added. The payload contains the full state of the auto access rule data structure, including empty fields.
+Informs that auto access rules were modified. The payload contains an array of all changes done as result of adding, updating, or deleting auto access rule.
+The resulting payload can contain multiple objects depending on the action:
+- for added [auto access](/management/configuration-api/v3.5/#auto-access) rule, the payload contains the complete state of the auto access rule data structure, including empty fields.
+- for updated [auto access](/management/configuration-api/v3.5/#auto-access) rule, contains only the updated properties
+- for deleted [auto access](/management/configuration-api/v3.5/#auto-access) rule, confirms deletion
 
-<CodeResponse title={'Sample push payload'}>
-
-```json
-{
-  "id": "pqi8oasdjahuakndw9nsad9na",
-  "description": "Chats on livechat.com from United States",
-  "access": {
-    "groups": [ 1 ]
-  },
-  "conditions": {
-    "domain": {
-      "values": [
-        {
-          "value": "livechat.com",
-          "exact_match": true
-        }
-      ]
-    },
-    "geolocation": {
-      "values": [
-        {
-          "country": "United States",
-          "country_code": "US"
-        }
-      ]
-    }
-  },
-  "next_id": "1faad6f5f1d6e8fdf27e8af9839783b7"
-}
-```
-
-</CodeResponse>
-
-### `auto_access_updated`
-
-Informs that the configration of an [auto access](/management/configuration-api/v3.5/#auto-access) rule changed. Contains only the updated properties.
-
-<CodeResponse title={'Sample push payload'}>
+<CodeResponse title={'Sample push payload after adding auto access rule'}>
 
 ```json
-{
-  "id": "pqi8oasdjahuakndw9nsad9na",
-  "access": {
-    "groups": [ 0, 42 ]
+[
+  {
+      "id": "dc70916fdc9d02ea0bcdee5b2fa64717",
+      "next_id": "b1cd0bfea640f671694110c6ae34356f",
+      "status": "updated"
+  },
+  {
+      "id": "b1cd0bfea640f671694110c6ae34356f",
+      "description": "",
+      "access": {
+          "groups": [
+              0
+          ]
+      },
+      "conditions": {
+          "url": {
+              "values": [
+                  {
+                      "value": "https://www.auto-access.test",
+                      "exact_match": false
+                  }
+              ]
+          },
+          "domain": {
+              "values": [
+                  {
+                      "value": "https://www.auto-access.test",
+                      "exact_match": true
+                  }
+              ]
+          },
+          "geolocation": {
+              "values": [
+                  {
+                      "country": "United States",
+                      "country_code": "US",
+                      "region": "California",
+                      "city": "Mountain View"
+                  }
+              ]
+          }
+      },
+      "next_id": "",
+      "status": "added"
   }
-}
+]
 ```
 
 </CodeResponse>
 
-### `auto_access_deleted`
-
-Informs that an [auto access](/management/configuration-api/v3.5/#auto-access) rule was deleted.
-
-<CodeResponse title={'Sample push payload'}>
+<CodeResponse title={'Sample push payload after updating auto access rule'}>
 
 ```json
-{
-  "id": "pqi8oasdjahuakndw9nsad9na"
-}
+[
+  {
+      "id": "b1cd0bfea640f671694110c6ae34356f",
+      "description": "Auto access updated",
+      "next_id": "dc70916fdc9d02ea0bcdee5b2fa64717",
+      "status": "updated"
+  },
+  {
+      "id": "dc70916fdc9d02ea0bcdee5b2fa64717",
+      "next_id": "",
+      "status": "updated"
+  }
+]
+
+```
+
+</CodeResponse>
+
+<CodeResponse title={'Sample push payload after deleting auto access rule'}>
+
+```json
+[
+  {
+      "id": "b1cd0bfea640f671694110c6ae34356f",
+      "next_id": "",
+      "status": "updated"
+  },
+  {
+      "id": "dc70916fdc9d02ea0bcdee5b2fa64717",
+      "status": "deleted"
+  }
+]
 ```
 
 </CodeResponse>


### PR DESCRIPTION
# Deploy preview

Scroll down to the checks section for the link to the deploy preview of your branch.

# Links

Link your Jira ticket.

- [Jira](https://livechatinc.atlassian.net/browse/API-9264)

# Description

We're changing how webhooks and pushes for modification of auto access rules work.
Instead of multiple pushes in 3.5, we're introducing a new push/webhook - auto_accesses_updated that aggregates all changes done in single action as a single push/webhook instead of old behavior, which resulted in multiple pushes from one action.

# Review and release

Apply changes and resolve conflicts. Once the described functionality lands on prod, let us know on #platform-docs-releases that your PR is ready for release. We will **merge** and **publish** the changes.
