### PR TITLE
API-11796: describe fix for get_chat access

### DIFF
--- a/src/pages/messaging/agent-chat-api/changelog/index.mdx
+++ b/src/pages/messaging/agent-chat-api/changelog/index.mdx
@@ -21,6 +21,8 @@ The developer preview version provides a preview of the upcoming changes to the 
 
 ## [v3.6] - Developer preview
 
+### Chats
+
 - The **Get Chat** ([Web](/messaging/agent-chat-api/v3.6/#get-chat) & [RTM](/messaging/agent-chat-api/v3.6/rtm-reference/#get-chat)) method now validates access to the requested thread.
 
 ## [v3.5] - 2022-11-23

--- a/src/pages/messaging/agent-chat-api/changelog/index.mdx
+++ b/src/pages/messaging/agent-chat-api/changelog/index.mdx
@@ -21,13 +21,14 @@ The developer preview version provides a preview of the upcoming changes to the 
 
 ## [v3.6] - Developer preview
 
-No changes yet.
+- The **Get Chat** ([Web](/messaging/agent-chat-api/v3.6/#get-chat) & [RTM](/messaging/agent-chat-api/v3.6/rtm-reference/#get-chat)) method now validates access to the requested thread.
 
 ## [v3.5] - 2022-11-23
 
 ### Chats
 
 - The **List Archives** ([Web](/messaging/agent-chat-api/v3.5/#list-archives) & [RTM](/messaging/agent-chat-api/v3.5/rtm-reference/#list-archives)) method has a new filter, `customer_countries`.
+- 🛠️ (2022-12-7): The **Get Chat** ([Web](/messaging/agent-chat-api/v3.5/#get-chat) & [RTM](/messaging/agent-chat-api/v3.5/rtm-reference/#get-chat)) method now validates access to the requested thread.
 
 ### Status
 
@@ -57,6 +58,7 @@ No changes yet.
 - The **Start Chat** ([Web](/messaging/agent-chat-api/v3.4/#start-chat) & [RTM](/messaging/agent-chat-api/v3.4/rtm-reference/#start-chat)) and **Resume Chat** ([Web](/messaging/agent-chat-api/v3.4/#resume-chat) & [RTM](/messaging/agent-chat-api/v3.4/rtm-reference/#resume-chat)) methods now require that authors (except the requester) of all initial events are listed in the `users` field. Both the events and users have a fixed `visibility` set to `all`.
 - The **Start Chat**, **Resume Chat**, **Send Event**, **Send Typing Indicator**, and **Send Rich Message Postback** methods now require either the `chats--all:rw` or `chats--access:rw` scope instead of the `chats.conversation--all:rw` or `chats.conversation--access:rw`.
 - The **Deactivate Chat** ([Web](/messaging/agent-chat-api/v3.4/#deactivate-chat) & [RTM](/messaging/agent-chat-api/v3.4/rtm-reference/#deactivate-chat)) method now requires the requester to be present on the list of chat users. You can override it with a new param, `ignore_requester_presence`.
+- 🛠️ (2022-12-7): The **Get Chat** ([Web](/messaging/agent-chat-api/v3.4/#get-chat) & [RTM](/messaging/agent-chat-api/v3.4/rtm-reference/#get-chat)) method now validates access to the requested thread.
 
 ### Chats users
 


### PR DESCRIPTION
# Deploy preview

Scroll down to the checks section for the link to the deploy preview of your branch.

# Links

Link your Jira ticket.

- [Jira](https://livechatinc.atlassian.net/browse/API-11796)

# Description

`get_chat` in Agent API v3.4+ now validates access to thread.

# Review and release

Apply changes and resolve conflicts. Once the described functionality lands on prod, let us know on #platform-docs-releases that your PR is ready for release. We will **merge** and **publish** the changes.
