### PR TITLE
API-11995 Removed create group priority requirement

### DIFF
--- a/src/pages/management/changelog/index.mdx
+++ b/src/pages/management/changelog/index.mdx
@@ -25,7 +25,9 @@ The developer preview version provides a preview of the upcoming changes to the 
 
 ## [v3.6] - Developer preview
 
-No changes yet.
+### Groups
+
+- The [**Create Group**](/management/configuration-api/v3.6/#create-group) method parameter `agent_priorities` requirement "At least one Agent must have the `normal` priority" were removed.
 
 ## [v3.5] - 2022-11-23
 

--- a/src/pages/management/changelog/index.mdx
+++ b/src/pages/management/changelog/index.mdx
@@ -27,7 +27,7 @@ The developer preview version provides a preview of the upcoming changes to the 
 
 ### Groups
 
-- The [**Create Group**](/management/configuration-api/v3.6/#create-group) method parameter `agent_priorities` requirement "At least one Agent must have the `normal` priority" were removed.
+- The "At least one Agent must have the `normal` priority" requirement was removed from the [**Create Group**](/management/configuration-api/v3.6/#create-group) method's  `agent_priorities` parameter.
 
 ## [v3.5] - 2022-11-23
 

--- a/src/pages/management/configuration-api/v3.6/index.mdx
+++ b/src/pages/management/configuration-api/v3.6/index.mdx
@@ -1507,7 +1507,7 @@ Creates a new group.
 | ----------------------- | --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `name`                  | `string`  | Yes      | Group name (up to 180 chars)                                                                                                     |
 | `language_code`         | `string`  | No       | The code of the group languange                                                                                                  |
-| `agent_priorities`__*__ | `object`  | Yes      | Agents' priorities in a group as a map in the `"<id>": "<priority>"` format. At least one Agent must have the `normal` priority. |
+| `agent_priorities`__*__ | `object`  | Yes      | Agents' priorities in a group as a map in the `"<id>": "<priority>"` format.                                                     |
 
 __*__ The table below presents the possible values for the `agent_priorities` map:
 


### PR DESCRIPTION
# Deploy preview

Scroll down to the checks section for the link to the deploy preview of your branch.

# Links

Link your Jira ticket.

- [Jira](https://livechatinc.atlassian.net/browse/API-11995)

# Description
Remove "At least one Agent must have the `normal` priority." requirement in Create group method.

# Review and release

Apply changes and resolve conflicts. Once the described functionality lands on prod, let us know on #platform-docs-releases that your PR is ready for release. We will **merge** and **publish** the changes.
