### PR TITLE
AA-13871: Apple Messages for Business Authentication new Authentication Message

### DIFF
--- a/src/pages/messaging/apple-messages-for-business/index.mdx
+++ b/src/pages/messaging/apple-messages-for-business/index.mdx
@@ -139,6 +139,7 @@ Pass authentication data between LiveChat and the customer's device using OAuth.
 | `authenticate.oauth2.clientSecret`          | Yes      | `string`  |
 | `authenticate.oauth2.state`                 | Yes      | `string`  |
 | `authenticate.oauth2.responseEncryptionKey` | Yes      | `string`  |
+| `authenticate.oauth2.redirectURI`           | No       | `string`  | The location where the Apple sends the user after successful authorization. It's required by the [New Authentication Message Specification](https://register.apple.com/resources/messages/msp-rest-api/new-oauth) |
 
 ### Invoke Custom Extension
 

--- a/src/pages/messaging/apple-messages-for-business/index.mdx
+++ b/src/pages/messaging/apple-messages-for-business/index.mdx
@@ -139,7 +139,7 @@ Pass authentication data between LiveChat and the customer's device using OAuth.
 | `authenticate.oauth2.clientSecret`          | Yes      | `string`  |
 | `authenticate.oauth2.state`                 | Yes      | `string`  |
 | `authenticate.oauth2.responseEncryptionKey` | Yes      | `string`  |
-| `authenticate.oauth2.redirectURI`           | No       | `string`  | The location where the Apple sends the user after successful authorization. It's required by the [New Authentication Message Specification](https://register.apple.com/resources/messages/msp-rest-api/new-oauth) |
+| `authenticate.oauth2.redirectURI`           | No       | `string`  | The location where Apple sends the user after successful authorization. It's required by the [New Authentication Message Specification](https://register.apple.com/resources/messages/msp-rest-api/new-oauth) |
 
 ### Invoke Custom Extension
 


### PR DESCRIPTION
# Deploy preview

https://63db94345db0cb348ed415bc--livechat-public-docs.netlify.app

# Links

Link your Jira ticket.

- [Jira](https://livechatinc.atlassian.net/browse/AA-13871)

# Description

We've added support to the new [Authentication Message](https://register.apple.com/resources/messages/msp-rest-api/new-oauth), which will work on devices running iOS 16, iPadOS 16 or macOS 13. The changes support backward compatibility with the older devices.

# Review and release

Apply changes and resolve conflicts. Once the described functionality lands on prod, let us know on #platform-docs-releases that your PR is ready for release. We will **merge** and **publish** the changes.
