### PR TITLE
Reset padding for `pre code`

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -614,6 +614,7 @@ td code {
 pre code {
   background: none;
   line-height: 1.42;
+  padding: 0;
 }
 code:before,
 code:after,


### PR DESCRIPTION
# Description
Remove annoying blank spaces for each first line in the code listing.

<img width="886" alt="Screenshot 2023-02-13 at 13 43 21" src="https://user-images.githubusercontent.com/351535/218461371-13a0ca55-39dd-402e-bbaa-0f5081e8ccb0.png">
