### PR TITLE
adjusting customerSDK public docs to future changes

### DIFF
--- a/src/pages/extending-chat-widget/customer-sdk/index.mdx
+++ b/src/pages/extending-chat-widget/customer-sdk/index.mdx
@@ -2212,7 +2212,7 @@ customerSDK.on('disconnected', ({ reason }) => {
 
 ### Fixed
 
-- Fixed situations when a value for `urlDetails.imageUrl` available in the `getUrlInfo` method can sometimes return a URL with a duplicated protocol (like "https://https://livechat.com/logo.png")
+- Fixed situations when a value for `urlDetails.imageUrl` available in the `getUrlInfo` method could sometimes return a URL with a duplicated protocol (like "https://https://...")
 
 ## [v3.1.0] - 2021-10-7
 

--- a/src/pages/extending-chat-widget/customer-sdk/index.mdx
+++ b/src/pages/extending-chat-widget/customer-sdk/index.mdx
@@ -2208,7 +2208,7 @@ customerSDK.on('disconnected', ({ reason }) => {
 
 # Changelog
 
-## [v3.1.2] - 2023-02-21
+## [v3.1.2] - 2023-02-28
 
 ### Fixed
 

--- a/src/pages/extending-chat-widget/customer-sdk/index.mdx
+++ b/src/pages/extending-chat-widget/customer-sdk/index.mdx
@@ -74,7 +74,7 @@ Or use the node-style `require` call:
 
 ### Using a script tag - UMD module hosted on unpkg's CDN
 
-`<script src="https://unpkg.com/@livechat/customer-sdk@3.1.0"></script>`
+`<script src="https://unpkg.com/@livechat/customer-sdk@3.1.2"></script>`
 
 If you just want to look around and play with the SDK, check out our
 [sample chat widget implementation](https://codesandbox.io/s/rm3prxw88n).
@@ -2207,6 +2207,12 @@ customerSDK.on('disconnected', ({ reason }) => {
 ```
 
 # Changelog
+
+## [v3.1.2] - 2023-02-21
+
+### Fixed
+
+- Fixed situations when a value for `urlDetails.imageUrl` available in the `getUrlInfo` method can sometimes return a URL with a duplicated protocol (like "https://https://livechat.com/logo.png")
 
 ## [v3.1.0] - 2021-10-7
 


### PR DESCRIPTION
# Deploy preview

https://63fc9ae73c0ada01f81ada8c--livechat-public-docs.netlify.app/extending-chat-widget/customer-sdk#using-a-script-tag---umd-module-hosted-on-unpkgs-cdn

# Links

Link your Jira ticket.

No Jira related to this task

# Description

We are about to release small changes to the CustomerSDK – **changes should be released next week on production**, probably on 2023-02-21. 

Changes will include a fix to `getUrlInfo` method, mainly to the `urlDetails.imageUrl`. Before the fix, this method could sometimes return a URL with a double protocol in front of the img address. 

Because the change also bumps the version of CustomerSDK, I also bumped it in the link to UMD module. 