### PR TITLE
API-12277: update get_dynamic_configuration

### DIFF
--- a/src/pages/messaging/customer-chat-api/changelog/index.mdx
+++ b/src/pages/messaging/customer-chat-api/changelog/index.mdx
@@ -21,7 +21,9 @@ The developer preview version provides a preview of the upcoming changes to the 
 
 ## [v3.6] - Developer preview
 
-No changes yet.
+### Config
+
+- The [**Get Dynamic Configuration**](/messaging/customer-chat-api/v3.6/#get-dynamic-configuration) response has a new format to support non-LiveChat widgets as default widgets.
 
 ## [v3.5] - 2022-11-23
 

--- a/src/pages/messaging/customer-chat-api/v3.6/index.mdx
+++ b/src/pages/messaging/customer-chat-api/v3.6/index.mdx
@@ -624,16 +624,19 @@ Returns the dynamic configuration of a given group. It provides data to call [**
 
 #### Response
 
-| Field                   | Data type | Notes                                                                                                                                |
-| ----------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `group_id`              | `number`  | The ID of the group for which the dynamic configuration is returned.                                                                 |
-| `organization_id`       | `string`  | The ID of the organization for which the dynamic configuration is returned.                                                          |
-| `client_limit_exceeded` | `bool`    | Specifies if the limit of customers having a chat was exceeded.                                                                      |
-| `domain_allowed`        | `bool`    | Specifies if `url` is configured as a trusted domain (configurable in the Agent Application).                                        |
-| `online_group_ids`      | `array`   | It is returned in response with all the group IDs where agents accept chats. It is not visible when there is no such group.    |
-| `config_version`        | `string`  | The version for which you want to get a configuration. Use it as `version` when calling [**Get Configuration**](#get-configuration). |
-| `localization_version`  | `string`  | The version for which you want to get a localization. Use it as `version` when calling [**Get Localization**](#get-localization).    |
-| `language`              | `string`  | The language of the group for which the dynamic configuration is returned.                                                           |
+| Field                            | Data type | Notes                                                                                                                                |
+| -------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `organization_id`                | `string`  | The ID of the organization for which the dynamic configuration is returned.                                                          |
+| `default_widget`                 | `string`  | The default widget to be used; possible values: `livechat`, `openwidget`, `chatbot`.                                                 |
+| `livechat_active`                | `bool`    | Specifies if the LiveChat product license is active.                                                                                 |
+| `livechat`                       | `object`  | Contains the configuration specific to the LiveChat product. It's present only when `livechat_active` is set to `true`.              |
+| `livechat.group_id`              | `number`  | The ID of the group for which the dynamic configuration is returned.                                                                 |
+| `livechat.client_limit_exceeded` | `bool`    | Specifies if the limit of customers having a chat was exceeded.                                                                      |
+| `livechat.domain_allowed`        | `bool`    | Specifies if `url` is configured as a trusted domain (configurable in the Agent Application).                                        |
+| `livechat.online_group_ids`      | `array`   | It is returned in response with all the group IDs where agents accept chats. It is not visible when there is no such group.          |
+| `livechat.config_version`        | `string`  | The version for which you want to get a configuration. Use it as `version` when calling [**Get Configuration**](#get-configuration). |
+| `livechat.localization_version`  | `string`  | The version for which you want to get a localization. Use it as `version` when calling [**Get Localization**](#get-localization).    |
+| `livechat.language`              | `string`  | The language of the group for which the dynamic configuration is returned.                                                           |
 
 </Text>
 
@@ -652,15 +655,20 @@ curl -X GET \
 
 ```json
 {
-  "group_id": 0,
-  "client_limit_exceeded": false,
-  "domain_allowed": true,
-  "online_group_ids": [
-    0
-  ],
-  "config_version": "84cc87cxza5ee24ed0f84fe3027fjf0c71",
-  "localization_version": "79cc87cea5ee24ed0f84fe3027fc0c74",
-  "language": "en"
+  "organization_id": "142cf3ad-5d54-4cf6-8ce1-3773d14d7f3f",
+  "default_widget": "livechat",
+  "livechat_active": true,
+  "livechat": {
+    "group_id": 0,
+    "client_limit_exceeded": false,
+    "domain_allowed": true,
+    "online_group_ids": [
+      0
+    ],
+    "config_version": "84cc87cxza5ee24ed0f84fe3027fjf0c71",
+    "localization_version": "79cc87cea5ee24ed0f84fe3027fc0c74",
+    "language": "en"
+  }
 }
 ```
 


### PR DESCRIPTION
# Preview

https://63fe0860b51feb19505af6c4--livechat-public-docs.netlify.app

# Links

- [API-12277](https://livechatinc.atlassian.net/browse/API-12277)

# Description

We've changed the response format of `get_dynamic_configuration` in v3.6+ to support non-LC widgets as default widgets.


[API-12277]: https://livechatinc.atlassian.net/browse/API-12277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ