### PR TITLE
ACC-2209 update authentication and add request body

### DIFF
--- a/src/configs/redoc/global-accounts-api/spec.yml
+++ b/src/configs/redoc/global-accounts-api/spec.yml
@@ -619,12 +619,16 @@ paths:
         - Accounts
       summary: Delete an account
       description: >-
-        Deletes an account for a given `account_id`. The ID can be replaced with
-        `me` to delete the account that performs the request.
+        Deletes an account for a given `account_id` or removes the given
+        account from a given product. The ID can be replaced with `me` to
+        delete the account that performs the request.
       security:
         - Personal Access Token: null
         - OAuth2 Bearer Token:
-            - accounts--my:rw
+            - accounts--my:rw or
+            - accounts--all:rw (if account_id is different than requester's ID) or
+            - accounts.roles.lc--all:rw (if product is LiveChat and account_id is different than requester's ID) or
+            - accounts.roles.hd--all:rw (if product is HelpDesk and account_id is different than requester's ID)
       parameters:
         - in: path
           name: account_id
@@ -633,6 +637,37 @@ paths:
             format: uuid
           required: true
           description: Unique account ID or `me`.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - description: Remove an account from a given product.
+                  type: object
+                  required:
+                    - mode
+                    - product
+                  properties:
+                    mode:
+                      type: string
+                      enum: 
+                        - product
+                    product:
+                      type: string
+                      enum:
+                        - LiveChat
+                        - HelpDesk
+                - description: Delete an account.
+                  type: object
+                  required:
+                    - mode
+                  properties:
+                    mode:
+                      type: string
+                      enum: 
+                        - organization
+                        - ""
       responses:
         '200':
           description: 'OK: Returns no content.'
@@ -691,7 +726,9 @@ paths:
       security:
         - Personal Access Token: null
         - OAuth2 Bearer Token:
-            - accounts.roles--all:rw
+            - accounts.roles--all:rw or
+            - accounts.roles.lc--all:rw (when request includes LiveChat roles) and/or
+            - accounts.roles.hd--all:rw (when request includes HelpDesk roles)
       tags:
         - Accounts
       parameters:


### PR DESCRIPTION
# Deploy preview

https://640af8507e0ecc6f98576924--livechat-public-docs.netlify.app/authorization/global-accounts-api#tag/Accounts/paths/~1accounts~1%7Baccount_id%7D/delete

# Links
[ACC-2209][]

[ACC-2209]: https://livechatinc.atlassian.net/browse/ACC-2209

# Description
I updated required scopes for two of the endpoints. This change is related to [ACC-2209][] that will remove some of the scopes from product admins. Therefore, for some of the accounts, more granular scopes will have to be used.

# Review and release

Apply changes and resolve conflicts. Once the described functionality lands on prod, let us know on #platform-docs-releases that your PR is ready for release. We will **merge** and **publish** the changes.
