### PR TITLE
API-12676: fix scopes description in Add User To Chat

### DIFF
--- a/src/pages/messaging/agent-chat-api/index.mdx
+++ b/src/pages/messaging/agent-chat-api/index.mdx
@@ -1054,9 +1054,9 @@ To learn how to add more than one agent to the chat, reach out to us [on Discord
 | **RTM API equivalent** | [`add_user_to_chat`](/messaging/agent-chat-api/v3.5/rtm-reference/#add-user-to-chat) |
 | **Webhook**            | [`user_added_to_chat`](/management/webhooks/v3.5/#user_added_to_chat)                |
 
-**\*** `chats--all:rw` - to add a user to a chat taking place in any group.
+**\*** `chats--all:rw` - to add the requester (related to the token) to a chat taking place in any group.
 
-**\*\*)** `chats--access:rw` - to add a user to a chat taking place in groups that the requester (related to the token) is a member of. (The agent groups and the chat groups must overlap - at least one group must be in common.)
+**\*\*)** `chats--access:rw` - to add a user to a chat taking place in groups that the user is a member of. (The agent groups and the chat groups must overlap - at least one group must be in common.)
 
 #### Request
 

--- a/src/pages/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -1156,9 +1156,9 @@ To learn how to add more than one agent to the chat, reach out to us [on Discord
 | **Web API equivalent** | [`add_user_to_chat`](/messaging/agent-chat-api/v3.5/#add-user-to-chat)                |
 | **Push message**       | [`user_added_to_chat`](/messaging/agent-chat-api/v3.5/rtm-pushes/#user_added_to_chat) |
 
-**\*** `chats--all:rw` - to add a user to a chat taking place in any group.
+**\*** `chats--all:rw` - to add the requester (related to the token) to a chat taking place in any group.
 
-**\*\*)** `chats--access:rw` - to add a user to a chat taking place in groups that the requester (related to the token) is a member of. (The agent groups and the chat groups must overlap - at least one group must be in common.)
+**\*\*)** `chats--access:rw` - to add a user to a chat taking place in groups that the user is a member of. (The agent groups and the chat groups must overlap - at least one group must be in common.)
 
 #### Request
 

--- a/src/pages/messaging/agent-chat-api/v3.4/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.4/index.mdx
@@ -1062,9 +1062,9 @@ To learn how to add more than one agent to the chat, reach out to us [on Discord
 | **RTM API equivalent** | [`add_user_to_chat`](/messaging/agent-chat-api/v3.4/rtm-reference/#add-user-to-chat) |
 | **Webhook**            | [`user_added_to_chat`](/management/webhooks/v3.4/#user_added_to_chat)                |
 
-**\*** `chats--all:rw` - to add a user to a chat taking place in any group.
+**\*** `chats--all:rw` - to add the requester (related to the token) to a chat taking place in any group.
 
-**\*\*)** `chats--access:rw` - to add a user to a chat taking place in groups that the requester (related to the token) is a member of. (The agent groups and the chat groups must overlap - at least one group must be in common.)
+**\*\*)** `chats--access:rw` - to add a user to a chat taking place in groups that the user is a member of. (The agent groups and the chat groups must overlap - at least one group must be in common.)
 
 #### Request
 

--- a/src/pages/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
@@ -1160,9 +1160,9 @@ To learn how to add more than one agent to the chat, reach out to us [on Discord
 | **Web API equivalent** | [`add_user_to_chat`](/messaging/agent-chat-api/v3.4/#add-user-to-chat)                |
 | **Push message**       | [`user_added_to_chat`](/messaging/agent-chat-api/v3.4/rtm-pushes/#user_added_to_chat) |
 
-**\*** `chats--all:rw` - to add a user to a chat taking place in any group.
+**\*** `chats--all:rw` - to add the requester (related to the token) to a chat taking place in any group.
 
-**\*\*)** `chats--access:rw` - to add a user to a chat taking place in groups that the requester (related to the token) is a member of. (The agent groups and the chat groups must overlap - at least one group must be in common.)
+**\*\*)** `chats--access:rw` - to add a user to a chat taking place in groups that the user is a member of. (The agent groups and the chat groups must overlap - at least one group must be in common.)
 
 #### Request
 

--- a/src/pages/messaging/agent-chat-api/v3.6/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.6/index.mdx
@@ -1088,9 +1088,9 @@ To learn how to add more than one agent to the chat, reach out to us [on Discord
 | **RTM API equivalent** | [`add_user_to_chat`](/messaging/agent-chat-api/v3.6/rtm-reference/#add-user-to-chat) |
 | **Webhook**            | [`user_added_to_chat`](/management/webhooks/v3.6/#user_added_to_chat)                |
 
-**\*** `chats--all:rw` - to add a user to a chat taking place in any group.
+**\*** `chats--all:rw` - to add the requester (related to the token) to a chat taking place in any group.
 
-**\*\*)** `chats--access:rw` - to add a user to a chat taking place in groups that the requester (related to the token) is a member of. (The agent groups and the chat groups must overlap - at least one group must be in common.)
+**\*\*)** `chats--access:rw` - to add a user to a chat taking place in groups that the user is a member of. (The agent groups and the chat groups must overlap - at least one group must be in common.)
 
 #### Request
 

--- a/src/pages/messaging/agent-chat-api/v3.6/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.6/rtm-reference/index.mdx
@@ -1196,9 +1196,9 @@ To learn how to add more than one agent to the chat, reach out to us [on Discord
 | **Web API equivalent** | [`add_user_to_chat`](/messaging/agent-chat-api/v3.6/#add-user-to-chat)                |
 | **Push message**       | [`user_added_to_chat`](/messaging/agent-chat-api/v3.6/rtm-pushes/#user_added_to_chat) |
 
-**\*** `chats--all:rw` - to add a user to a chat taking place in any group.
+**\*** `chats--all:rw` - to add the requester (related to the token) to a chat taking place in any group.
 
-**\*\*)** `chats--access:rw` - to add a user to a chat taking place in groups that the requester (related to the token) is a member of. (The agent groups and the chat groups must overlap - at least one group must be in common.)
+**\*\*)** `chats--access:rw` - to add a user to a chat taking place in groups that the user is a member of. (The agent groups and the chat groups must overlap - at least one group must be in common.)
 
 #### Request
 


### PR DESCRIPTION
# Links

- [Jira](https://livechatinc.atlassian.net/browse/API-12676)

# Description

Fix scopes description in Add User To Chat.
Scope `chats--all:rw` allows access to all chats only for the requester, so when adding other agents using token with this scope, they still have to have access to that chat.
Scope `chats--access:rw` requires the user's access, not the requester's access to match the chat access.

