### PR TITLE
NO-DED adding x-agent-id to Web and RTM Agent Chat API

### DIFF
--- a/src/constant/index.js
+++ b/src/constant/index.js
@@ -10,7 +10,7 @@ const VERSIONS_GROUPS = {
     STABLE_VERSION: "3.0",
     LEGACY_VERSIONS: ["1.0", "2.0"],
     DEV_PREVIEW_VERSION: "",
-    DEPRECATED_VERSIONS: ["3.1"],
+    DEPRECATED_VERSIONS: [""],
     ALL_VERSIONS: ["1.0", "2.0", "3.0"],
   },
   "data-reporting": {

--- a/src/pages/messaging/agent-chat-api/index.mdx
+++ b/src/pages/messaging/agent-chat-api/index.mdx
@@ -68,11 +68,11 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 ## Bots
 
-Sometimes, you want to [send an event as a bot](#send-event). To call an event, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
+Sometimes, you want to [send an event as a bot](#send-event). To do it, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
 
-In both situations, the `X-Author-Id` header comes with a helping hand. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
+In both situations, the `X-Author-Id` header is what you need to include in your request. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
 
-`X-Author-Id: <bot_id>` header is needed with a [bearer token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
+`X-Author-Id: <bot_id>` header is needed with a [Bearer Token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
 
 ## Postman collection
 

--- a/src/pages/messaging/agent-chat-api/index.mdx
+++ b/src/pages/messaging/agent-chat-api/index.mdx
@@ -66,7 +66,7 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 💡 The maximum duration of the `page_id` parameter before it expires is one month.
 
-## Bots
+## Calling the API as a bot
 
 Sometimes, you want to [send an event as a bot](#send-event). To do it, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
 
@@ -95,12 +95,12 @@ To find sample payloads of **events**, **users**, and **other common structures*
 
 If you specify the API version in the URL, you don't have to include the optional `"X-API-Version: 3.5"` header.
 
-| Required Header |                   Value                    |                                          Notes |
-| --------------- | :----------------------------------------: | ---------------------------------------------: |
-| `Content-Type`  | `multipart/form-data; boundary=<boundary>` |             Valid for the `upload_file` method |
-| `Content-Type`  |             `application/json`             | Valid for all methods except for `upload_file` |
-| `Authorization` |              `Bearer <token>`              |                                   Access token |
-| `X-Author-Id`   |              `<bot_id>`                    |                      Valid only for Bot Agents |
+| Required Header |                   Value                    |                                                  Notes |
+| --------------- | :----------------------------------------: | -----------------------------------------------------: |
+| `Content-Type`  | `multipart/form-data; boundary=<boundary>` |                     Valid for the `upload_file` method |
+| `Content-Type`  |             `application/json`             |         Valid for all methods except for `upload_file` |
+| `Authorization` |              `Bearer <token>`              |                                           Access token |
+| `X-Author-Id`   |              `<bot_id>`                    | [Valid only for Bot Agents](#calling-the-api-as-a-bot) |
 
 </Text>
 <Code>
@@ -1053,7 +1053,7 @@ Adds a user to the chat. The following restrictions apply:
 
 To learn how to add more than one agent to the chat, reach out to us [on Discord](https://discord.gg/gRzwSaCxg4) or via email, developers@livechat.com.
 
-To add a bot to a chat in a group it’s not part of, use the `X-Author-Id` header set to the bot’s id. [Read more...](#bots)
+To add a bot to a chat in a group it’s not part of, use the `X-Author-Id` header set to the bot’s id. [Read more...](#calling-the-api-as-a-bot)
 
 #### Specifics
 
@@ -1175,7 +1175,7 @@ Events with `visibility:agents` are sent to agents only, and with `visibility:al
 
 The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
-To call the API as a bot, use the `X-Author-Id` header set to the bot's id. [Read more...](#bots)
+To call the API as a bot, use the `X-Author-Id` header set to the bot's id. [Read more...](#calling-the-api-as-a-bot)
 
 #### Specifics
 

--- a/src/pages/messaging/agent-chat-api/index.mdx
+++ b/src/pages/messaging/agent-chat-api/index.mdx
@@ -66,6 +66,14 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 💡 The maximum duration of the `page_id` parameter before it expires is one month.
 
+## Bots
+
+Sometimes, you want to [send an event as a bot](#send-event). To call an event, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
+
+In both situations, the `X-Author-Id` header comes with a helping hand. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
+
+`X-Author-Id: <bot_id>` header is needed with a [bearer token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
+
 ## Postman collection
 
 You can find all the requests from the Agent Chat Web API v3.5 in Postman. In our collection, we use [environment variables](https://learning.getpostman.com/docs/postman/environments_and_globals/manage_environments/) that store, for example, the access token. Importing the collection from the link below downloads the environment as well. Remember to replace sample tokens with your own.
@@ -92,7 +100,7 @@ If you specify the API version in the URL, you don't have to include the optiona
 | `Content-Type`  | `multipart/form-data; boundary=<boundary>` |             Valid for the `upload_file` method |
 | `Content-Type`  |             `application/json`             | Valid for all methods except for `upload_file` |
 | `Authorization` |              `Bearer <token>`              |                                   Access token |
-| `X-Author-Id`   |              `<bot_agent_id>`              |                      Valid only for Bot Agents |
+| `X-Author-Id`   |              `<bot_id>`                    |                      Valid only for Bot Agents |
 
 </Text>
 <Code>
@@ -1045,6 +1053,8 @@ Adds a user to the chat. The following restrictions apply:
 
 To learn how to add more than one agent to the chat, reach out to us [on Discord](https://discord.gg/gRzwSaCxg4) or via email, developers@livechat.com.
 
+To add a bot to a chat in a group it’s not part of, use the `X-Author-Id` header set to the bot’s id. [Read more...](#bots)
+
 #### Specifics
 
 |                        |                                                                                      |
@@ -1165,7 +1175,7 @@ Events with `visibility:agents` are sent to agents only, and with `visibility:al
 
 The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
-To call the API as a bot, use the `X-Author-Id` header set to the bot's id.
+To call the API as a bot, use the `X-Author-Id` header set to the bot's id. [Read more...](#bots)
 
 #### Specifics
 

--- a/src/pages/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -95,11 +95,11 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 ## Bots
 
-Sometimes, you want to [send an event as a bot](#send-event). To call an event, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
+Sometimes, you want to [send an event as a bot](#send-event). To do it, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
 
-In both situations, the `Author-Id` header comes with a helping hand. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
+In both situations, the `Author-Id` header is what you need to include in your request. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
 
-`Author-Id: <bot_id>` header is needed with a [bearer token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
+`Author-Id: <bot_id>` header is needed with a [Bearer Token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
 
 # Data structures
 

--- a/src/pages/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -93,7 +93,7 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 💡 The maximum duration of the `page_id` parameter before it expires is one month.
 
-## Bots
+## Calling the API as a bot
 
 Sometimes, you want to [send an event as a bot](#send-event). To do it, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
 
@@ -1155,7 +1155,7 @@ Adds a user to the chat. The following restrictions apply:
 
 To learn how to add more than one agent to the chat, reach out to us [on Discord](https://discord.gg/gRzwSaCxg4) or via email, developers@livechat.com.
 
-To add a bot to a chat in a group it’s not part of, use the `author_id` property set to the bot’s id. [Read more...](#bots)
+To add a bot to a chat in a group it’s not part of, use the `author_id` property set to the bot’s id. [Read more...](#calling-the-api-as-a-bot)
 
 #### Specifics
 
@@ -1298,7 +1298,7 @@ Events with `visibility:agents` are sent to agents only, and with `visibility:al
 
 The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
-To call the API as a bot, use the `author_id` property set to the bot's id in the payload. [Read more...](#bots)
+To call the API as a bot, use the `author_id` property set to the bot's id in the payload. [Read more...](#calling-the-api-as-a-bot)
 
 #### Specifics
 

--- a/src/pages/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -93,6 +93,14 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 💡 The maximum duration of the `page_id` parameter before it expires is one month.
 
+## Bots
+
+Sometimes, you want to [send an event as a bot](#send-event). To call an event, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
+
+In both situations, the `Author-Id` header comes with a helping hand. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
+
+`Author-Id: <bot_id>` header is needed with a [bearer token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
+
 # Data structures
 
 To find sample payloads of **events**, **users**, and **other common structures** such as chats or threads [visit the Data structures](/messaging/agent-chat-api/v3.5/data-structures) document.
@@ -1147,6 +1155,8 @@ Adds a user to the chat. The following restrictions apply:
 
 To learn how to add more than one agent to the chat, reach out to us [on Discord](https://discord.gg/gRzwSaCxg4) or via email, developers@livechat.com.
 
+To add a bot to a chat in a group it’s not part of, use the `author_id` property set to the bot’s id. [Read more...](#bots)
+
 #### Specifics
 
 |                        |                                                                                       |
@@ -1288,7 +1298,7 @@ Events with `visibility:agents` are sent to agents only, and with `visibility:al
 
 The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
-To call the API as a bot, use the `author_id` property set to the bot's id in the payload.
+To call the API as a bot, use the `author_id` property set to the bot's id in the payload. [Read more...](#bots)
 
 #### Specifics
 

--- a/src/pages/messaging/agent-chat-api/v3.4/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.4/index.mdx
@@ -71,7 +71,7 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 💡 The maximum duration of the `page_id` parameter before it expires is one month.
 
-## Bots
+## Calling the API as a bot
 
 Sometimes, you want to [send an event as a bot](#send-event). To do it, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
 
@@ -100,12 +100,12 @@ To find sample payloads of **events**, **users**, and **other common structures*
 
 If you specify the API version in the URL, you don't have to include the optional `"X-API-Version: 3.4"` header.
 
-| Required Header |                   Value                    |                                          Notes |
-| --------------- | :----------------------------------------: | ---------------------------------------------: |
-| `Content-Type`  | `multipart/form-data; boundary=<boundary>` |             Valid for the `upload_file` method |
-| `Content-Type`  |             `application/json`             | Valid for all methods except for `upload_file` |
-| `Authorization` |              `Bearer <token>`              |                                   Access token |
-| `X-Author-Id`   |              `<bot_id>`                    |                      Valid only for Bot Agents |
+| Required Header |                   Value                    |                                                  Notes |
+| --------------- | :----------------------------------------: | -----------------------------------------------------: |
+| `Content-Type`  | `multipart/form-data; boundary=<boundary>` |                     Valid for the `upload_file` method |
+| `Content-Type`  |             `application/json`             |         Valid for all methods except for `upload_file` |
+| `Authorization` |              `Bearer <token>`              |                                           Access token |
+| `X-Author-Id`   |              `<bot_id>`                    | [Valid only for Bot Agents](#calling-the-api-as-a-bot) |
 
 </Text>
 <Code>
@@ -1061,7 +1061,7 @@ Adds a user to the chat. The following restrictions apply:
 
 To learn how to add more than one agent to the chat, reach out to us [on Discord](https://discord.gg/gRzwSaCxg4) or via email, developers@livechat.com.
 
-To add a bot to a chat in a group it’s not part of, use the `X-Author-Id` header set to the bot’s id. [Read more...](#bots)
+To add a bot to a chat in a group it’s not part of, use the `X-Author-Id` header set to the bot’s id. [Read more...](#calling-the-api-as-a-bot)
 
 #### Specifics
 
@@ -1183,7 +1183,7 @@ Events with `visibility:agents` are sent to agents only, and with `visibility:al
 
 The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
-To call the API as a bot, use the `X-Author-Id` header set to the bot's id. [Read more...](#bots)
+To call the API as a bot, use the `X-Author-Id` header set to the bot's id. [Read more...](#calling-the-api-as-a-bot)
 
 #### Specifics
 

--- a/src/pages/messaging/agent-chat-api/v3.4/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.4/index.mdx
@@ -71,6 +71,14 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 💡 The maximum duration of the `page_id` parameter before it expires is one month.
 
+## Bots
+
+Sometimes, you want to [send an event as a bot](#send-event). To call an event, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
+
+In both situations, the `X-Author-Id` header comes with a helping hand. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
+
+`X-Author-Id: <bot_id>` header is needed with a [bearer token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
+
 ## Postman collection
 
 You can find all the requests from the Agent Chat Web API v3.4 in Postman. In our collection, we use [environment variables](https://learning.getpostman.com/docs/postman/environments_and_globals/manage_environments/) that store, for example, the access token. Importing the collection from the link below downloads the environment as well. Remember to replace sample tokens with your own.
@@ -97,7 +105,7 @@ If you specify the API version in the URL, you don't have to include the optiona
 | `Content-Type`  | `multipart/form-data; boundary=<boundary>` |             Valid for the `upload_file` method |
 | `Content-Type`  |             `application/json`             | Valid for all methods except for `upload_file` |
 | `Authorization` |              `Bearer <token>`              |                                   Access token |
-| `X-Author-Id`   |              `<bot_agent_id>`              |                      Valid only for Bot Agents |
+| `X-Author-Id`   |              `<bot_id>`                    |                      Valid only for Bot Agents |
 
 </Text>
 <Code>
@@ -1053,6 +1061,8 @@ Adds a user to the chat. The following restrictions apply:
 
 To learn how to add more than one agent to the chat, reach out to us [on Discord](https://discord.gg/gRzwSaCxg4) or via email, developers@livechat.com.
 
+To add a bot to a chat in a group it’s not part of, use the `X-Author-Id` header set to the bot’s id. [Read more...](#bots)
+
 #### Specifics
 
 |                        |                                                                                      |
@@ -1173,7 +1183,7 @@ Events with `visibility:agents` are sent to agents only, and with `visibility:al
 
 The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
-To call the API as a bot, use the `X-Author-Id` header set to the bot's id.
+To call the API as a bot, use the `X-Author-Id` header set to the bot's id. [Read more...](#bots)
 
 #### Specifics
 

--- a/src/pages/messaging/agent-chat-api/v3.4/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.4/index.mdx
@@ -73,11 +73,11 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 ## Bots
 
-Sometimes, you want to [send an event as a bot](#send-event). To call an event, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
+Sometimes, you want to [send an event as a bot](#send-event). To do it, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
 
-In both situations, the `X-Author-Id` header comes with a helping hand. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
+In both situations, the `X-Author-Id` header is what you need to include in your request. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
 
-`X-Author-Id: <bot_id>` header is needed with a [bearer token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
+`X-Author-Id: <bot_id>` header is needed with a [Bearer Token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
 
 ## Postman collection
 

--- a/src/pages/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
@@ -100,9 +100,9 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 ## Bots
 
-Sometimes, you want to [send an event as a bot](#send-event). To call an event, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
+Sometimes, you want to [send an event as a bot](#send-event). To do it, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
 
-In both situations, the `Author-Id` header comes with a helping hand. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
+In both situations, the `Author-Id` header is what you need to include in your request. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
 
 `Author-Id: <bot_id>` header is needed with a [bearer token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
 

--- a/src/pages/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
@@ -98,6 +98,14 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 💡 The maximum duration of the `page_id` parameter before it expires is one month.
 
+## Bots
+
+Sometimes, you want to [send an event as a bot](#send-event). To call an event, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
+
+In both situations, the `Author-Id` header comes with a helping hand. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
+
+`Author-Id: <bot_id>` header is needed with a [bearer token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
+
 # Data structures
 
 To find sample payloads of **events**, **users**, and **other common structures** such as chats or threads [visit the Data structures](/messaging/agent-chat-api/v3.4/data-structures) document.
@@ -1151,6 +1159,8 @@ Adds a user to the chat. The following restrictions apply:
 
 To learn how to add more than one agent to the chat, reach out to us [on Discord](https://discord.gg/gRzwSaCxg4) or via email, developers@livechat.com.
 
+To add a bot to a chat in a group it’s not part of, use the `author_id` property set to the bot’s id. [Read more...](#bots)
+
 #### Specifics
 
 |                        |                                                                                       |
@@ -1292,7 +1302,7 @@ Events with `visibility:agents` are sent to agents only, and with `visibility:al
 
 The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
-To call the API as a bot, use the `author_id` property set to the bot's id in the payload.
+To call the API as a bot, use the `author_id` property set to the bot's id in the payload. [Read more...](#bots)
 
 #### Specifics
 

--- a/src/pages/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.4/rtm-reference/index.mdx
@@ -98,13 +98,13 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 💡 The maximum duration of the `page_id` parameter before it expires is one month.
 
-## Bots
+## Calling the API as a bot
 
 Sometimes, you want to [send an event as a bot](#send-event). To do it, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
 
 In both situations, the `Author-Id` header is what you need to include in your request. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
 
-`Author-Id: <bot_id>` header is needed with a [bearer token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
+`Author-Id: <bot_id>` header is needed with a [Bearer Token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
 
 # Data structures
 
@@ -1159,7 +1159,7 @@ Adds a user to the chat. The following restrictions apply:
 
 To learn how to add more than one agent to the chat, reach out to us [on Discord](https://discord.gg/gRzwSaCxg4) or via email, developers@livechat.com.
 
-To add a bot to a chat in a group it’s not part of, use the `author_id` property set to the bot’s id. [Read more...](#bots)
+To add a bot to a chat in a group it’s not part of, use the `author_id` property set to the bot’s id. [Read more...](#calling-the-api-as-a-bot)
 
 #### Specifics
 
@@ -1302,7 +1302,7 @@ Events with `visibility:agents` are sent to agents only, and with `visibility:al
 
 The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
-To call the API as a bot, use the `author_id` property set to the bot's id in the payload. [Read more...](#bots)
+To call the API as a bot, use the `author_id` property set to the bot's id in the payload. [Read more...](#calling-the-api-as-a-bot)
 
 #### Specifics
 

--- a/src/pages/messaging/agent-chat-api/v3.6/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.6/index.mdx
@@ -67,7 +67,7 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 💡 The maximum duration of the `page_id` parameter before it expires is one month.
 
-## Bots
+## Calling the API as a bot
 
 Sometimes, you want to [send an event as a bot](#send-event). To do it, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
 
@@ -90,12 +90,12 @@ To find sample payloads of **events**, **users**, and **other common structures*
 
 If you specify the API version in the URL, you don't have to include the optional `"X-API-Version: 3.6"` header.
 
-| Required Header |                   Value                    |                                          Notes |
-| --------------- | :----------------------------------------: | ---------------------------------------------: |
-| `Content-Type`  | `multipart/form-data; boundary=<boundary>` |             Valid for the `upload_file` method |
-| `Content-Type`  |             `application/json`             | Valid for all methods except for `upload_file` |
-| `Authorization` |              `Bearer <token>`              |                                   Access token |
-| `X-Author-Id`   |              `<bot_id>`                    |                      Valid only for Bot Agents |
+| Required Header |                   Value                    |                                                  Notes |
+| --------------- | :----------------------------------------: | -----------------------------------------------------: |
+| `Content-Type`  | `multipart/form-data; boundary=<boundary>` |                     Valid for the `upload_file` method |
+| `Content-Type`  |             `application/json`             |         Valid for all methods except for `upload_file` |
+| `Authorization` |              `Bearer <token>`              |                                           Access token |
+| `X-Author-Id`   |              `<bot_id>`                    | [Valid only for Bot Agents](#calling-the-api-as-a-bot) |
 
 </Text>
 <Code>
@@ -1087,7 +1087,7 @@ Adds a user to the chat. The following restrictions apply:
 
 To learn how to add more than one agent to the chat, reach out to us [on Discord](https://discord.gg/gRzwSaCxg4) or via email, developers@livechat.com.
 
-To add a bot to a chat in a group it’s not part of, use the `X-Author-Id` header set to the bot’s id. [Read more...](#bots)
+To add a bot to a chat in a group it’s not part of, use the `X-Author-Id` header set to the bot’s id. [Read more...](#calling-the-api-as-a-bot)
 
 #### Specifics
 
@@ -1209,7 +1209,7 @@ Events with `visibility:agents` are sent to agents only, and with `visibility:al
 
 The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
-To call the API as a bot, use the `X-Author-Id` header set to the bot's id. [Read more...](#bots)
+To call the API as a bot, use the `X-Author-Id` header set to the bot's id. [Read more...](#calling-the-api-as-a-bot)
 
 #### Specifics
 

--- a/src/pages/messaging/agent-chat-api/v3.6/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.6/index.mdx
@@ -67,6 +67,14 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 💡 The maximum duration of the `page_id` parameter before it expires is one month.
 
+## Bots
+
+Sometimes, you want to [send an event as a bot](#send-event). To call an event, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
+
+In both situations, the `X-Author-Id` header comes with a helping hand. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
+
+`X-Author-Id: <bot_id>` header is needed with a [bearer token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
+
 # Data structures
 
 To find sample payloads of **events**, **users**, and **other common structures** such as chats or threads [visit the Data structures](/messaging/agent-chat-api/v3.6/data-structures) document.
@@ -87,7 +95,7 @@ If you specify the API version in the URL, you don't have to include the optiona
 | `Content-Type`  | `multipart/form-data; boundary=<boundary>` |             Valid for the `upload_file` method |
 | `Content-Type`  |             `application/json`             | Valid for all methods except for `upload_file` |
 | `Authorization` |              `Bearer <token>`              |                                   Access token |
-| `X-Author-Id`   |              `<bot_agent_id>`              |                      Valid only for Bot Agents |
+| `X-Author-Id`   |              `<bot_id>`                    |                      Valid only for Bot Agents |
 
 </Text>
 <Code>
@@ -1079,6 +1087,8 @@ Adds a user to the chat. The following restrictions apply:
 
 To learn how to add more than one agent to the chat, reach out to us [on Discord](https://discord.gg/gRzwSaCxg4) or via email, developers@livechat.com.
 
+To add a bot to a chat in a group it’s not part of, use the `X-Author-Id` header set to the bot’s id. [Read more...](#bots)
+
 #### Specifics
 
 |                        |                                                                                      |
@@ -1199,7 +1209,7 @@ Events with `visibility:agents` are sent to agents only, and with `visibility:al
 
 The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
-To call the API as a bot, use the `X-Author-Id` header set to the bot's id.
+To call the API as a bot, use the `X-Author-Id` header set to the bot's id. [Read more...](#bots)
 
 #### Specifics
 

--- a/src/pages/messaging/agent-chat-api/v3.6/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.6/index.mdx
@@ -69,11 +69,11 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 ## Bots
 
-Sometimes, you want to [send an event as a bot](#send-event). To call an event, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
+Sometimes, you want to [send an event as a bot](#send-event). To do it, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
 
-In both situations, the `X-Author-Id` header comes with a helping hand. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
+In both situations, the `X-Author-Id` header is what you need to include in your request. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
 
-`X-Author-Id: <bot_id>` header is needed with a [bearer token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
+`X-Author-Id: <bot_id>` header is needed with a [Bearer Token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
 
 # Data structures
 

--- a/src/pages/messaging/agent-chat-api/v3.6/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.6/rtm-reference/index.mdx
@@ -94,7 +94,7 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 💡 The maximum duration of the `page_id` parameter before it expires is one month.
 
-## Bots
+## Calling the API as a bot
 
 Sometimes, you want to [send an event as a bot](#send-event). To do it, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
 
@@ -1195,7 +1195,7 @@ Adds a user to the chat. The following restrictions apply:
 
 To learn how to add more than one agent to the chat, reach out to us [on Discord](https://discord.gg/gRzwSaCxg4) or via email, developers@livechat.com.
 
-To add a bot to a chat in a group it’s not part of, use the `author_id` property set to the bot’s id. [Read more...](#bots)
+To add a bot to a chat in a group it’s not part of, use the `author_id` property set to the bot’s id. [Read more...](#calling-the-api-as-a-bot)
 
 #### Specifics
 
@@ -1338,7 +1338,7 @@ Events with `visibility:agents` are sent to agents only, and with `visibility:al
 
 The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
-To call the API as a bot, use the `author_id` property set to the bot's id in the payload. [Read more...](#bots)
+To call the API as a bot, use the `author_id` property set to the bot's id in the payload. [Read more...](#calling-the-api-as-a-bot)
 
 #### Specifics
 

--- a/src/pages/messaging/agent-chat-api/v3.6/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.6/rtm-reference/index.mdx
@@ -94,6 +94,14 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 💡 The maximum duration of the `page_id` parameter before it expires is one month.
 
+## Bots
+
+Sometimes, you want to [send an event as a bot](#send-event). To call an event, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
+
+In both situations, the `Author-Id` header comes with a helping hand. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
+
+`Author-Id: <bot_id>` header is needed with a [bearer token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
+
 # Data structures
 
 To find sample payloads of **events**, **users**, and **other common structures** such as chats or threads [visit the Data structures](/messaging/agent-chat-api/v3.6/data-structures) document.
@@ -1187,6 +1195,8 @@ Adds a user to the chat. The following restrictions apply:
 
 To learn how to add more than one agent to the chat, reach out to us [on Discord](https://discord.gg/gRzwSaCxg4) or via email, developers@livechat.com.
 
+To add a bot to a chat in a group it’s not part of, use the `author_id` property set to the bot’s id. [Read more...](#bots)
+
 #### Specifics
 
 |                        |                                                                                       |
@@ -1328,7 +1338,7 @@ Events with `visibility:agents` are sent to agents only, and with `visibility:al
 
 The method updates the requester's `events_seen_up_to` as if they've seen all chat events.
 
-To call the API as a bot, use the `author_id` property set to the bot's id in the payload.
+To call the API as a bot, use the `author_id` property set to the bot's id in the payload. [Read more...](#bots)
 
 #### Specifics
 

--- a/src/pages/messaging/agent-chat-api/v3.6/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.6/rtm-reference/index.mdx
@@ -96,11 +96,11 @@ The `filters`, `limit`, and `sort_order` parameters can't be provided along with
 
 ## Bots
 
-Sometimes, you want to [send an event as a bot](#send-event). To call an event, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
+Sometimes, you want to [send an event as a bot](#send-event). To do it, you need to have a token that allows you to send it. The token can be easily generated for an agent, but you cannot generate a token for a bot. The other time you want to [add a user to your chat](#add-user-to-chat), and this user happens to be a bot in the group with no access to this chat, so you cannot add it.  
 
-In both situations, the `Author-Id` header comes with a helping hand. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
+In both situations, the `Author-Id` header is what you need to include in your request. With it, you can authorize using the agent’s token and send the event as a bot or add a bot to a chat even if the bot belongs to the group that has no access to this chat.
 
-`Author-Id: <bot_id>` header is needed with a [bearer token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
+`Author-Id: <bot_id>` header is needed with a [Bearer Token](/authorization/agent-authorization/) that needs to have the same `client_id` as the bot or [PAT](/authorization/agent-authorization#personal-access-tokens) that is from the organization that owns the bot's `client_id`.
 
 # Data structures
 


### PR DESCRIPTION
# Deploy preview

Scroll down to the checks section for the link to the deploy preview of your branch.

# Links

Link your Jira ticket.

- [Jira]()

# Description

As agreed with Paweł, the new Bot section has been added to the Web and RTM Agent Chat API. The section is needed as many devs ask about it or have problems with calling methods as bots.

# Review and release

Apply changes and resolve conflicts. Once the described functionality lands on prod, let us know on #platform-docs-releases that your PR is ready for release. We will **merge** and **publish** the changes.
