### PR TITLE
Specify when owner_client_id is required for wh mgmt

### DIFF
--- a/src/pages/management/configuration-api/index.mdx
+++ b/src/pages/management/configuration-api/index.mdx
@@ -2855,7 +2855,7 @@ For `bot` webhooks, you need to [create a bot](#create-bot), [register webhooks]
 | `filters.chat_presence.user_ids.exclude_values` | no       | `[]string` | Array of Users' ids; if any specified Users is in the chat, the webhook will not be triggered.                                                                                                                                                    |
 | `filters.chat_presence.my_bots`                 | no       | `bool`     | If any bot owned by `owner_client_id` is in the chat, the webhook will be triggered.                                                                                                                                                              |
 | `filters.source_type`                           | no       | `[]string` | Array of source types. Possible values: `my_client` (client ID of your app), `other_clients` (client IDs other than your app's), `system` (no client ID); if the source which triggered the webhook matches the filter, the webhook will be sent. |
-| `owner_client_id`                               | yes      | `string`   | The Client ID for which the webhook will be registered. [What is Client ID and where to find it?](/authorization/authorization-in-practice/#step-1-configure-the-authorization-building-block)                                                    |
+| `owner_client_id`                               | yes      | `string`   | The Client ID for which the webhook will be registered. [What is Client ID and where to find it?](/authorization/authorization-in-practice/#step-1-configure-the-authorization-building-block). Required only when authorizing via [PATs](/authorization/authorizing-api-calls/#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
 | `type`                                          | yes      | `string`   | `bot` or `license`                                                                                                                                                                                                                                |
 
 #### Triggering actions
@@ -2951,7 +2951,7 @@ Lists all webhooks registered for the given Client ID.
 
 | Parameter         | Required | Data type | Notes                                                                  |
 | ----------------- | -------- | --------- | ---------------------------------------------------------------------- |
-| `owner_client_id` | yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). |
+| `owner_client_id` | yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). Required only when authorizing via [PATs](/authorization/authorizing-api-calls/#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
 
 </Text>
 
@@ -2998,7 +2998,7 @@ Unregisters a webhook previously [registered](#register-webhook) for a Client ID
 | Parameter         | Required | Data type | Notes                                                                  |
 | ----------------- | -------- | --------- | ---------------------------------------------------------------------- |
 | `id`              | Yes      | `string`  | Webhook ID                                                             |
-| `owner_client_id` | Yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). |
+| `owner_client_id` | Yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). Required only when authorizing via [PATs](/authorization/authorizing-api-calls/#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
 
 #### Response
 

--- a/src/pages/management/configuration-api/v3.6/index.mdx
+++ b/src/pages/management/configuration-api/v3.6/index.mdx
@@ -2836,7 +2836,7 @@ For `bot` webhooks, you need to [create a bot](#create-bot), [register webhooks]
 | `filters.chat_presence.user_ids.exclude_values` | no       | `[]string` | Array of Users' ids; if any specified Users is in the chat, the webhook will not be triggered.                                                                                                                                                    |
 | `filters.chat_presence.my_bots`                 | no       | `bool`     | If any bot owned by `owner_client_id` is in the chat, the webhook will be triggered.                                                                                                                                                              |
 | `filters.source_type`                           | no       | `[]string` | Array of source types. Possible values: `my_client` (client ID of your app), `other_clients` (client IDs other than your app's), `system` (no client ID); if the source which triggered the webhook matches the filter, the webhook will be sent. |
-| `owner_client_id`                               | yes      | `string`   | The Client ID for which the webhook will be registered. [What is Client ID and where to find it?](/authorization/authorization-in-practice/#step-1-configure-the-authorization-building-block)                                                    |
+| `owner_client_id`                               | yes      | `string`   | The Client ID for which the webhook will be registered. [What is Client ID and where to find it?](/authorization/authorization-in-practice/#step-1-configure-the-authorization-building-block). Required only when authorizing via [PATs](/authorization/authorizing-api-calls/#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
 | `type`                                          | yes      | `string`   | `bot` or `license`                                                                                                                                                                                                                                |
 
 #### Triggering actions
@@ -2932,7 +2932,7 @@ Lists all webhooks registered for the given Client ID.
 
 | Parameter         | Required | Data type | Notes                                                                  |
 | ----------------- | -------- | --------- | ---------------------------------------------------------------------- |
-| `owner_client_id` | yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). |
+| `owner_client_id` | yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). Required only when authorizing via [PATs](/authorization/authorizing-api-calls/#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
 
 </Text>
 
@@ -2979,7 +2979,7 @@ Unregisters a webhook previously [registered](#register-webhook) for a Client ID
 | Parameter         | Required | Data type | Notes                                                                  |
 | ----------------- | -------- | --------- | ---------------------------------------------------------------------- |
 | `id`              | Yes      | `string`  | Webhook ID                                                             |
-| `owner_client_id` | Yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). |
+| `owner_client_id` | Yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). Required only when authorizing via [PATs](/authorization/authorizing-api-calls/#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
 
 #### Response
 


### PR DESCRIPTION
# Description

Specify that `owner_client_id` is required for webhooks management iff the request is authorized with PAT.
