### PR TITLE
remove 'customer_page_updated' push from all versions of Customer-API

### DIFF
--- a/src/pages/messaging/customer-chat-api/changelog/index.mdx
+++ b/src/pages/messaging/customer-chat-api/changelog/index.mdx
@@ -25,6 +25,10 @@ The developer preview version provides a preview of the upcoming changes to the 
 
 - The [**Get Dynamic Configuration**](/messaging/customer-chat-api/v3.6/#get-dynamic-configuration) response has a new format to support non-LiveChat widgets as default widgets.
 
+### Customers
+
+- The **customer_page_updated** was removed.
+
 ## [v3.5] - 2022-11-23
 
 ### Status
@@ -32,6 +36,10 @@ The developer preview version provides a preview of the upcoming changes to the 
 - The [**customer_disconnected**](/messaging/customer-chat-api/v3.5/rtm-pushes/#customer_disconnected) push has a new reason, `logged_out_remotely`.
 - A new push, [**groups_status_updated**](/messaging/customer-chat-api/v3.5/rtm-pushes/#groups_status_updated) has been added.
 - The `incoming_multicast` push is no longer sent when group statuses change. 
+
+### Customers
+
+- 🛠️ (2024-03-10): The **customer_page_updated** was removed.
 
 ## [v3.4] - 2021-12-22
 
@@ -42,6 +50,10 @@ The mandatory query string parameter, `license_id`,  was replaced with `organiza
 ### Events
 
 - The **Form** ([Web](/messaging/customer-chat-api/v3.4/data-structures/#form) & [RTM](/messaging/customer-chat-api/v3.4/data-structures/#form)) and **Filled Form** ([Web](/messaging/customer-chat-api/v3.4/data-structures/#filled-form) & [RTM](/messaging/customer-chat-api/v3.4/data-structures/#filled-form)) events have a new field, `form_type`.
+
+### Customers
+
+- 🛠️ (2024-03-10): The **customer_page_updated** was removed.
 
 ## [v3.3] - 2021-03-30
 
@@ -95,6 +107,7 @@ The mandatory query string parameter, `license_id`,  was replaced with `organiza
   - now returns only the updated data.
   - has a new format; the fields are no longer nested within the `customer` field.
 - The **Customer** ([Web](/messaging/customer-chat-api/v3.3/data-structures/#customer) & [RTM](/messaging/customer-chat-api/v3.3/data-structures/#customer)) data structure has a new property, `email_verified`.
+- 🛠️ (2024-03-10): The **customer_page_updated** was removed.
 
 
 ### Status 
@@ -171,6 +184,7 @@ The mandatory query string parameter, `license_id`,  was replaced with `organiza
 - The [**customer_updated**](/messaging/customer-chat-api/v3.2/rtm-pushes/#customer_updated) push is no longer triggered by **Set Customer Session Fields**.
 - Each method, response, and push that deals with a variation of customer `fields` had this field renamed to `session_fields` and its format changed. It's now an array that respects the item order.
 - There's a new method, **Get Customer** ([Web](/messaging/customer-chat-api/v3.2/#get-customer) & [RTM](/messaging/customer-chat-api/v3.2/rtm-reference/#get-customer)).
+- 🛠️ (2024-03-10): The **customer_page_updated** was removed.
 
 ### Status
 

--- a/src/pages/messaging/customer-chat-api/rtm-pushes/index.mdx
+++ b/src/pages/messaging/customer-chat-api/rtm-pushes/index.mdx
@@ -33,8 +33,8 @@ Here's what you need to know about **pushes**:
 | **Chat users**  | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                 |
 | **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                        |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
-| **Customers**   | [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                     |
-| **Status**      | [`customer_disconnected`](#customer_disconnected) [`groups_status_updated`](#groups_status_updated)                                                                                                                                                                                                                                              |
+| **Customers**   | [`customer_updated`](#customer_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                                                                       |
+| **Status**      | [`customer_disconnected`](#customer_disconnected) [`groups_status_updated`](#groups_status_updated)                                                                                                                                                                                                                                             |
 | **Other**       | [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_greeting`](#incoming_greeting) [`greeting_accepted`](#greeting_accepted) [`greeting_canceled`](#greeting_canceled) [`queue_position_updated`](#queue_position_updated)       |
 
 </Text>
@@ -448,22 +448,6 @@ Informs that customer's data changed. The push payload contains the updated fiel
 ```json
 {
   // "User > Customer" object
-}
-```
-
-</CodeResponse>
-
-### `customer_page_updated`
-
-Informs that a Customer moved to another page of the website, for example by clicking a link.
-
-<CodeResponse title={'Sample push payload'}>
-
-```json
-{
-  "url": "https://livechatinc.com/pricing",
-  "title": "pricing",
-  "opened_at": "2020-09-10T08:22:21.128420Z"
 }
 ```
 

--- a/src/pages/messaging/customer-chat-api/rtm-reference/index.mdx
+++ b/src/pages/messaging/customer-chat-api/rtm-reference/index.mdx
@@ -1366,7 +1366,7 @@ When updating customer data while the customer has an active chat, the update wi
 | ---------------------- | ---------------------------------------------------------------------------------------------- |
 | **Action**             | `update_customer_page`                                                                         |
 | **Web API equivalent** | -                                                                                              |
-| **Push message**       | [`customer_page_updated`](/messaging/customer-chat-api/v3.5/rtm-pushes/#customer_page_updated) |
+| **Push message**       | -                                                                                              |
 
 Agent and referrer are updated by default using the browser’s headers.
 

--- a/src/pages/messaging/customer-chat-api/v3.2/rtm-pushes/index.mdx
+++ b/src/pages/messaging/customer-chat-api/v3.2/rtm-pushes/index.mdx
@@ -34,7 +34,7 @@ Here's what you need to know about **pushes**:
 | **Chat users**  | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                 |
 | **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                        |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
-| **Customers**   | [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                     |
+| **Customers**   | [`customer_updated`](#customer_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                                                                       |
 | **Status**      | [`customer_disconnected`](#customer_disconnected)                                                                                                                                                                                                                                                                                               |
 | **Other**       | [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_greeting`](#incoming_greeting) [`greeting_accepted`](#greeting_accepted) [`greeting_canceled`](#greeting_canceled) [`queue_position_updated`](#queue_position_updated)       |
 
@@ -450,22 +450,6 @@ Informs that Customer's data was updated.
   "customer": {
   // "User > Customer" object
   }
-}
-```
-
-</CodeResponse>
-
-### `customer_page_updated`
-
-Informs that a Customer changed the website - moved to another page of the website, for example by clicking on a link.
-
-<CodeResponse title={'Sample push payload'}>
-
-```json
-{
-  "url": "https://livechatinc.com/pricing",
-  "title": "pricing",
-  "timestamp": 123456789
 }
 ```
 

--- a/src/pages/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
+++ b/src/pages/messaging/customer-chat-api/v3.2/rtm-reference/index.mdx
@@ -1445,7 +1445,7 @@ When updating customer data while the customer has an active chat, the update wi
 | ---------------------- | ---------------------------------------------------------------------------------------------- |
 | **Action**             | `update_customer_page`                                                                         |
 | **Web API equivalent** | -                                                                                              |
-| **Push message**       | [`customer_page_updated`](/messaging/customer-chat-api/v3.2/rtm-pushes/#customer_page_updated) |
+| **Push message**       | -                                                                                              |
 
 Agent and referrer are updated by default using the browser’s headers.
 

--- a/src/pages/messaging/customer-chat-api/v3.3/rtm-pushes/index.mdx
+++ b/src/pages/messaging/customer-chat-api/v3.3/rtm-pushes/index.mdx
@@ -34,7 +34,7 @@ Here's what you need to know about **pushes**:
 | **Chat users**  | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                 |
 | **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                        |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
-| **Customers**   | [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                     |
+| **Customers**   | [`customer_updated`](#customer_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                                                                       |
 | **Status**      | [`customer_disconnected`](#customer_disconnected)                                                                                                                                                                                                                                                                                               |
 | **Other**       | [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_greeting`](#incoming_greeting) [`greeting_accepted`](#greeting_accepted) [`greeting_canceled`](#greeting_canceled) [`queue_position_updated`](#queue_position_updated)       |
 
@@ -449,22 +449,6 @@ Informs that customer's data changed. The push payload contains the updated fiel
 ```json
 {
   // "User > Customer" object
-}
-```
-
-</CodeResponse>
-
-### `customer_page_updated`
-
-Informs that a Customer moved to another page of the website, for example by clicking a link.
-
-<CodeResponse title={'Sample push payload'}>
-
-```json
-{
-  "url": "https://livechatinc.com/pricing",
-  "title": "pricing",
-  "opened_at": "2020-09-10T08:22:21.128420Z"
 }
 ```
 

--- a/src/pages/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
+++ b/src/pages/messaging/customer-chat-api/v3.3/rtm-reference/index.mdx
@@ -1387,7 +1387,7 @@ When updating customer data while the customer has an active chat, the update wi
 | ---------------------- | ----------------------------------------------------------------------------------------- |
 | **Action**             | `update_customer_page`                                                                    |
 | **Web API equivalent** | -                                                                                         |
-| **Push message**       | [`customer_page_updated`](/messaging/customer-chat-api/rtm-pushes/#customer_page_updated) |
+| **Push message**       | -                                                                                         |
 
 Agent and referrer are updated by default using the browser’s headers.
 

--- a/src/pages/messaging/customer-chat-api/v3.4/rtm-pushes/index.mdx
+++ b/src/pages/messaging/customer-chat-api/v3.4/rtm-pushes/index.mdx
@@ -34,7 +34,7 @@ Here's what you need to know about **pushes**:
 | **Chat users**  | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                 |
 | **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                        |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
-| **Customers**   | [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                     |
+| **Customers**   | [`customer_updated`](#customer_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                                                                       |
 | **Status**      | [`customer_disconnected`](#customer_disconnected)                                                                                                                                                                                                                                                                                               |
 | **Other**       | [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_greeting`](#incoming_greeting) [`greeting_accepted`](#greeting_accepted) [`greeting_canceled`](#greeting_canceled) [`queue_position_updated`](#queue_position_updated)       |
 
@@ -449,22 +449,6 @@ Informs that customer's data changed. The push payload contains the updated fiel
 ```json
 {
   // "User > Customer" object
-}
-```
-
-</CodeResponse>
-
-### `customer_page_updated`
-
-Informs that a Customer moved to another page of the website, for example by clicking a link.
-
-<CodeResponse title={'Sample push payload'}>
-
-```json
-{
-  "url": "https://livechatinc.com/pricing",
-  "title": "pricing",
-  "opened_at": "2020-09-10T08:22:21.128420Z"
 }
 ```
 

--- a/src/pages/messaging/customer-chat-api/v3.4/rtm-reference/index.mdx
+++ b/src/pages/messaging/customer-chat-api/v3.4/rtm-reference/index.mdx
@@ -1389,7 +1389,7 @@ When updating customer data while the customer has an active chat, the update wi
 | ---------------------- | ---------------------------------------------------------------------------------------------- |
 | **Action**             | `update_customer_page`                                                                         |
 | **Web API equivalent** | -                                                                                              |
-| **Push message**       | [`customer_page_updated`](/messaging/customer-chat-api/v3.4/rtm-pushes/#customer_page_updated) |
+| **Push message**       | -                                                                                              |
 
 Agent and referrer are updated by default using the browser’s headers.
 

--- a/src/pages/messaging/customer-chat-api/v3.6/rtm-pushes/index.mdx
+++ b/src/pages/messaging/customer-chat-api/v3.6/rtm-pushes/index.mdx
@@ -34,8 +34,8 @@ Here's what you need to know about **pushes**:
 | **Chat users**  | [`user_added_to_chat`](#user_added_to_chat) [`user_removed_from_chat`](#user_removed_from_chat)                                                                                                                                                                                                                                                 |
 | **Events**      | [`incoming_event`](#incoming_event) [`event_updated`](#event_updated)[`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                        |
 | **Properties**  | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted) |
-| **Customers**   | [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                     |
-| **Status**      | [`customer_disconnected`](#customer_disconnected) [`groups_status_updated`](#groups_status_updated)                                                                                                                                                                                                                                              |
+| **Customers**   | [`customer_updated`](#customer_updated) [`customer_side_storage_updated`](#customer_side_storage_updated)                                                                                                                                                                                                                                       |
+| **Status**      | [`customer_disconnected`](#customer_disconnected) [`groups_status_updated`](#groups_status_updated)                                                                                                                                                                                                                                             |
 | **Other**       | [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_greeting`](#incoming_greeting) [`greeting_accepted`](#greeting_accepted) [`greeting_canceled`](#greeting_canceled) [`queue_position_updated`](#queue_position_updated)       |
 
 </Text>
@@ -449,22 +449,6 @@ Informs that customer's data changed. The push payload contains the updated fiel
 ```json
 {
   // "User > Customer" object
-}
-```
-
-</CodeResponse>
-
-### `customer_page_updated`
-
-Informs that a Customer moved to another page of the website, for example by clicking a link.
-
-<CodeResponse title={'Sample push payload'}>
-
-```json
-{
-  "url": "https://livechatinc.com/pricing",
-  "title": "pricing",
-  "opened_at": "2020-09-10T08:22:21.128420Z"
 }
 ```
 

--- a/src/pages/messaging/customer-chat-api/v3.6/rtm-reference/index.mdx
+++ b/src/pages/messaging/customer-chat-api/v3.6/rtm-reference/index.mdx
@@ -1367,7 +1367,7 @@ When updating customer data while the customer has an active chat, the update wi
 | ---------------------- | ---------------------------------------------------------------------------------------------- |
 | **Action**             | `update_customer_page`                                                                         |
 | **Web API equivalent** | -                                                                                              |
-| **Push message**       | [`customer_page_updated`](/messaging/customer-chat-api/v3.6/rtm-pushes/#customer_page_updated) |
+| **Push message**       | -                                                                                              |
 
 Agent and referrer are updated by default using the browser’s headers.
 


### PR DESCRIPTION
# Deploy preview

Scroll down to the checks section for the link to the deploy preview of your branch.

# Links

Link your Jira ticket.

- Don't have one

# Description
We are removing `customer_page_updated` from all the Customer API versions, because it's unused and useless and generates a lot of data.

# Review and release

Apply changes and resolve conflicts. Once the described functionality lands on prod, let us know on #platform-docs-releases that your PR is ready for release. We will **merge** and **publish** the changes.
