### PR TITLE
Fix authorization docs

### DIFF
--- a/src/pages/authorization/sign-in-with-livechat/index.mdx
+++ b/src/pages/authorization/sign-in-with-livechat/index.mdx
@@ -486,13 +486,13 @@ For successful user authorization processes, the returned data will consists of 
 
 | Field             | Returned                               | Description                                                                                                                                            |
 | ----------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `access_token`    | only for `response_type: access_token` | Used for authorizing LiveChat API calls.                                                                                                               |
+| `access_token`    | only for `response_type: token`        | Used for authorizing LiveChat API calls.                                                                                                               |
 | `code`            | only for `response_type: code`         | Must be exchanged for `access_token` and `refresh_token`                                                                                               |
-| `scopes`          | for both response types                | An array of scopes that `access_token` has.                                                                                                            |
+| `scope`           | for both response types                | An array of scopes that `access_token` has.                                                                                                            |
 | `expires_in`      | for both response types                | Defines for how long `access_token` will be valid.                                                                                                     |
-| `account_id`      | for both response types                | LiveChat Accounts user ID (can be found in <a href="https://platform.text.com/console/" rel="noopener nofollow" target="_blank">Developer Console</a>) |
-| `organization_id` | for both response types                | LiveChat Accounts organization ID to which the account is logged in.                                                                                   |
-| `client_id`       | for both response types                | `client_id` that you passed in the `init` method.                                                                                                      |
+| `account_id`      | only for `response_type: code`         | LiveChat Accounts user ID (can be found in <a href="https://platform.text.com/console/" rel="noopener nofollow" target="_blank">Developer Console</a>) |
+| `organization_id` | only for `response_type: code`         | LiveChat Accounts organization ID to which the account is logged in.                                                                                   |
+| `client_id`       | only for `response_type: code`         | `client_id` that you passed in the `init` method.                                                                                                      |
 
 💡 You can validate an access token by calling `/v2/info`. [Read more...](/authorization/authorizing-api-calls/#validating-the-access-token)
 


### PR DESCRIPTION
# Description
We had inprecise information in authorization documentation in Log in with LiveChat section. I have added correct notes for response types and data that are returned during Accounts token exchange
