### PR TITLE
API-13656: Make owner_client_id required in some methods

### DIFF
--- a/src/pages/management/configuration-api/index.mdx
+++ b/src/pages/management/configuration-api/index.mdx
@@ -1224,15 +1224,15 @@ Bots based on templates will work in the same way as those created by the [Creat
 
 #### Request
 
-| Parameter                                | Required | Data type  | Notes                                                                                                                                                                                                                                                                                              |
-| ---------------------------------------- | -------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                                   | Yes      | `string`   | Display name                                                                                                                                                                                                                                                                                       |
-| `avatar`                                 | No       | `string`   | Avatar URL                                                                                                                                                                                                                                                                                         |
-| `max_chats_count`                        | No       | `int`      | Max. number of incoming chats that can be routed to the bot; default: 6. Limited to 500.                                                                                                                                                                                                           |
-| `default_group_priority`<sup>**1**</sup> | No       | `string`   | The default routing priority for a group without defined priority.                                                                                                                                                                                                                                 |
-| `job_title`                              | No       | `string`   | Bot's job title                                                                                                                                                                                                                                                                                    |
-| `owner_client_id`                        | Yes      | `string`   | Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
-| `affect_existing_installations`          | No       | `bool`     | If set to `true`, a bot based on this template will be created on all licenses that have given application installed. Otherwise only new installations will trigger bot creation.                                                                                                                  |
+| Parameter                                | Required | Data type  | Notes                                                                                                                                                                             |
+| ---------------------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                                   | Yes      | `string`   | Display name                                                                                                                                                                      |
+| `avatar`                                 | No       | `string`   | Avatar URL                                                                                                                                                                        |
+| `max_chats_count`                        | No       | `int`      | Max. number of incoming chats that can be routed to the bot; default: 6. Limited to 500.                                                                                          |
+| `default_group_priority`<sup>**1**</sup> | No       | `string`   | The default routing priority for a group without defined priority.                                                                                                                |
+| `job_title`                              | No       | `string`   | Bot's job title                                                                                                                                                                   |
+| `owner_client_id`                        | Yes      | `string`   | **Client Id** that will own the bot template; must be owned by your organization.                                                                                                 |
+| `affect_existing_installations`          | No       | `bool`     | If set to `true`, a bot based on this template will be created on all licenses that have given application installed. Otherwise only new installations will trigger bot creation. |
 
 **1)** Possible priority values:
 
@@ -1352,11 +1352,11 @@ Deletes a bot template specified by `id`. The bots associated with the template 
 
 #### Request
 
-| Parameter                       | Required | Type     | Notes  |
-| ------------------------------- | -------- | -------- | ------ |
-| `id`                            | Yes      | `string` | Bot Template ID                                                                                                                                                                                                                                                                                    |
-| `owner_client_id`               | Yes      | `string` | Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
-| `affect_existing_installations` | No       | `bool`   | If set to `true`, a bot based on this template will be deleted from all licenses that have given application installed.                                                                                                                                                                            |
+| Parameter                       | Required | Type     | Notes                                                                                                                   |
+| ------------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `id`                            | Yes      | `string` | Bot Template ID                                                                                                         |
+| `owner_client_id`               | Yes      | `string` | **Client Id** that owns the bot template; must be owned by your organization.                                           |
+| `affect_existing_installations` | No       | `bool`   | If set to `true`, a bot based on this template will be deleted from all licenses that have given application installed. |
 
 #### Response
 
@@ -1458,7 +1458,7 @@ Updates an existing bot template.
 | `max_chats_count`                        | No       | `int`      | Maximum incoming chats that can be routed to the Bot. Limited to 500.                                                                                                                                                                                                                              |
 | `default_group_priority`<sup>**1**</sup> | No       | `string`   | The default routing priority for a group without defined priority.                                                                                                                                                                                                                                 |
 | `job_title`                              | No       | `string`   | Bot's job title                                                                                                                                                                                                                                                                                    |
-| `owner_client_id`                        | Yes      | `string`   | Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
+| `owner_client_id`                        | Yes      | `string`   | **Client Id** that owns the bot template; must be owned by your organization.                                        |
 | `affect_existing_installations`          | No       | `bool`     | If set to `true`, bots based on this template will be updated on all licenses that have given application installed.                                                                                                                                                                               |
 
 **1)** Possible priority values:
@@ -1582,9 +1582,9 @@ Returns the list of bot templates created for a Client ID (application).
 
 #### Request
 
-| Parameter         | Required | Type       | Notes                                                                                                                                                                                                                                                                                              |
-| ----------------- | -------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `owner_client_id` | Yes      | `string`   | Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
+| Parameter         | Required | Type       | Notes                                                                                  |
+| ----------------- | -------- | ---------- | -------------------------------------------------------------------------------------- |
+| `owner_client_id` | Yes      | `string`   | **Client Id** that owns the bot templates to list; must be owned by your organization. |
 
 </Text>
 
@@ -1802,11 +1802,11 @@ Resets secret for given bot template.
 
 #### Request
 
-| Parameter                       | Required | Type     | Notes                                                                                                                                                                                                                                                                                              |
-| ------------------------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`                            | Yes      | `string` | Bot template ID                                                                                                                                                                                                                                                                                    |
-| `owner_client_id`               | Yes      | `string` | Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
-| `affect_existing_installations` | No       | `bool`   | If set to `true`, the new secret is set to for all existing bots based on this template.                                                                                                                                                                                                           |
+| Parameter                       | Required | Type     | Notes                                                                                    |
+| ------------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------- |
+| `id`                            | Yes      | `string` | Bot template ID                                                                          |
+| `owner_client_id`               | Yes      | `string` | **Client Id** that owns the bot template; must be owned by your organization.            |
+| `affect_existing_installations` | No       | `bool`   | If set to `true`, the new secret is set to for all existing bots based on this template. |
 
 </Text>
 
@@ -3233,7 +3233,7 @@ For `bot` webhooks, you need to [create a bot](#create-bot), [register webhooks]
 | `filters.chat_presence.user_ids.exclude_values` | no       | `[]string` | Array of Users' ids; if any specified Users is in the chat, the webhook will not be triggered.                                                                                                                                                    |
 | `filters.chat_presence.my_bots`                 | no       | `bool`     | If any bot owned by `owner_client_id` is in the chat, the webhook will be triggered.                                                                                                                                                              |
 | `filters.source_type`                           | no       | `[]string` | Array of source types. Possible values: `my_client` (client ID of your app), `other_clients` (client IDs other than your app's), `system` (no client ID); if the source which triggered the webhook matches the filter, the webhook will be sent. |
-| `owner_client_id`                               | yes      | `string`   | The Client ID for which the webhook will be registered. [What is Client ID and where to find it?](/authorization/authorization-in-practice/#step-1-configure-the-authorization-building-block). Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
+| `owner_client_id`                               | yes      | `string`   | **Client Id** that will own the webhook; must be owned by your organization.                                                                                                                                                                      |
 | `type`                                          | yes      | `string`   | `bot` or `license`                                                                                                                                                                                                                                |
 
 #### Triggering actions
@@ -3329,7 +3329,7 @@ Lists all webhooks registered for the given Client ID.
 
 | Parameter         | Required | Data type | Notes                                                                  |
 | ----------------- | -------- | --------- | ---------------------------------------------------------------------- |
-| `owner_client_id` | yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
+| `owner_client_id` | yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). |
 
 </Text>
 
@@ -3376,7 +3376,7 @@ Unregisters a webhook previously [registered](#register-webhook) for a Client ID
 | Parameter         | Required | Data type | Notes                                                                  |
 | ----------------- | -------- | --------- | ---------------------------------------------------------------------- |
 | `id`              | Yes      | `string`  | Webhook ID                                                             |
-| `owner_client_id` | Yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
+| `owner_client_id` | Yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). |
 
 #### Response
 

--- a/src/pages/management/configuration-api/v3.6/index.mdx
+++ b/src/pages/management/configuration-api/v3.6/index.mdx
@@ -1208,15 +1208,15 @@ Bots based on templates will work in the same way as those created by the [Creat
 
 #### Request
 
-| Parameter                                | Required | Data type  | Notes                                                                                                                                                                                                                                                                                              |
-| ---------------------------------------- | -------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                                   | Yes      | `string`   | Display name                                                                                                                                                                                                                                                                                       |
-| `avatar`                                 | No       | `string`   | Avatar URL                                                                                                                                                                                                                                                                                         |
-| `max_chats_count`                        | No       | `int`      | Max. number of incoming chats that can be routed to the bot; default: 6. Limited to 500.                                                                                                                                                                                                           |
-| `default_group_priority`<sup>**1**</sup> | No       | `string`   | The default routing priority for a group without defined priority.                                                                                                                                                                                                                                 |
-| `job_title`                              | No       | `string`   | Bot's job title                                                                                                                                                                                                                                                                                    |
-| `owner_client_id`                        | Yes      | `string`   | Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
-| `affect_existing_installations`          | No       | `bool`     | If set to `true`, a bot based on this template will be created on all licenses that have given application installed. Otherwise only new installations will trigger bot creation.                                                                                                                  |
+| Parameter                                | Required | Data type  | Notes                                                                                                                                                                             |
+| ---------------------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                                   | Yes      | `string`   | Display name                                                                                                                                                                      |
+| `avatar`                                 | No       | `string`   | Avatar URL                                                                                                                                                                        |
+| `max_chats_count`                        | No       | `int`      | Max. number of incoming chats that can be routed to the bot; default: 6. Limited to 500.                                                                                          |
+| `default_group_priority`<sup>**1**</sup> | No       | `string`   | The default routing priority for a group without defined priority.                                                                                                                |
+| `job_title`                              | No       | `string`   | Bot's job title                                                                                                                                                                   |
+| `owner_client_id`                        | Yes      | `string`   | **Client Id** that will own the bot template; must be owned by your organization.                                                                                                 |
+| `affect_existing_installations`          | No       | `bool`     | If set to `true`, a bot based on this template will be created on all licenses that have given application installed. Otherwise only new installations will trigger bot creation. |
 
 **1)** Possible priority values:
 
@@ -1336,11 +1336,11 @@ Deletes a bot template specified by `id`. The bots associated with the template 
 
 #### Request
 
-| Parameter                       | Required | Type     | Notes  |
-| ------------------------------- | -------- | -------- | ------ |
-| `id`                            | Yes      | `string` | Bot Template ID                                                                                                                                                                                                                                                                                    |
-| `owner_client_id`               | Yes      | `string` | Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
-| `affect_existing_installations` | No       | `bool`   | If set to `true`, a bot based on this template will be deleted from all licenses that have given application installed.                                                                                                                                                                            |
+| Parameter                       | Required | Type     | Notes                                                                                                                   |
+| ------------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `id`                            | Yes      | `string` | Bot Template ID                                                                                                         |
+| `owner_client_id`               | Yes      | `string` | **Client Id** that owns the bot template; must be owned by your organization.                                           |
+| `affect_existing_installations` | No       | `bool`   | If set to `true`, a bot based on this template will be deleted from all licenses that have given application installed. |
 
 #### Response
 
@@ -1442,7 +1442,7 @@ Updates an existing bot template.
 | `max_chats_count`                        | No       | `int`      | Maximum incoming chats that can be routed to the Bot. Limited to 500.                                                                                                                                                                                                                              |
 | `default_group_priority`<sup>**1**</sup> | No       | `string`   | The default routing priority for a group without defined priority.                                                                                                                                                                                                                                 |
 | `job_title`                              | No       | `string`   | Bot's job title                                                                                                                                                                                                                                                                                    |
-| `owner_client_id`                        | Yes      | `string`   | Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
+| `owner_client_id`                        | Yes      | `string`   | **Client Id** that owns the bot template; must be owned by your organization.                                        |
 | `affect_existing_installations`          | No       | `bool`     | If set to `true`, bots based on this template will be updated on all licenses that have given application installed.                                                                                                                                                                               |
 
 **1)** Possible priority values:
@@ -1566,9 +1566,9 @@ Returns the list of bot templates created for a Client ID (application).
 
 #### Request
 
-| Parameter         | Required | Type       | Notes                                                                                                                                                                                                                                                                                              |
-| ----------------- | -------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `owner_client_id` | Yes      | `string`   | Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
+| Parameter         | Required | Type       | Notes                                                                                  |
+| ----------------- | -------- | ---------- | -------------------------------------------------------------------------------------- |
+| `owner_client_id` | Yes      | `string`   | **Client Id** that owns the bot templates to list; must be owned by your organization. |
 
 </Text>
 
@@ -1786,11 +1786,11 @@ Resets secret for given bot template.
 
 #### Request
 
-| Parameter                       | Required | Type     | Notes                                                                                                                                                                                                                                                                                              |
-| ------------------------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`                            | Yes      | `string` | Bot template ID                                                                                                                                                                                                                                                                                    |
-| `owner_client_id`               | Yes      | `string` | Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
-| `affect_existing_installations` | No       | `bool`   | If set to `true`, the new secret is set to for all existing bots based on this template.                                                                                                                                                                                                           |
+| Parameter                       | Required | Type     | Notes                                                                                    |
+| ------------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------- |
+| `id`                            | Yes      | `string` | Bot template ID                                                                          |
+| `owner_client_id`               | Yes      | `string` | **Client Id** that owns the bot template; must be owned by your organization.            |
+| `affect_existing_installations` | No       | `bool`   | If set to `true`, the new secret is set to for all existing bots based on this template. |
 
 </Text>
 
@@ -3207,7 +3207,7 @@ For `bot` webhooks, you need to [create a bot](#create-bot), [register webhooks]
 | `filters.chat_presence.user_ids.exclude_values` | no       | `[]string` | Array of Users' ids; if any specified Users is in the chat, the webhook will not be triggered.                                                                                                                                                    |
 | `filters.chat_presence.my_bots`                 | no       | `bool`     | If any bot owned by `owner_client_id` is in the chat, the webhook will be triggered.                                                                                                                                                              |
 | `filters.source_type`                           | no       | `[]string` | Array of source types. Possible values: `my_client` (client ID of your app), `other_clients` (client IDs other than your app's), `system` (no client ID); if the source which triggered the webhook matches the filter, the webhook will be sent. |
-| `owner_client_id`                               | yes      | `string`   | The Client ID for which the webhook will be registered. [What is Client ID and where to find it?](/authorization/authorization-in-practice/#step-1-configure-the-authorization-building-block). Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
+| `owner_client_id`                               | yes      | `string`   | **Client Id** that will own the webhook; must be owned by your organization.                                                                                                                                                                      |
 | `type`                                          | yes      | `string`   | `bot` or `license`                                                                                                                                                                                                                                |
 
 #### Triggering actions
@@ -3303,7 +3303,7 @@ Lists all webhooks registered for the given Client ID.
 
 | Parameter         | Required | Data type | Notes                                                                  |
 | ----------------- | -------- | --------- | ---------------------------------------------------------------------- |
-| `owner_client_id` | yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
+| `owner_client_id` | yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). |
 
 </Text>
 
@@ -3350,7 +3350,7 @@ Unregisters a webhook previously [registered](#register-webhook) for a Client ID
 | Parameter         | Required | Data type | Notes                                                                  |
 | ----------------- | -------- | --------- | ---------------------------------------------------------------------- |
 | `id`              | Yes      | `string`  | Webhook ID                                                             |
-| `owner_client_id` | Yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). Required only when authorizing via [PATs](/authorization/agent-authorization#personal-access-tokens). When you provide this param while authorizing with a Bearer Token, the `client_id` associated with the Bearer Token will be ignored, and provided `owner_client_id` will be used instead. |
+| `owner_client_id` | Yes      | `string`  | The webhook owner (the Client ID for which the webhook is registered). |
 
 #### Response
 


### PR DESCRIPTION
# Links

- [Jira](https://livechatinc.atlassian.net/browse/API-13656)

# Description

Due to security reasons we no longer fall back to the token's client_id when authorizing via Bearer token for properties, webhooks and bot templates management.

