### PR TITLE
chore: add Aikido Safe Chain to CI workflows

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -19,6 +19,15 @@ jobs:
         with:
           node-version: "18.17.0"
 
+      - name: Install Aikido Safe Chain 1.5.3
+        shell: bash
+        run: |
+          curl -fsSL -o /tmp/install-safe-chain.sh https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh
+          echo "0107cbbbf90159379756157e902acae512d62ffbd174307e42c5fe9f266792d3  /tmp/install-safe-chain.sh" | sha256sum -c
+          sh /tmp/install-safe-chain.sh --ci
+      - name: Verify Aikido Safe Chain
+        shell: bash
+        run: safe-chain --version && npm safe-chain-verify
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,15 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Install Aikido Safe Chain 1.5.3
+        shell: bash
+        run: |
+          curl -fsSL -o /tmp/install-safe-chain.sh https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh
+          echo "0107cbbbf90159379756157e902acae512d62ffbd174307e42c5fe9f266792d3  /tmp/install-safe-chain.sh" | sha256sum -c
+          sh /tmp/install-safe-chain.sh --ci
+      - name: Verify Aikido Safe Chain
+        shell: bash
+        run: safe-chain --version && npm safe-chain-verify
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Aikido Safe Chain — automated PR

This PR injects a Safe Chain setup step into CI workflows before package-manager install steps.

### What changed

A `Set up Aikido Safe Chain` step was injected before the first package-manager install step in every job that installs npm, pip, or yarn packages.

### Why

Safe Chain intercepts all package downloads via a local proxy that blocks known malware and enforces a 48-hour minimum package age, preventing day-zero supply chain attacks.

See: [AikidoSec/safe-chain](https://github.com/AikidoSec/safe-chain)

### Review checklist

- [ ] Confirm the new step appears before the install step(s) in each affected job
- [ ] Verify CI is still green after merge
- [ ] **Merge into `master`**