### PR TITLE
feat(docs): add customer segment memberships to v3.6 and v3.7 EUEE-1590

### DIFF
--- a/payloads/messaging/v3.6/agent-chat-api/index.js
+++ b/payloads/messaging/v3.6/agent-chat-api/index.js
@@ -21,4 +21,5 @@ export { default as customerProperty } from "./other-structures/customerProperty
 export { default as formFields } from "./other-structures/formFields.json";
 export { default as filledFormFields } from "./other-structures/filledFormFields.json";
 export { default as properties } from "./other-structures/properties.json";
+export { default as segmentMembership } from "./other-structures/segmentMembership.json";
 export { default as thread } from "./other-structures/thread.json";

--- a/payloads/messaging/v3.6/agent-chat-api/other-structures/segmentMembership.json
+++ b/payloads/messaging/v3.6/agent-chat-api/other-structures/segmentMembership.json
@@ -1,0 +1,18 @@
+{
+  "segment_id": 0,
+  "is_member": true,
+  "membership_last_updated_at": "2026-07-15T09:31:45.075731Z",
+  "membership_attribution": [
+    "464d206a-ba7d-4ce1-98d6-d03f8f14970e"
+  ],
+  "conditions_provenance": {
+    "email_set": {
+      "last_updated_at": "2026-07-15T09:31:45.075731Z",
+      "agent_account_id": "464d206a-ba7d-4ce1-98d6-d03f8f14970e",
+      "agent_client_id": "71d32c598862b01b9e2298281339dbc2"
+    },
+    "phone_number_set": {
+      "last_updated_at": "2026-07-15T09:42:23.048723Z"
+    }
+  }
+}

--- a/payloads/messaging/v3.6/agent-chat-api/users/customer.json
+++ b/payloads/messaging/v3.6/agent-chat-api/users/customer.json
@@ -124,5 +124,25 @@
       "last_updated_agent_account_id": "464d206a-ba7d-4ce1-98d6-d03f8f14970e",
       "last_updated_agent_client_id": "71d32c598862b01b9e2298281339dbc2"
     }
-  }
+  },
+  "segment_memberships": [
+    {
+      "segment_id": 0,
+      "is_member": true,
+      "membership_last_updated_at": "2026-07-15T09:31:45.075731Z",
+      "membership_attribution": [
+        "464d206a-ba7d-4ce1-98d6-d03f8f14970e"
+      ],
+      "conditions_provenance": {
+        "email_set": {
+          "last_updated_at": "2026-07-15T09:31:45.075731Z",
+          "agent_account_id": "464d206a-ba7d-4ce1-98d6-d03f8f14970e",
+          "agent_client_id": "71d32c598862b01b9e2298281339dbc2"
+        },
+        "phone_number_set": {
+          "last_updated_at": "2026-07-15T09:42:23.048723Z"
+        }
+      }
+    }
+  ]
 }

--- a/payloads/messaging/v3.7/agent-chat-api/index.js
+++ b/payloads/messaging/v3.7/agent-chat-api/index.js
@@ -21,4 +21,5 @@ export { default as customerProperty } from "./other-structures/customerProperty
 export { default as formFields } from "./other-structures/formFields.json";
 export { default as filledFormFields } from "./other-structures/filledFormFields.json";
 export { default as properties } from "./other-structures/properties.json";
+export { default as segmentMembership } from "./other-structures/segmentMembership.json";
 export { default as thread } from "./other-structures/thread.json";

--- a/payloads/messaging/v3.7/agent-chat-api/other-structures/segmentMembership.json
+++ b/payloads/messaging/v3.7/agent-chat-api/other-structures/segmentMembership.json
@@ -1,0 +1,18 @@
+{
+  "segment_id": 0,
+  "is_member": true,
+  "membership_last_updated_at": "2026-07-15T09:31:45.075731Z",
+  "membership_attribution": [
+    "464d206a-ba7d-4ce1-98d6-d03f8f14970e"
+  ],
+  "conditions_provenance": {
+    "email_set": {
+      "last_updated_at": "2026-07-15T09:31:45.075731Z",
+      "agent_account_id": "464d206a-ba7d-4ce1-98d6-d03f8f14970e",
+      "agent_client_id": "71d32c598862b01b9e2298281339dbc2"
+    },
+    "phone_number_set": {
+      "last_updated_at": "2026-07-15T09:42:23.048723Z"
+    }
+  }
+}

--- a/payloads/messaging/v3.7/agent-chat-api/users/customer.json
+++ b/payloads/messaging/v3.7/agent-chat-api/users/customer.json
@@ -124,5 +124,25 @@
       "last_updated_agent_account_id": "464d206a-ba7d-4ce1-98d6-d03f8f14970e",
       "last_updated_agent_client_id": "71d32c598862b01b9e2298281339dbc2"
     }
-  }
+  },
+  "segment_memberships": [
+    {
+      "segment_id": 0,
+      "is_member": true,
+      "membership_last_updated_at": "2026-07-15T09:31:45.075731Z",
+      "membership_attribution": [
+        "464d206a-ba7d-4ce1-98d6-d03f8f14970e"
+      ],
+      "conditions_provenance": {
+        "email_set": {
+          "last_updated_at": "2026-07-15T09:31:45.075731Z",
+          "agent_account_id": "464d206a-ba7d-4ce1-98d6-d03f8f14970e",
+          "agent_client_id": "71d32c598862b01b9e2298281339dbc2"
+        },
+        "phone_number_set": {
+          "last_updated_at": "2026-07-15T09:42:23.048723Z"
+        }
+      }
+    }
+  ]
 }

--- a/src/pages/messaging/agent-chat-api/changelog/index.mdx
+++ b/src/pages/messaging/agent-chat-api/changelog/index.mdx
@@ -77,12 +77,14 @@ The developer preview version provides a preview of the upcoming changes to the 
   - [**customer_property_definition_created**](/messaging/agent-chat-api/rtm-pushes/#customer_property_definition_created)
   - [**customer_property_definition_updated**](/messaging/agent-chat-api/rtm-pushes/#customer_property_definition_updated)
   - [**customer_properties_values_updated**](/messaging/agent-chat-api/rtm-pushes/#customer_properties_values_updated)
+  - [**segment_memberships_updated**](/messaging/agent-chat-api/rtm-pushes/#segment_memberships_updated)
 - The [**Customer**](/messaging/agent-chat-api/data-structures#customer) data structure now contains information about phone number and omnichannel data (when available).
 - The **Update Customer** ([Web](/messaging/agent-chat-api/#update-customer) & [RTM](/messaging/agent-chat-api/rtm-reference/#update-customer)) method has new fields, `phone_number` and `omnichannel`.
 - The `omnichannel` field now supports WhatsApp data: `id`, `name`, and `phone_number`.
 - The [**Customer**](/messaging/agent-chat-api/data-structures#customer) data structure now contains the customer's `address` information.
 - The [**Customer**](/messaging/agent-chat-api/data-structures#customer) data structure has a new `carts` field containing an array of [**Cart**](/messaging/agent-chat-api/data-structures#cart) objects.
 - The [**Customer**](/messaging/agent-chat-api/data-structures#customer) data structure has a new `customer_properties` field containing a map of [**Customer Property**](/messaging/agent-chat-api/data-structures#customer-property) objects.
+- The [**Customer**](/messaging/agent-chat-api/data-structures#customer) data structure has a new `segment_memberships` field containing an array of [**Segment Membership**](/messaging/agent-chat-api/data-structures#segment-membership) objects.
 - The [**customer_updated**](/messaging/agent-chat-api/rtm-pushes/#customer_updated) push now includes cart data.
 
 ### Status

--- a/src/pages/messaging/agent-chat-api/data-structures/index.mdx
+++ b/src/pages/messaging/agent-chat-api/data-structures/index.mdx
@@ -440,7 +440,7 @@ It is not possible to send a System event in API version 3.6.
 | `omnichannel`                    | optional  |                                                                                                                                                           |
 | `address`                        | optional  | An object of the customer's address data.                                                                                                                 |
 | `customer_properties`            | optional  | An object where the keys are the IDs of the [customer properties](#customer-property) and the values are their data.                                      |
-| `segment_memberships`            | optional  | An array of the customer's segment memberships. See [Segment Membership](#segment-membership) for the object structure.                                   |
+| `segment_memberships`            | optional  | An array of the customer's [segment memberships](#segment-membership).                                                                                    |
 
 ### Cart
 
@@ -485,25 +485,27 @@ The customer property's type is set on creation by the agent.
 
 ### Segment Membership
 
-Segment memberships describe which segments the customer belongs to. The `segment_memberships` field is omitted when there's no record of any segment membership state for the customer.
+Segment memberships describe which segments the customer belongs to. A segment is a named rule that classifies customers based on their data. Each segment is defined by conditions. Text evaluates every customer against each active segment definition automatically whenever the customer's data changes.
+
+Every organization has two built-in segments, lead (ID `0`) and qualified lead (ID `1`). You can also [create custom segment definitions](/management/customer-data-platform-api#/paths/~1v1~1create_segment_definition/post).
 
 <CodeResponse version="v3.6" type="agent" title={'Sample Segment Membership data structure'} json="segmentMembership"/>
 
-| Field                        | Req./Opt. | Data type  | Notes                                                                                                                                                                                                                                                               |
-| ---------------------------- | --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `segment_id`                 | required  | `number`   | The ID of the segment definition this membership refers to. The built-in default segment has the ID `0`.                                                                                                                                                            |
-| `is_member`                  | required  | `bool`     | Whether the customer currently satisfies the segment's conditions.                                                                                                                                                                                                  |
-| `membership_last_updated_at` | optional  | `string`   | RFC 3339 datetime string; the time when `is_member` last changed. Returned only if the customer was a member of the segment at least once.                                                                                                                          |
-| `membership_attribution`     | optional  | `[]string` | Account IDs of the agents credited with the customer joining the segment. Returned only when an agent's change added the customer to the segment.                                                                                                                   |
-| `conditions_provenance`      | optional  | `object`   | An object where the keys are the names of the conditions the customer satisfies (for example, `email_set`) and the values are [Condition Provenance](#condition-provenance) objects. Conditions are reported even when the customer isn't a member of the segment.  |
+| Field                        | Req./Opt. | Data type  | Notes                                                                                                                                                                                                                                                                                                |
+| ---------------------------- | --------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `segment_id`                 | required  | `number`   | The ID of the segment definition.                                                                                                                                                                                                                                                                    |
+| `is_member`                  | required  | `bool`     | Whether the customer currently meets all conditions of the segment.                                                                                                                                                                                                                                  |
+| `membership_last_updated_at` | optional  | `string`   | RFC 3339 datetime string; the time when `is_member` last changed. Returned only if the customer was a member of the segment at least once.                                                                                                                                                           |
+| `membership_attribution`     | optional  | `[]string` | Account IDs of the agents credited with the customer joining the segment. Returned only when an agent's change added the customer to the segment.                                                                                                                                                    |
+| `conditions_provenance`      | optional  | `object`   | An object where the keys are the names of the conditions the customer meets (for example, `email_set`) and the values are [Condition Provenance](#condition-provenance) objects. If the customer meets a segment condition, it will be returned even if the customer isn't a member of that segment. |
 
 ### Condition Provenance
 
 | Field              | Req./Opt. | Data type | Notes                                                                                                                                                    |
 | ------------------ | --------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `last_updated_at`  | required  | `string`  | RFC 3339 datetime string; the time when the condition was last satisfied.                                                                                |
-| `agent_account_id` | optional  | `string`  | Account ID of the agent whose change satisfied the condition. Returned only when the change is attributable to an agent.                                 |
-| `agent_client_id`  | optional  | `string`  | Client ID of the application that issued the token of the agent who satisfied the condition. Returned only when the change is attributable to an agent.  |
+| `last_updated_at`  | required  | `string`  | RFC 3339 datetime string; the time when the condition was last met.                                                                                      |
+| `agent_account_id` | optional  | `string`  | The account ID of the agent whose change made the customer meet the condition. Returned only when attributable to an agent.                              |
+| `agent_client_id`  | optional  | `string`  | The client ID of the application that issued the agent token. Returned only when attributable to an agent.                                               |
 
 # Other common structures
 

--- a/src/pages/messaging/agent-chat-api/data-structures/index.mdx
+++ b/src/pages/messaging/agent-chat-api/data-structures/index.mdx
@@ -440,6 +440,7 @@ It is not possible to send a System event in API version 3.6.
 | `omnichannel`                    | optional  |                                                                                                                                                           |
 | `address`                        | optional  | An object of the customer's address data.                                                                                                                 |
 | `customer_properties`            | optional  | An object where the keys are the IDs of the [customer properties](#customer-property) and the values are their data.                                      |
+| `segment_memberships`            | optional  | An array of the customer's segment memberships. See [Segment Membership](#segment-membership) for the object structure.                                   |
 
 ### Cart
 
@@ -481,6 +482,28 @@ The customer property's type is set on creation by the agent.
 | `last_updated_at`               | required  | `string`  | RFC 3339 datetime string.                                                                  |
 | `last_updated_agent_account_id` | optional  | `string`  | Account ID of the agent that last set this value.                                          |
 | `last_updated_agent_client_id`  | optional  | `string`  | Client ID of the application that last set this value.                                     |
+
+### Segment Membership
+
+Segment memberships describe which segments the customer belongs to. The `segment_memberships` field is omitted when there's no record of any segment membership state for the customer.
+
+<CodeResponse version="v3.6" type="agent" title={'Sample Segment Membership data structure'} json="segmentMembership"/>
+
+| Field                        | Req./Opt. | Data type  | Notes                                                                                                                                                                                                                                                               |
+| ---------------------------- | --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `segment_id`                 | required  | `number`   | The ID of the segment definition this membership refers to. The built-in default segment has the ID `0`.                                                                                                                                                            |
+| `is_member`                  | required  | `bool`     | Whether the customer currently satisfies the segment's conditions.                                                                                                                                                                                                  |
+| `membership_last_updated_at` | optional  | `string`   | RFC 3339 datetime string; the time when `is_member` last changed. Returned only if the customer was a member of the segment at least once.                                                                                                                          |
+| `membership_attribution`     | optional  | `[]string` | Account IDs of the agents credited with the customer joining the segment. Returned only when an agent's change added the customer to the segment.                                                                                                                   |
+| `conditions_provenance`      | optional  | `object`   | An object where the keys are the names of the conditions the customer satisfies (for example, `email_set`) and the values are [Condition Provenance](#condition-provenance) objects. Conditions are reported even when the customer isn't a member of the segment.  |
+
+### Condition Provenance
+
+| Field              | Req./Opt. | Data type | Notes                                                                                                                                                    |
+| ------------------ | --------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `last_updated_at`  | required  | `string`  | RFC 3339 datetime string; the time when the condition was last satisfied.                                                                                |
+| `agent_account_id` | optional  | `string`  | Account ID of the agent whose change satisfied the condition. Returned only when the change is attributable to an agent.                                 |
+| `agent_client_id`  | optional  | `string`  | Client ID of the application that issued the token of the agent who satisfied the condition. Returned only when the change is attributable to an agent.  |
 
 # Other common structures
 

--- a/src/pages/messaging/agent-chat-api/index.mdx
+++ b/src/pages/messaging/agent-chat-api/index.mdx
@@ -1953,7 +1953,7 @@ Returns the info about the customer with a given `id`.
 | `chat_ids`            | []string  | The IDs of the customer's chats. Returned only if the customer had at least one chat.                                             |
 | `omnichannel`         | object    | An object of the customer's [omnichannel data](/messaging/agent-chat-api/data-structures/#customer).                              |
 | `address`             | object    | An object of the customer's address data. Returned only if set.                                                                   |
-| `segment_memberships` | []object  | The customer's [segment memberships](/messaging/agent-chat-api/v3.6/data-structures/#segment-membership). Returned only if set.   |
+| `segment_memberships` | []object  | The customer's [segment memberships](/messaging/agent-chat-api/data-structures/#segment-membership). Returned only if set.        |
 
 </Text>
 <Code>

--- a/src/pages/messaging/agent-chat-api/index.mdx
+++ b/src/pages/messaging/agent-chat-api/index.mdx
@@ -1938,21 +1938,22 @@ Returns the info about the customer with a given `id`.
 
 #### Response
 
-| Field            | Data type | Notes                                                                                                                             |
-| ---------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `id`             | string    | The [customer's](/messaging/agent-chat-api/v3.6/data-structures/#customer) ID.                                                    |
-| `type`           | string    | `customer`                                                                                                                        |
-| `name`           | string    | The customer's name. Returned only if set.                                                                                        |
-| `email`          | string    | The customer's email. Returned only if set.                                                                                       |
-| `avatar`         | string    | The customer's avatar. Returned only if set.                                                                                      |
-| `phone_number`   | string    | The customer's phone number. Returned only if set.                                                                                |
-| `created_at`     | string    | The date and time when the customer's identity was created.                                                                       |
-| `session_fields` | []object  | An array of custom object-enclosed key-value pairs. Returned only if set. Available for the session duration.                     |
-| `statistics`     | object    | Counters for started threads, opened pages, etc.                                                                                  |
-| `visit`          | object    | Geolocation and opened pages from the customer's most recent online visit. Returned only if the customer logged in at least once. |
-| `chat_ids`       | []string  | The IDs of the customer's chats. Returned only if the customer had at least one chat.                                             |
-| `omnichannel`    | object    | An object of the customer's [omnichannel data](/messaging/agent-chat-api/data-structures/#customer).                              |
-| `address`        | object    | An object of the customer's address data. Returned only if set.                                                                   |
+| Field                 | Data type | Notes                                                                                                                             |
+| --------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                  | string    | The [customer's](/messaging/agent-chat-api/v3.6/data-structures/#customer) ID.                                                    |
+| `type`                | string    | `customer`                                                                                                                        |
+| `name`                | string    | The customer's name. Returned only if set.                                                                                        |
+| `email`               | string    | The customer's email. Returned only if set.                                                                                       |
+| `avatar`              | string    | The customer's avatar. Returned only if set.                                                                                      |
+| `phone_number`        | string    | The customer's phone number. Returned only if set.                                                                                |
+| `created_at`          | string    | The date and time when the customer's identity was created.                                                                       |
+| `session_fields`      | []object  | An array of custom object-enclosed key-value pairs. Returned only if set. Available for the session duration.                     |
+| `statistics`          | object    | Counters for started threads, opened pages, etc.                                                                                  |
+| `visit`               | object    | Geolocation and opened pages from the customer's most recent online visit. Returned only if the customer logged in at least once. |
+| `chat_ids`            | []string  | The IDs of the customer's chats. Returned only if the customer had at least one chat.                                             |
+| `omnichannel`         | object    | An object of the customer's [omnichannel data](/messaging/agent-chat-api/data-structures/#customer).                              |
+| `address`             | object    | An object of the customer's address data. Returned only if set.                                                                   |
+| `segment_memberships` | []object  | The customer's [segment memberships](/messaging/agent-chat-api/v3.6/data-structures/#segment-membership). Returned only if set.   |
 
 </Text>
 <Code>

--- a/src/pages/messaging/agent-chat-api/rtm-pushes/index.mdx
+++ b/src/pages/messaging/agent-chat-api/rtm-pushes/index.mdx
@@ -721,7 +721,7 @@ Indicates that the values of [customer properties](/messaging/agent-chat-api/dat
 
 ### `segment_memberships_updated`
 
-Indicates that the customer joined or left at least one segment. The push is sent only when the `is_member` field of a [segment membership](/messaging/agent-chat-api/data-structures#segment-membership) changes; all the changes evaluated at the same time are grouped into one push.
+Indicates that the customer joined or left at least one segment. Sent only when the `is_member` field of a [segment membership](/messaging/agent-chat-api/data-structures#segment-membership) changes. All the changes evaluated at the same time are grouped into one push.
 
 <CodeResponse title={'Sample push payload: the customer joined a segment'}>
 
@@ -773,7 +773,7 @@ Indicates that the customer joined or left at least one segment. The push is sen
 
 | Field                 | Notes                                                                                                                                                           |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `customer_id`         | The ID of the customer whose segment memberships changed.                                                                                                       |
+| `customer_id`         | The ID of the customer.                                                                                                                                         |
 | `segment_memberships` | The new state of all the customer's [segment memberships](/messaging/agent-chat-api/data-structures#segment-membership), not only the ones that changed.        |
 | `segments_added`      | The IDs of the segments the customer has just joined. Returned only if the customer joined any segment.                                                         |
 | `segments_removed`    | The IDs of the segments the customer has just left. Returned only if the customer left any segment.                                                             |
@@ -1641,7 +1641,7 @@ Indicates an error occurred during processing of an asynchronous query (e.g. aft
   "action": "set_thread_summary",
   "chat_id": "PJ0MRSHTDG",
   "thread_id": "K600PKZON8",
-  
+
 }
 ```
 

--- a/src/pages/messaging/agent-chat-api/rtm-pushes/index.mdx
+++ b/src/pages/messaging/agent-chat-api/rtm-pushes/index.mdx
@@ -1640,8 +1640,7 @@ Indicates an error occurred during processing of an asynchronous query (e.g. aft
 {
   "action": "set_thread_summary",
   "chat_id": "PJ0MRSHTDG",
-  "thread_id": "K600PKZON8",
-
+  "thread_id": "K600PKZON8"
 }
 ```
 

--- a/src/pages/messaging/agent-chat-api/rtm-pushes/index.mdx
+++ b/src/pages/messaging/agent-chat-api/rtm-pushes/index.mdx
@@ -35,7 +35,7 @@ Here's what you need to know about **pushes**:
 | **Events**        | [`incoming_event`](#incoming_event) [`event_deleted`](#event_deleted) [`event_updated`](#event_updated) [`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | **Properties**    | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | **Thread tags**   | [`thread_tagged`](#thread_tagged) [`thread_untagged`](#thread_untagged)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| **Customers**     | [`incoming_customers`](#incoming_customers) [`incoming_customer`](#incoming_customer) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_properties_values_updated`](#customer_properties_values_updated) [`customer_statistics_updated`](#customer_statistics_updated) [`customer_banned`](#customer_banned) [`customer_transferred`](#customer_transferred) [`customer_left`](#customer_left) [`subscribed_customers_totals_updated`](#subscribed_customers_totals_updated) [`ticket_created`](#ticket_created)  [`ticket_deleted`](#ticket_deleted)                                                                                                                                                                                                                                                                                                    |
+| **Customers**     | [`incoming_customers`](#incoming_customers) [`incoming_customer`](#incoming_customer) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_properties_values_updated`](#customer_properties_values_updated) [`segment_memberships_updated`](#segment_memberships_updated) [`customer_statistics_updated`](#customer_statistics_updated) [`customer_banned`](#customer_banned) [`customer_transferred`](#customer_transferred) [`customer_left`](#customer_left) [`subscribed_customers_totals_updated`](#subscribed_customers_totals_updated) [`ticket_created`](#ticket_created)  [`ticket_deleted`](#ticket_deleted)                                                                                                                                                                                                                                      |
 | **Status**        | [`routing_status_set`](#routing_status_set) [`agent_disconnected`](#agent_disconnected)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | **Configuration** | [`agent_created`](#agent_created) [`agent_approved`](#agent_approved) [`agent_updated`](#agent_updated) [`agent_suspended`](#agent_suspended) [`agent_unsuspended`](#agent_unsuspended) [`agent_deleted`](#agent_deleted) [`auto_accesses_updated`](#auto_accesses_updated) [`bot_created`](#bot_created) [`bot_updated`](#bot_updated) [`bot_deleted`](#bot_deleted) [`group_created`](#group_created) [`group_updated`](#group_updated) [`group_deleted`](#group_deleted) [`tag_created`](#tag_created) [`tag_deleted`](#tag_deleted) [`tag_updated`](#tag_updated) [`groups_status_updated`](#groups_status_updated) [`license_properties_updated`](#license_properties_updated) [`group_properties_updated`](#group_properties_updated) [`customer_property_definition_created`](#customer_property_definition_created) [`customer_property_definition_updated`](#customer_property_definition_updated) |
 | **Other**         | [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_sneak_peek`](#incoming_sneak_peek) [`incoming_thinking_indicator`](#incoming_thinking_indicator) [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`chat_unfollowed`](#chat_unfollowed) [`queue_positions_updated`](#queue_positions_updated) [`thread_summary_set`](#thread_summary_set) [`incoming_error`](#incoming_error)                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
@@ -718,6 +718,65 @@ Indicates that the values of [customer properties](/messaging/agent-chat-api/dat
 ```
 
 </CodeResponse>
+
+### `segment_memberships_updated`
+
+Indicates that the customer joined or left at least one segment. The push is sent only when the `is_member` field of a [segment membership](/messaging/agent-chat-api/data-structures#segment-membership) changes; all the changes evaluated at the same time are grouped into one push.
+
+<CodeResponse title={'Sample push payload: the customer joined a segment'}>
+
+```json
+{
+  "customer_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "segment_memberships": [
+    {
+      "segment_id": 0,
+      "is_member": true,
+      "membership_last_updated_at": "2026-07-13T13:11:21.187676Z",
+      "membership_attribution": [
+        "464d206a-ba7d-4ce1-98d6-d03f8f14970e"
+      ],
+      "conditions_provenance": {
+        "email_set": {
+          "last_updated_at": "2026-07-13T13:11:21.187676Z",
+          "agent_account_id": "464d206a-ba7d-4ce1-98d6-d03f8f14970e",
+          "agent_client_id": "71d32c598862b01b9e2298281339dbc2"
+        }
+      }
+    }
+  ],
+  "segments_added": [0]
+}
+```
+
+</CodeResponse>
+
+<CodeResponse title={'Sample push payload: the customer left a segment'}>
+
+```json
+{
+  "customer_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "segment_memberships": [
+    {
+      "segment_id": 0,
+      "is_member": false,
+      "membership_last_updated_at": "2026-07-13T13:11:53.970263Z"
+    }
+  ],
+  "segments_removed": [0]
+}
+```
+
+</CodeResponse>
+
+#### Push payload
+
+| Field                 | Notes                                                                                                                                                           |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `customer_id`         | The ID of the customer whose segment memberships changed.                                                                                                       |
+| `segment_memberships` | The new state of all the customer's [segment memberships](/messaging/agent-chat-api/data-structures#segment-membership), not only the ones that changed.        |
+| `segments_added`      | The IDs of the segments the customer has just joined. Returned only if the customer joined any segment.                                                         |
+| `segments_removed`    | The IDs of the segments the customer has just left. Returned only if the customer left any segment.                                                             |
 
 ### `customer_statistics_updated`
 

--- a/src/pages/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -2139,7 +2139,7 @@ Returns the info about the customer with a given `id`.
 | `chat_ids`            | []string  | The IDs of a customer's chats. Returned only if the customer had at least one chat.                                               |
 | `omnichannel`         | object    | An object of the customer's [omnichannel data](/messaging/agent-chat-api/data-structures/#customer).                              |
 | `address`             | object    | An object of the customer's address data. Returned only if set.                                                                   |
-| `segment_memberships` | []object  | The customer's [segment memberships](/messaging/agent-chat-api/v3.6/data-structures/#segment-membership). Returned only if set.   |
+| `segment_memberships` | []object  | The customer's [segment memberships](/messaging/agent-chat-api/data-structures/#segment-membership). Returned only if set.        |
 
 </Text>
 <Code>

--- a/src/pages/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -2124,21 +2124,22 @@ Returns the info about the customer with a given `id`.
 
 #### Response
 
-| Field            | Data type | Notes                                                                                                                             |
-| ---------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `id`             | string    | The [customer's](/messaging/agent-chat-api/v3.6/data-structures/#customer) ID.                                                    |
-| `type`           | string    | `customer`                                                                                                                        |
-| `name`           | string    | The customer's name. Returned only if set.                                                                                        |
-| `email`          | string    | The customer's email. Returned only if set.                                                                                       |
-| `avatar`         | string    | The customer's avatar. Returned only if set.                                                                                      |
-| `phone_number`   | string    | The customer's phone number. Returned only if set.                                                                                |
-| `created_at`     | string    | Specifies when the customer's identity was created.                                                                               |
-| `session_fields` | []object  | An array of custom object-enclosed key-value pairs. Returned only if set. Available for the session duration.                     |
-| `statistics`     | object    | Counters for started threads, opened pages, etc.                                                                                  |
-| `visit`          | object    | Geolocation and opened pages from the customer's most recent online visit. Returned only if the customer logged in at least once. |
-| `chat_ids`       | []string  | The IDs of a customer's chats. Returned only if the customer had at least one chat.                                               |
-| `omnichannel`    | object    | An object of the customer's [omnichannel data](/messaging/agent-chat-api/data-structures/#customer).                              |
-| `address`        | object    | An object of the customer's address data. Returned only if set.                                                                   |
+| Field                 | Data type | Notes                                                                                                                             |
+| --------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                  | string    | The [customer's](/messaging/agent-chat-api/v3.6/data-structures/#customer) ID.                                                    |
+| `type`                | string    | `customer`                                                                                                                        |
+| `name`                | string    | The customer's name. Returned only if set.                                                                                        |
+| `email`               | string    | The customer's email. Returned only if set.                                                                                       |
+| `avatar`              | string    | The customer's avatar. Returned only if set.                                                                                      |
+| `phone_number`        | string    | The customer's phone number. Returned only if set.                                                                                |
+| `created_at`          | string    | Specifies when the customer's identity was created.                                                                               |
+| `session_fields`      | []object  | An array of custom object-enclosed key-value pairs. Returned only if set. Available for the session duration.                     |
+| `statistics`          | object    | Counters for started threads, opened pages, etc.                                                                                  |
+| `visit`               | object    | Geolocation and opened pages from the customer's most recent online visit. Returned only if the customer logged in at least once. |
+| `chat_ids`            | []string  | The IDs of a customer's chats. Returned only if the customer had at least one chat.                                               |
+| `omnichannel`         | object    | An object of the customer's [omnichannel data](/messaging/agent-chat-api/data-structures/#customer).                              |
+| `address`             | object    | An object of the customer's address data. Returned only if set.                                                                   |
+| `segment_memberships` | []object  | The customer's [segment memberships](/messaging/agent-chat-api/v3.6/data-structures/#segment-membership). Returned only if set.   |
 
 </Text>
 <Code>

--- a/src/pages/messaging/agent-chat-api/v3.7/data-structures/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.7/data-structures/index.mdx
@@ -438,6 +438,7 @@ It is not possible to send a System event in API version 3.7.
 | `carts`                          | optional  | An array of customer's shopping carts. See [Cart](#cart) for the object structure.                                                                        |
 | `address`                        | optional  | An object of the customer's address data.                                                                                                                 |
 | `customer_properties`            | optional  | An object where the keys are the IDs of the [customer properties](#customer-property) and the values are their data.                                      |
+| `segment_memberships`            | optional  | An array of the customer's segment memberships. See [Segment Membership](#segment-membership) for the object structure.                                   |
 
 ### Cart
 
@@ -479,6 +480,28 @@ The customer property's type is set on creation by the agent.
 | `last_updated_at`               | required  | `string`  | RFC 3339 datetime string.                                                                  |
 | `last_updated_agent_account_id` | optional  | `string`  | Account ID of the agent that last set this value.                                          |
 | `last_updated_agent_client_id`  | optional  | `string`  | Client ID of the application that last set this value.                                     |
+
+### Segment Membership
+
+Segment memberships describe which segments the customer belongs to. The `segment_memberships` field is omitted when there's no record of any segment membership state for the customer.
+
+<CodeResponse version="v3.7" type="agent" title={'Sample Segment Membership data structure'} json="segmentMembership"/>
+
+| Field                        | Req./Opt. | Data type  | Notes                                                                                                                                                                                                                                                               |
+| ---------------------------- | --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `segment_id`                 | required  | `number`   | The ID of the segment definition this membership refers to. The built-in default segment has the ID `0`.                                                                                                                                                            |
+| `is_member`                  | required  | `bool`     | Whether the customer currently satisfies the segment's conditions.                                                                                                                                                                                                  |
+| `membership_last_updated_at` | optional  | `string`   | RFC 3339 datetime string; the time when `is_member` last changed. Returned only if the customer was a member of the segment at least once.                                                                                                                          |
+| `membership_attribution`     | optional  | `[]string` | Account IDs of the agents credited with the customer joining the segment. Returned only when an agent's change added the customer to the segment.                                                                                                                   |
+| `conditions_provenance`      | optional  | `object`   | An object where the keys are the names of the conditions the customer satisfies (for example, `email_set`) and the values are [Condition Provenance](#condition-provenance) objects. Conditions are reported even when the customer isn't a member of the segment.  |
+
+### Condition Provenance
+
+| Field              | Req./Opt. | Data type | Notes                                                                                                                                                    |
+| ------------------ | --------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `last_updated_at`  | required  | `string`  | RFC 3339 datetime string; the time when the condition was last satisfied.                                                                                |
+| `agent_account_id` | optional  | `string`  | Account ID of the agent whose change satisfied the condition. Returned only when the change is attributable to an agent.                                 |
+| `agent_client_id`  | optional  | `string`  | Client ID of the application that issued the token of the agent who satisfied the condition. Returned only when the change is attributable to an agent.  |
 
 # Other common structures
 

--- a/src/pages/messaging/agent-chat-api/v3.7/data-structures/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.7/data-structures/index.mdx
@@ -438,7 +438,7 @@ It is not possible to send a System event in API version 3.7.
 | `carts`                          | optional  | An array of customer's shopping carts. See [Cart](#cart) for the object structure.                                                                        |
 | `address`                        | optional  | An object of the customer's address data.                                                                                                                 |
 | `customer_properties`            | optional  | An object where the keys are the IDs of the [customer properties](#customer-property) and the values are their data.                                      |
-| `segment_memberships`            | optional  | An array of the customer's segment memberships. See [Segment Membership](#segment-membership) for the object structure.                                   |
+| `segment_memberships`            | optional  | An array of the customer's [segment memberships](#segment-membership).                                                                                    |
 
 ### Cart
 
@@ -483,25 +483,27 @@ The customer property's type is set on creation by the agent.
 
 ### Segment Membership
 
-Segment memberships describe which segments the customer belongs to. The `segment_memberships` field is omitted when there's no record of any segment membership state for the customer.
+Segment memberships describe which segments the customer belongs to. A segment is a named rule that classifies customers based on their data. Each segment is defined by conditions. Text evaluates every customer against each active segment definition automatically whenever the customer's data changes.
+
+Every organization has two built-in segments, lead (ID `0`) and qualified lead (ID `1`). You can also [create custom segment definitions](/management/customer-data-platform-api#/paths/~1v1~1create_segment_definition/post).
 
 <CodeResponse version="v3.7" type="agent" title={'Sample Segment Membership data structure'} json="segmentMembership"/>
 
-| Field                        | Req./Opt. | Data type  | Notes                                                                                                                                                                                                                                                               |
-| ---------------------------- | --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `segment_id`                 | required  | `number`   | The ID of the segment definition this membership refers to. The built-in default segment has the ID `0`.                                                                                                                                                            |
-| `is_member`                  | required  | `bool`     | Whether the customer currently satisfies the segment's conditions.                                                                                                                                                                                                  |
-| `membership_last_updated_at` | optional  | `string`   | RFC 3339 datetime string; the time when `is_member` last changed. Returned only if the customer was a member of the segment at least once.                                                                                                                          |
-| `membership_attribution`     | optional  | `[]string` | Account IDs of the agents credited with the customer joining the segment. Returned only when an agent's change added the customer to the segment.                                                                                                                   |
-| `conditions_provenance`      | optional  | `object`   | An object where the keys are the names of the conditions the customer satisfies (for example, `email_set`) and the values are [Condition Provenance](#condition-provenance) objects. Conditions are reported even when the customer isn't a member of the segment.  |
+| Field                        | Req./Opt. | Data type  | Notes                                                                                                                                                                                                                                                                                                |
+| ---------------------------- | --------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `segment_id`                 | required  | `number`   | The ID of the segment definition.                                                                                                                                                                                                                                                                    |
+| `is_member`                  | required  | `bool`     | Whether the customer currently meets all conditions of the segment.                                                                                                                                                                                                                                  |
+| `membership_last_updated_at` | optional  | `string`   | RFC 3339 datetime string; the time when `is_member` last changed. Returned only if the customer was a member of the segment at least once.                                                                                                                                                           |
+| `membership_attribution`     | optional  | `[]string` | Account IDs of the agents credited with the customer joining the segment. Returned only when an agent's change added the customer to the segment.                                                                                                                                                    |
+| `conditions_provenance`      | optional  | `object`   | An object where the keys are the names of the conditions the customer meets (for example, `email_set`) and the values are [Condition Provenance](#condition-provenance) objects. If the customer meets a segment condition, it will be returned even if the customer isn't a member of that segment. |
 
 ### Condition Provenance
 
 | Field              | Req./Opt. | Data type | Notes                                                                                                                                                    |
 | ------------------ | --------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `last_updated_at`  | required  | `string`  | RFC 3339 datetime string; the time when the condition was last satisfied.                                                                                |
-| `agent_account_id` | optional  | `string`  | Account ID of the agent whose change satisfied the condition. Returned only when the change is attributable to an agent.                                 |
-| `agent_client_id`  | optional  | `string`  | Client ID of the application that issued the token of the agent who satisfied the condition. Returned only when the change is attributable to an agent.  |
+| `last_updated_at`  | required  | `string`  | RFC 3339 datetime string; the time when the condition was last met.                                                                                      |
+| `agent_account_id` | optional  | `string`  | The account ID of the agent whose change made the customer meet the condition. Returned only when attributable to an agent.                              |
+| `agent_client_id`  | optional  | `string`  | The client ID of the application that issued the agent token. Returned only when attributable to an agent.                                               |
 
 # Other common structures
 

--- a/src/pages/messaging/agent-chat-api/v3.7/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.7/index.mdx
@@ -1934,21 +1934,22 @@ Returns the info about the customer with a given `id`.
 
 #### Response
 
-| Field            | Data type | Notes                                                                                                                             |
-| ---------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `id`             | string    | The [customer's](/messaging/agent-chat-api/v3.7/data-structures/#customer) ID.                                                    |
-| `type`           | string    | `customer`                                                                                                                        |
-| `name`           | string    | The customer's name. Returned only if set.                                                                                        |
-| `email`          | string    | The customer's email. Returned only if set.                                                                                       |
-| `avatar`         | string    | The customer's avatar. Returned only if set.                                                                                      |
-| `phone_number`   | string    | The customer's phone number. Returned only if set.                                                                                |
-| `created_at`     | string    | Specifies when the customer's identity was created.                                                                               |
-| `session_fields` | []object  | An array of custom object-enclosed key-value pairs. Returned only if set. Available for the session duration.                     |
-| `statistics`     | object    | Counters for started threads, opened pages, etc.                                                                                  |
-| `visit`          | object    | Geolocation and opened pages from the customer's most recent online visit. Returned only if the customer logged in at least once. |
-| `chat_ids`       | []string  | The IDs of a customer's chats. Returned only if the customer had at least one chat.                                               |
-| `omnichannel`    | object    | An object of the customer's [omnichannel data](/messaging/agent-chat-api/v3.7/data-structures/#customer).                         |
-| `address`        | object    | An object of the customer's address data. Returned only if set.                                                                   |
+| Field                 | Data type | Notes                                                                                                                             |
+| --------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                  | string    | The [customer's](/messaging/agent-chat-api/v3.7/data-structures/#customer) ID.                                                    |
+| `type`                | string    | `customer`                                                                                                                        |
+| `name`                | string    | The customer's name. Returned only if set.                                                                                        |
+| `email`               | string    | The customer's email. Returned only if set.                                                                                       |
+| `avatar`              | string    | The customer's avatar. Returned only if set.                                                                                      |
+| `phone_number`        | string    | The customer's phone number. Returned only if set.                                                                                |
+| `created_at`          | string    | Specifies when the customer's identity was created.                                                                               |
+| `session_fields`      | []object  | An array of custom object-enclosed key-value pairs. Returned only if set. Available for the session duration.                     |
+| `statistics`          | object    | Counters for started threads, opened pages, etc.                                                                                  |
+| `visit`               | object    | Geolocation and opened pages from the customer's most recent online visit. Returned only if the customer logged in at least once. |
+| `chat_ids`            | []string  | The IDs of a customer's chats. Returned only if the customer had at least one chat.                                               |
+| `omnichannel`         | object    | An object of the customer's [omnichannel data](/messaging/agent-chat-api/v3.7/data-structures/#customer).                         |
+| `address`             | object    | An object of the customer's address data. Returned only if set.                                                                   |
+| `segment_memberships` | []object  | The customer's [segment memberships](/messaging/agent-chat-api/v3.7/data-structures/#segment-membership). Returned only if set.   |
 
 </Text>
 <Code>

--- a/src/pages/messaging/agent-chat-api/v3.7/rtm-pushes/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.7/rtm-pushes/index.mdx
@@ -35,7 +35,7 @@ Here's what you need to know about **pushes**:
 | **Events**        | [`incoming_event`](#incoming_event) [`event_deleted`](#event_deleted) [`event_updated`](#event_updated) [`incoming_rich_message_postback`](#incoming_rich_message_postback)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | **Properties**    | [`chat_properties_updated`](#chat_properties_updated) [`chat_properties_deleted`](#chat_properties_deleted) [`thread_properties_updated`](#thread_properties_updated) [`thread_properties_deleted`](#thread_properties_deleted) [`event_properties_updated`](#event_properties_updated) [`event_properties_deleted`](#event_properties_deleted)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | **Thread tags**   | [`thread_tagged`](#thread_tagged) [`thread_untagged`](#thread_untagged)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| **Customers**     | [`incoming_customers`](#incoming_customers) [`incoming_customer`](#incoming_customer) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_properties_values_updated`](#customer_properties_values_updated) [`customer_statistics_updated`](#customer_statistics_updated) [`customer_banned`](#customer_banned) [`customer_transferred`](#customer_transferred) [`customer_left`](#customer_left) [`subscribed_customers_totals_updated`](#subscribed_customers_totals_updated) [`ticket_created`](#ticket_created)  [`ticket_deleted`](#ticket_deleted)                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| **Customers**     | [`incoming_customers`](#incoming_customers) [`incoming_customer`](#incoming_customer) [`customer_updated`](#customer_updated) [`customer_page_updated`](#customer_page_updated) [`customer_properties_values_updated`](#customer_properties_values_updated) [`segment_memberships_updated`](#segment_memberships_updated) [`customer_statistics_updated`](#customer_statistics_updated) [`customer_banned`](#customer_banned) [`customer_transferred`](#customer_transferred) [`customer_left`](#customer_left) [`subscribed_customers_totals_updated`](#subscribed_customers_totals_updated) [`ticket_created`](#ticket_created)  [`ticket_deleted`](#ticket_deleted)                                                                                                                                                                                                                                                                                                                                                                                                        |
 | **Status**        | [`routing_status_set`](#routing_status_set) [`agent_disconnected`](#agent_disconnected)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | **Configuration** | [`agent_created`](#agent_created) [`agent_approved`](#agent_approved) [`agent_updated`](#agent_updated) [`agent_suspended`](#agent_suspended) [`agent_unsuspended`](#agent_unsuspended) [`agent_deleted`](#agent_deleted) [`auto_accesses_updated`](#auto_accesses_updated) [`bot_created`](#bot_created) [`bot_updated`](#bot_updated) [`bot_deleted`](#bot_deleted) [`canned_response_created`](#canned_response_created) [`canned_response_updated`](#canned_response_updated) [`canned_response_deleted`](#canned_response_deleted) [`group_created`](#group_created) [`group_updated`](#group_updated) [`group_deleted`](#group_deleted) [`tag_created`](#tag_created) [`tag_deleted`](#tag_deleted) [`tag_updated`](#tag_updated) [`groups_status_updated`](#groups_status_updated) [`license_properties_updated`](#license_properties_updated) [`group_properties_updated`](#group_properties_updated) [`customer_property_definition_created`](#customer_property_definition_created) [`customer_property_definition_updated`](#customer_property_definition_updated) |
 | **Other**         | [`events_marked_as_seen`](#events_marked_as_seen) [`incoming_sneak_peek`](#incoming_sneak_peek) [`incoming_thinking_indicator`](#incoming_thinking_indicator) [`incoming_typing_indicator`](#incoming_typing_indicator) [`incoming_multicast`](#incoming_multicast) [`chat_unfollowed`](#chat_unfollowed) [`queue_positions_updated`](#queue_positions_updated) [`thread_summary_set`](#thread_summary_set) [`incoming_error`](#incoming_error)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
@@ -718,6 +718,65 @@ Indicates that the values of customer properties were updated.
 ```
 
 </CodeResponse>
+
+### `segment_memberships_updated`
+
+Indicates that the customer joined or left at least one segment. The push is sent only when the `is_member` field of a [segment membership](/messaging/agent-chat-api/v3.7/data-structures#segment-membership) changes; all the changes evaluated at the same time are grouped into one push.
+
+<CodeResponse title={'Sample push payload: the customer joined a segment'}>
+
+```json
+{
+  "customer_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "segment_memberships": [
+    {
+      "segment_id": 0,
+      "is_member": true,
+      "membership_last_updated_at": "2026-07-13T13:11:21.187676Z",
+      "membership_attribution": [
+        "464d206a-ba7d-4ce1-98d6-d03f8f14970e"
+      ],
+      "conditions_provenance": {
+        "email_set": {
+          "last_updated_at": "2026-07-13T13:11:21.187676Z",
+          "agent_account_id": "464d206a-ba7d-4ce1-98d6-d03f8f14970e",
+          "agent_client_id": "71d32c598862b01b9e2298281339dbc2"
+        }
+      }
+    }
+  ],
+  "segments_added": [0]
+}
+```
+
+</CodeResponse>
+
+<CodeResponse title={'Sample push payload: the customer left a segment'}>
+
+```json
+{
+  "customer_id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "segment_memberships": [
+    {
+      "segment_id": 0,
+      "is_member": false,
+      "membership_last_updated_at": "2026-07-13T13:11:53.970263Z"
+    }
+  ],
+  "segments_removed": [0]
+}
+```
+
+</CodeResponse>
+
+#### Push payload
+
+| Field                 | Notes                                                                                                                                                            |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `customer_id`         | The ID of the customer whose segment memberships changed.                                                                                                        |
+| `segment_memberships` | The new state of all the customer's [segment memberships](/messaging/agent-chat-api/v3.7/data-structures#segment-membership), not only the ones that changed.    |
+| `segments_added`      | The IDs of the segments the customer has just joined. Returned only if the customer joined any segment.                                                          |
+| `segments_removed`    | The IDs of the segments the customer has just left. Returned only if the customer left any segment.                                                              |
 
 ### `customer_statistics_updated`
 

--- a/src/pages/messaging/agent-chat-api/v3.7/rtm-pushes/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.7/rtm-pushes/index.mdx
@@ -721,7 +721,7 @@ Indicates that the values of customer properties were updated.
 
 ### `segment_memberships_updated`
 
-Indicates that the customer joined or left at least one segment. The push is sent only when the `is_member` field of a [segment membership](/messaging/agent-chat-api/v3.7/data-structures#segment-membership) changes; all the changes evaluated at the same time are grouped into one push.
+Indicates that the customer joined or left at least one segment. Sent only when the `is_member` field of a [segment membership](/messaging/agent-chat-api/v3.7/data-structures#segment-membership) changes. All changes evaluated at the same time are grouped into one push.
 
 <CodeResponse title={'Sample push payload: the customer joined a segment'}>
 
@@ -773,7 +773,7 @@ Indicates that the customer joined or left at least one segment. The push is sen
 
 | Field                 | Notes                                                                                                                                                            |
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `customer_id`         | The ID of the customer whose segment memberships changed.                                                                                                        |
+| `customer_id`         | The ID of the customer.                                                                                                                                          |
 | `segment_memberships` | The new state of all the customer's [segment memberships](/messaging/agent-chat-api/v3.7/data-structures#segment-membership), not only the ones that changed.    |
 | `segments_added`      | The IDs of the segments the customer has just joined. Returned only if the customer joined any segment.                                                          |
 | `segments_removed`    | The IDs of the segments the customer has just left. Returned only if the customer left any segment.                                                              |

--- a/src/pages/messaging/agent-chat-api/v3.7/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.7/rtm-reference/index.mdx
@@ -2120,21 +2120,22 @@ Returns the info about the customer with a given `id`.
 
 #### Response
 
-| Field            | Data type | Notes                                                                                                                             |
-| ---------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `id`             | string    | The [customer's](/messaging/agent-chat-api/v3.7/data-structures/#customer) ID.                                                    |
-| `type`           | string    | `customer`                                                                                                                        |
-| `name`           | string    | The customer's name. Returned only if set.                                                                                        |
-| `email`          | string    | The customer's email. Returned only if set.                                                                                       |
-| `avatar`         | string    | The customer's avatar. Returned only if set.                                                                                      |
-| `phone_number`   | string    | The customer's phone number. Returned only if set.                                                                                |
-| `created_at`     | string    | Specifies when the customer's identity was created.                                                                               |
-| `session_fields` | []object  | An array of custom object-enclosed key-value pairs. Returned only if set. Available for the session duration.                     |
-| `statistics`     | object    | Counters for started threads, opened pages, etc.                                                                                  |
-| `visit`          | object    | Geolocation and opened pages from the customer's most recent online visit. Returned only if the customer logged in at least once. |
-| `chat_ids`       | []string  | IDs of a customer's chats. Returned only if the customer had at least one chat.                                                   |
-| `omnichannel`    | object    | An object of the customer's [omnichannel data](/messaging/agent-chat-api/v3.7/data-structures/#customer).                         |
-| `address`        | object    | An object of the customer's address data. Returned only if set.                                                                   |
+| Field                 | Data type | Notes                                                                                                                             |
+| --------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                  | string    | The [customer's](/messaging/agent-chat-api/v3.7/data-structures/#customer) ID.                                                    |
+| `type`                | string    | `customer`                                                                                                                        |
+| `name`                | string    | The customer's name. Returned only if set.                                                                                        |
+| `email`               | string    | The customer's email. Returned only if set.                                                                                       |
+| `avatar`              | string    | The customer's avatar. Returned only if set.                                                                                      |
+| `phone_number`        | string    | The customer's phone number. Returned only if set.                                                                                |
+| `created_at`          | string    | Specifies when the customer's identity was created.                                                                               |
+| `session_fields`      | []object  | An array of custom object-enclosed key-value pairs. Returned only if set. Available for the session duration.                     |
+| `statistics`          | object    | Counters for started threads, opened pages, etc.                                                                                  |
+| `visit`               | object    | Geolocation and opened pages from the customer's most recent online visit. Returned only if the customer logged in at least once. |
+| `chat_ids`            | []string  | IDs of a customer's chats. Returned only if the customer had at least one chat.                                                   |
+| `omnichannel`         | object    | An object of the customer's [omnichannel data](/messaging/agent-chat-api/v3.7/data-structures/#customer).                         |
+| `address`             | object    | An object of the customer's address data. Returned only if set.                                                                   |
+| `segment_memberships` | []object  | The customer's [segment memberships](/messaging/agent-chat-api/v3.7/data-structures/#segment-membership). Returned only if set.   |
 
 </Text>
 <Code>


### PR DESCRIPTION
Document the new `segment_memberships` customer field and the `segment_memberships_updated` RTM push in the Agent Chat API v3.6 and v3.7:

- add the Segment Membership and Condition Provenance data structures, along with their sample payloads,
- add the `segment_memberships` field to the Customer data structure and to the Get Customer responses (Web & RTM),
- document the `segment_memberships_updated` push.

Jira: https://livechatinc.atlassian.net/browse/EUEE-1590