### PR TITLE
feat(docs): document customer relationship_level in 3.6 and v3.7 EUEE-1586

### DIFF
--- a/payloads/messaging/v3.6/agent-chat-api/users/customer.json
+++ b/payloads/messaging/v3.6/agent-chat-api/users/customer.json
@@ -124,5 +124,6 @@
       "last_updated_agent_account_id": "464d206a-ba7d-4ce1-98d6-d03f8f14970e",
       "last_updated_agent_client_id": "71d32c598862b01b9e2298281339dbc2"
     }
-  }
+  },
+  "relationship_level": "vip"
 }

--- a/payloads/messaging/v3.7/agent-chat-api/users/customer.json
+++ b/payloads/messaging/v3.7/agent-chat-api/users/customer.json
@@ -124,5 +124,6 @@
       "last_updated_agent_account_id": "464d206a-ba7d-4ce1-98d6-d03f8f14970e",
       "last_updated_agent_client_id": "71d32c598862b01b9e2298281339dbc2"
     }
-  }
+  },
+  "relationship_level": "vip"
 }

--- a/src/pages/messaging/agent-chat-api/changelog/index.mdx
+++ b/src/pages/messaging/agent-chat-api/changelog/index.mdx
@@ -38,6 +38,7 @@ The developer preview version provides a preview of the upcoming changes to the 
 
 - The [**customer_updated**](/messaging/agent-chat-api/v3.7/rtm-pushes/#customer_updated) push now includes cart data.
 - The **Update Customer** ([Web](/messaging/agent-chat-api/v3.7/#update-customer) & [RTM](/messaging/agent-chat-api/v3.7/rtm-reference/#update-customer)) method now allows to clear the values of `name`, `email`, `phone_number` and `address` components by providing an empty string as the new field value.
+- The [**Customer**](/messaging/agent-chat-api/v3.7/data-structures#customer) data structure has a new `relationship_level` field, and the [**customer_updated**](/messaging/agent-chat-api/v3.7/rtm-pushes/#customer_updated) push reports its changes.
 
 ### Other
 
@@ -85,6 +86,7 @@ The developer preview version provides a preview of the upcoming changes to the 
 - The [**Customer**](/messaging/agent-chat-api/data-structures#customer) data structure has a new `carts` field containing an array of [**Cart**](/messaging/agent-chat-api/data-structures#cart) objects.
 - The [**Customer**](/messaging/agent-chat-api/data-structures#customer) data structure has a new `customer_properties` field containing a map of [**Customer Property**](/messaging/agent-chat-api/data-structures#customer-property) objects.
 - The [**customer_updated**](/messaging/agent-chat-api/rtm-pushes/#customer_updated) push now includes cart data.
+- The [**Customer**](/messaging/agent-chat-api/data-structures#customer) data structure has a new `relationship_level` field, and the [**customer_updated**](/messaging/agent-chat-api/rtm-pushes/#customer_updated) push reports its changes.
 
 ### Status
 

--- a/src/pages/messaging/agent-chat-api/data-structures/index.mdx
+++ b/src/pages/messaging/agent-chat-api/data-structures/index.mdx
@@ -440,6 +440,7 @@ It is not possible to send a System event in API version 3.6.
 | `omnichannel`                    | optional  |                                                                                                                                                           |
 | `address`                        | optional  | An object of the customer's address data.                                                                                                                 |
 | `customer_properties`            | optional  | An object where the keys are the IDs of the [customer properties](#customer-property) and the values are their data.                                      |
+| `relationship_level`             | optional  | The customer's relationship level. The only supported value is `vip`. Returned only if set.                                                               |
 
 ### Cart
 

--- a/src/pages/messaging/agent-chat-api/index.mdx
+++ b/src/pages/messaging/agent-chat-api/index.mdx
@@ -1953,6 +1953,7 @@ Returns the info about the customer with a given `id`.
 | `chat_ids`            | []string  | The IDs of the customer's chats. Returned only if the customer had at least one chat.                                             |
 | `omnichannel`         | object    | An object of the customer's [omnichannel data](/messaging/agent-chat-api/data-structures/#customer).                              |
 | `address`             | object    | An object of the customer's address data. Returned only if set.                                                                   |
+| `relationship_level`  | string    | The customer's relationship level. The only supported value is `vip`. Returned only if set.       |
 | `segment_memberships` | []object  | The customer's [segment memberships](/messaging/agent-chat-api/data-structures/#segment-membership). Returned only if set.        |
 
 </Text>

--- a/src/pages/messaging/agent-chat-api/rtm-pushes/index.mdx
+++ b/src/pages/messaging/agent-chat-api/rtm-pushes/index.mdx
@@ -679,6 +679,20 @@ Indicates that customer's data changed. The push payload contains the updated fi
 
 </CodeResponse>
 
+A change of the customer's `relationship_level` is reported in a separate push, which contains only `id`, `type`, and `relationship_level`. The value is `null` when the relationship level was removed.
+
+<CodeResponse title={'Sample push payload for a relationship level change'}>
+
+```json
+{
+  "id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "type": "customer",
+  "relationship_level": "vip"
+}
+```
+
+</CodeResponse>
+
 ### `customer_page_updated`
 
 Indicates that a customer moved to another page of the website.

--- a/src/pages/messaging/agent-chat-api/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/rtm-reference/index.mdx
@@ -2139,6 +2139,7 @@ Returns the info about the customer with a given `id`.
 | `chat_ids`            | []string  | The IDs of a customer's chats. Returned only if the customer had at least one chat.                                               |
 | `omnichannel`         | object    | An object of the customer's [omnichannel data](/messaging/agent-chat-api/data-structures/#customer).                              |
 | `address`             | object    | An object of the customer's address data. Returned only if set.                                                                   |
+| `relationship_level`  | string    | The customer's relationship level. The only supported value is `vip`. Returned only if set.       |
 | `segment_memberships` | []object  | The customer's [segment memberships](/messaging/agent-chat-api/data-structures/#segment-membership). Returned only if set.        |
 
 </Text>

--- a/src/pages/messaging/agent-chat-api/v3.7/data-structures/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.7/data-structures/index.mdx
@@ -438,6 +438,7 @@ It is not possible to send a System event in API version 3.7.
 | `carts`                          | optional  | An array of customer's shopping carts. See [Cart](#cart) for the object structure.                                                                        |
 | `address`                        | optional  | An object of the customer's address data.                                                                                                                 |
 | `customer_properties`            | optional  | An object where the keys are the IDs of the [customer properties](#customer-property) and the values are their data.                                      |
+| `relationship_level`             | optional  | The customer's relationship level. The only supported value is `vip`. Returned only if set.                                                               |
 
 ### Cart
 

--- a/src/pages/messaging/agent-chat-api/v3.7/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.7/index.mdx
@@ -1946,6 +1946,7 @@ Returns the info about the customer with a given `id`.
 | `chat_ids`            | []string  | The IDs of a customer's chats. Returned only if the customer had at least one chat.                                               |
 | `omnichannel`         | object    | An object of the customer's [omnichannel data](/messaging/agent-chat-api/v3.7/data-structures/#customer).                         |
 | `address`             | object    | An object of the customer's address data. Returned only if set.                                                                   |
+| `relationship_level`  | string    | The customer's relationship level. The only supported value is `vip`. Returned only if set.       |
 | `segment_memberships` | []object  | The customer's [segment memberships](/messaging/agent-chat-api/v3.7/data-structures/#segment-membership). Returned only if set.   |
 
 </Text>

--- a/src/pages/messaging/agent-chat-api/v3.7/rtm-pushes/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.7/rtm-pushes/index.mdx
@@ -679,6 +679,20 @@ Indicates that customer's data changed. The push payload contains the updated fi
 
 </CodeResponse>
 
+A change of the customer's `relationship_level` is reported in a separate push, which contains only `id`, `type`, and `relationship_level`. The value is `null` when the relationship level was removed.
+
+<CodeResponse title={'Sample push payload for a relationship level change'}>
+
+```json
+{
+  "id": "b7eff798-f8df-4364-8059-649c35c9ed0c",
+  "type": "customer",
+  "relationship_level": "vip"
+}
+```
+
+</CodeResponse>
+
 ### `customer_page_updated`
 
 Indicates that a customer moved to another page of the website.

--- a/src/pages/messaging/agent-chat-api/v3.7/rtm-reference/index.mdx
+++ b/src/pages/messaging/agent-chat-api/v3.7/rtm-reference/index.mdx
@@ -2132,6 +2132,7 @@ Returns the info about the customer with a given `id`.
 | `chat_ids`            | []string  | IDs of a customer's chats. Returned only if the customer had at least one chat.                                                   |
 | `omnichannel`         | object    | An object of the customer's [omnichannel data](/messaging/agent-chat-api/v3.7/data-structures/#customer).                         |
 | `address`             | object    | An object of the customer's address data. Returned only if set.                                                                   |
+| `relationship_level`  | string    | The customer's relationship level. The only supported value is `vip`. Returned only if set.       |
 | `segment_memberships` | []object  | The customer's [segment memberships](/messaging/agent-chat-api/v3.7/data-structures/#segment-membership). Returned only if set.   |
 
 </Text>


### PR DESCRIPTION
Documents the native per-customer relationship level exposed by agent-api in versions 3.6 and 3.7 (EUEE-1586).

## What is documented

- `relationship_level` added to the **Customer** data structure table and to the sample Customer payload (3.6 and v3.7). String enum, the only supported value is `vip`, returned only when set.
- `customer_updated` push: a relationship level change arrives as a separate, sparse payload containing only `id`, `type`, and `relationship_level`, where `null` means the level was removed. Added as its own sample payload instead of extending the existing one, because the CDP-sourced push never carries the monitoring fields shown there.
- Changelog entries under **Customers** for both v3.6 and v3.7.

Versions 3.4 and 3.5 are untouched — they neither expose the field nor receive the push.

## Out of scope

- The write path (`POST /v1/update_customer` in the Customer Data Platform API, scope `customers:rw`) is not documented here. `src/configs/redoc/customer-data-platform-api/spec.yml` has drifted from the service spec in `livechat/api` (missing `/v1/delete_customer_property_definition`, `/v1/set_customer_properties_values`, `/v1/has_sales_events`), so syncing it is a separate task.
- `segment_memberships` (EUEE-1567) is still undocumented in the Customer data structure.
- The v3.7 Customer table is still missing the `phone_number` and `omnichannel` rows that v3.6 has.

## Prerequisites before merge

- [ ] `livechat/api` PR1/3 for EUEE-1586 (native relationship level: per-customer set + push) released to **production**.
